### PR TITLE
Fix bug on multiline commands

### DIFF
--- a/js/sim.js
+++ b/js/sim.js
@@ -165,6 +165,27 @@ function emit(socket, type, data) {
 	}
 }
 
+function checkMultiLines(text) {
+	// Checking for multiline commands
+	if (text.substr(0, 1) === '/') {
+	 	var splitText = text.split('\n');
+ 		// We need to make a different check for PMs since they use commas and other commands do not
+	 	if (text.indexOf(',') > -1 && (text.substr(0, 4) === '/msg' || text.substr(0, 8) === '/whisper' || text.substr(0, 3) === '/w ')) {
+	 		var messageTo = text.substr(0, text.indexOf(',') + 1);
+	 		for (var i=1, len=splitText.length; i<len; i++) if (splitText[i]) splitText[i] = messageTo + splitText[i];
+	 		text = splitText.join('\n');
+ 		} else {
+ 			var firstLine = splitText[0];
+ 			firstLine = firstLine.split(' ');
+ 			var command = firstLine[0];
+ 			for (var i=1, len=splitText.length; i<len; i++) if (splitText[i]) splitText[i] = command + ' ' + splitText[i];
+ 			text = splitText.join('\n'); 
+ 		}
+	}
+	
+	return text;
+}
+
 function BattleRoom(id, elem) {
 	var selfR = this;
 	this.id = id;
@@ -896,22 +917,7 @@ function BattleRoom(id, elem) {
 				rooms.lobby.chatHistory.push(text);
 				text = rooms.lobby.parseCommand(text);
 				if (text) {
-					// Checking for multiline commands
-					if (text.substr(0, 1) === '/') {
-					 	var splitText = text.split('\n');
-				 		// We need to make a different check for PMs since they use commas and other commands do not
-					 	if (text.indexOf(',') > -1 && (text.substr(0, 4) === '/msg' || text.substr(0, 8) === '/whisper' || text.substr(0, 3) === '/w ')) {
-					 		var messageTo = text.substr(0, text.indexOf(',') + 1);
-					 		for (var i=1, len=splitText.length; i<len; i++) if (splitText[i]) splitText[i] = messageTo + splitText[i];
-					 		text = splitText.join('\n');
-				 		} else {
-				 			var firstLine = splitText[0];
-				 			firstLine = firstLine.split(' ');
-				 			var command = firstLine[0];
-				 			for (var i=1, len=splitText.length; i<len; i++) if (splitText[i]) splitText[i] = command + ' ' + splitText[i];
-				 			text = splitText.join('\n'); 
-				 		}
-					}
+					text = checkMultiLines(text);
 					selfR.send(text);
 				}
 				selfR.chatboxElem.val('');
@@ -2233,22 +2239,7 @@ function Lobby(id, elem) {
 				selfR.chatHistory.push(text);
 				text = selfR.parseCommand(text);
 				if (text) {
-					// Checking for multiline commands
-					if (text.substr(0, 1) === '/') {
-					 	var splitText = text.split('\n');
-				 		// We need to make a different check for PMs since they use commas and other commands do not
-					 	if (text.indexOf(',') > -1 && (text.substr(0, 4) === '/msg' || text.substr(0, 8) === '/whisper' || text.substr(0, 3) === '/w ')) {
-					 		var messageTo = text.substr(0, text.indexOf(',') + 1);
-					 		for (var i=1, len=splitText.length; i<len; i++) if (splitText[i]) splitText[i] = messageTo + splitText[i];
-					 		text = splitText.join('\n');
-				 		} else {
-				 			var firstLine = splitText[0];
-				 			firstLine = firstLine.split(' ');
-				 			var command = firstLine[0];
-				 			for (var i=1, len=splitText.length; i<len; i++) if (splitText[i]) splitText[i] = command + ' ' + splitText[i];
-				 			text = splitText.join('\n'); 
-				 		}
-					}
+					text = checkMultiLines(text);
 					selfR.send(text);
 				}
 				selfR.chatboxElem.val('');


### PR DESCRIPTION
When you tried to PM, announce, or declare multiple lines from 
Lobby and Battle chat,  the subsequent lines were sent to the Lobby chat as regular messages. This is now solved in both all private 
message commands and other commands such as reply and wall.
