### PR TITLE
CSS vertical layering

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -530,19 +530,19 @@ function Battle(frame, logFrame, noPreload) {
 		self.elem.append('<div></div>');
 		self.spriteElem = self.elem.children().last();
 
-		self.spriteElem.append('<div></div>');
+		self.spriteElem.append('<div id="sprites_op"></div>');
 		self.spriteElems[1] = self.spriteElem.children().last();
-		self.spriteElem.append('<div></div>');
+		self.spriteElem.append('<div id="front_op"></div>');
 		self.spriteElemsFront[1] = self.spriteElem.children().last();
-		self.spriteElem.append('<div></div>');
+		self.spriteElem.append('<div id="front_p"></div>');
 		self.spriteElemsFront[0] = self.spriteElem.children().last();
-		self.spriteElem.append('<div></div>');
+		self.spriteElem.append('<div id="sprites_p"></div>');
 		self.spriteElems[0] = self.spriteElem.children().last();
 
-		self.elem.append('<div></div>');
+		self.elem.append('<div id="stat_container"></div>');
 		self.statElem = self.elem.children().last();
 
-		self.elem.append('<div></div>');
+		self.elem.append('<div id="fx_container"></div>');
 		self.fxElem = self.elem.children().last();
 
 		self.elem.append('<div class="leftbar"></div>');

--- a/style/battle.css
+++ b/style/battle.css
@@ -131,6 +131,32 @@ License: GPLv2
 	margin-top: 0.5em;
 }
 
+/** Vertical layering of sprites and effects **/
+#sprites_op>img:nth-child(1)
+{
+	z-index: 3;
+}
+#sprites_op>img:nth-child(2)
+{
+	z-index: 2;
+}
+#sprites_op>img:nth-child(3)
+{
+	z-index: 1;
+}
+#front_op>*
+{
+	z-index: 10;
+}
+#stat_container>*
+{
+	z-index: 20;
+}
+#fx_container>*
+{
+	z-index: 30;
+}
+
 .playbutton
 {
 	position: absolute;
@@ -139,6 +165,7 @@ License: GPLv2
 	left: 0;
 	right: 0;
 	text-align: center;
+	z-index: 100;
 }
 .playbutton button
 {


### PR DESCRIPTION
Add IDs to the vertical layers of the battle screen (sprites, frontsprite, statbar, fx) and assign them z-index properties. For the opponent side, reverse the z-index order of the in-battle sprites to avoid the left sprite overlapping the right one.
