### PR TITLE
Add translation support

### DIFF
--- a/data/translations.js
+++ b/data/translations.js
@@ -1,0 +1,13334 @@
+exports.Translations = {
+	"The @0 your Pokémon saw in the dream appeared!": [
+		"ゆめで　であった @0が　あらわれた！",
+		"Un @0 vu en rêve apparaît!",
+		"Appare @0 visto in sogno!",
+		"Ein @0 (Traum) erscheint!",
+		"¡Es el @0 que viste en tu sueño!"
+	],
+	"@0 appeared!": [
+		"@0が　あらわれた！",
+		"@0 apparaît!",
+		"Appare @0!",
+		"Ein @0 erscheint!",
+		"¡Un @0!"
+	],
+	"You are challenged by @0 @1!": [
+		"@0の　@1が しょうぶを　しかけてきた！",
+		"Un combat est lancé par @0 @1!",
+		"Parte la sfida di @1 (@0)!",
+		"Eine Herausforderung von @0 @1!",
+		"Prepárate para un desafío a manos de... ¡@0 @1!"
+	],
+	"You are challenged by @0!": [
+		"@0が しょうぶを　しかけてきた！",
+		"Un combat est lancé par @0!",
+		"Parte la sfida di @0!",
+		"Eine Herausforderung von @0!",
+		"Prepárate para un desafío a manos de... ¡@0!"
+	],
+	"You are challenged by @0 @1 and @2 @3!": [
+		"@0の　@1と @2の　@3が しょうぶを　しかけてきた！",
+		"@0 @1 et @2 @3 veulent se battre!",
+		"Parte la sfida di @1 (@0) e @3 (@2)!",
+		"@0 @1 und @2 @3 möchten kämpfen!",
+		"¡@0 @1 quiere luchar! ¡@2 @3, también!"
+	],
+	"You are challenged by @0 and @1!": [
+		"@0と　@1が しょうぶを　しかけてきた！",
+		"@0 et @1 veulent se battre!",
+		"Parte la sfida di @0 e @1!",
+		"@0 und @1 möchten kämpfen!",
+		"¡@0 y @1 quieren luchar!"
+	],
+	"Go! @0!": [
+		"ゆけっ！　@0！",
+		"@0! Go!",
+		"Avanti, @0!",
+		"Los, @0!",
+		"¡Adelante, @0!"
+	],
+	"Go! @0 and @1!": [
+		"ゆけっ！　@0！ @1！",
+		"@0 et @1! Go!",
+		"Avanti, @0 e @1!",
+		"Los, @0 und @1!",
+		"¡Adelante, @0 y @1!"
+	],
+	"Go! @0, @1, and @2!": [
+		"ゆけっ！　@0！ @1！　@2！",
+		"@0, @1 et @2! Go!",
+		"Avanti, @0, @1 e @2!",
+		"Los, @0, @1 und @2!",
+		"¡Adelante, @0, @1 y @2!"
+	],
+	"@0 @1 sent out @2!": [
+		"@0の　@1は @2を　くりだした！",
+		"Un @2 est envoyé par @0 @1!",
+		"@1 (@0) manda in campo @2!",
+		"@2 wird von @0 @1 in den Kampf geschickt!",
+		"¡@0 @1 saca a @2!"
+	],
+	"@0 @1 sent out @2 and @3!": [
+		"@0の　@1は @2と @3を　くりだした！",
+		"Un @2 et un @3 sont envoyés par @0 @1!",
+		"@2 e @3 vengono mandati in campo da @1 (@0)!",
+		"@2 und @3 werden von @0 @1 in den Kampf geschickt!",
+		"@0 @1: ¡@2 y @3, salid!"
+	],
+	"@0 @1 sent out @2, @3, and @4!": [
+		"@0の　@1は @2と　@3と @4を　くりだした！",
+		"Un @2, un @3 et un @4 sont envoyés par @0 @1!",
+		"@1 (@0) manda in campo @2, @3 e @4!",
+		"@2, @3 und @4 werden von @0 @1 in den Kampf geschickt!",
+		"¡@0 @1 saca a @2, @3 y @4!"
+	],
+	"@0 sent out @1!": [
+		"@0は @1を　くりだした！",
+		"@1 est envoyé par @0!",
+		"@0 manda in campo @1!",
+		"@1 wird von @0 in den Kampf geschickt!",
+		"¡@0 saca a @1!"
+	],
+	"@0 sent out @1 and @2!": [
+		"@0は @1と @2を　くりだした！",
+		"@1 et @2 sont envoyés par @0!",
+		"@0 manda in campo @1 e @2!",
+		"@1 und @2 werden von @0 in den Kampf geschickt!",
+		"@0: ¡@1 y @2, salid!"
+	],
+	"@0 sent out @1, @2, and @3!": [
+		"@0は @1と　@2と @3を　くりだした！",
+		"@1, @2 et @3 sont envoyés par @0!",
+		"@0 manda in campo @1, @2 e @3!",
+		"@1, @2 und @3 werden von @0 in den Kampf geschickt!",
+		"¡@0 saca a @1, @2 y @3!"
+	],
+	"@0 @1 is about to send in @2. Will you switch your Pokémon?": [
+		"@0の　@1は @2を　くりだそうとしている ポケモンを　いれかえますか？",
+		"Un @2 va être envoyé par @0 @1. Voulez-vous changer de Pokémon?",
+		"La prossima scelta di @1 (@0) sarà @2! Vuoi cambiare Pokémon?",
+		"@0 @1 setzt als Nächstes @2 ein. Möchtest du dein Pokémon wechseln?",
+		"¡@0 @1 enviará a @2! ¿Quieres cambiar de Pokémon?"
+	],
+	"You're in charge, @0!": [
+		"まかせた！　@0！",
+		"@0! Fonce!",
+		"Dai, @0!",
+		"Du schaffst es, @0!",
+		"¡Vamos, @0!"
+	],
+	"Go for it, @0!": [
+		"がんばれ！　@0！",
+		"En avant, @0!",
+		"Coraggio, @0!",
+		"Streng dich an, @0!",
+		"¡Tú puedes, @0!"
+	],
+	"Just a little more! Hang in there, @0!": [
+		"あとすこしだ！ がんばれ！　@0！",
+		"Un dernier petit effort! Tiens bon, @0!",
+		"Ancora un piccolo sforzo, @0! Non mollare!",
+		"Nur noch ein bisschen! Halte durch, @0!",
+		"¡Ya queda poco! ¡Aguanta, @0!"
+	],
+	"Your foe's weak! Get 'em, @0!": [
+		"あいてが　よわっている！ チャンスだ！　@0！",
+		"L'ennemi est faible! Attaque, @0!",
+		"Il nemico è debole! Forza, @0!",
+		"Mach es fertig! Los, @0!",
+		"¡Tu enemigo está débil! ¡A por él, @0!"
+	],
+	"@0, switch out! Come back!": [
+		"@0　こうたい！ もどれ！",
+		"@0, on change! Reviens!",
+		"@0, è ora! Rientra!",
+		"@0! Komm zurück!",
+		"¡@0, cambio! ¡Vuelve aquí!"
+	],
+	"@0, come back!": [
+		"@0 もどれ！",
+		"Reviens, @0!",
+		"@0, rientra!",
+		"@0, komm zurück!",
+		"¡@0, ven aquí!"
+	],
+	"@0, enough! Get back!": [
+		"@0　よし！ もどれ！",
+		"@0, ça suffit! Reviens!",
+		"@0, può bastare! Rientra!",
+		"@0, das reicht! Komm zurück!",
+		"¡@0, está bien! ¡Ven aquí!"
+	],
+	"@0, OK! Come back!": [
+		"@0　いいぞ！ もどれ！",
+		"OK, @0! Reviens!",
+		"@0, ok! Rientra!",
+		"@0, es ist gut! Komm zurück!",
+		"¡Bien hecho, @0! ¡Ven aquí!"
+	],
+	"@0, good job! Get back!": [
+		"@0　よくやった！ もどれ！",
+		"Bien, @0! Reviens!",
+		"@0, bene! Rientra!",
+		"Gut gemacht, @0! Komm zurück!",
+		"¡Muy bien, @0! ¡Ven aquí!"
+	],
+	"@0 @1 withdrew @2!": [
+		"@0の　@1は @2を　ひっこめた！",
+		"Le @2 est retiré par @0 @1!",
+		"@2 è stato ritirato dalla lotta da @1 (@0)!",
+		"@2 wurde von @0 @1 zurückgerufen!",
+		"@0 @1: ¡@2, retírate!"
+	],
+	"@0 withdrew @1!": [
+		"@0は @1を　ひっこめた！",
+		"@1 est retiré par @0!",
+		"@1 è stato ritirato dalla lotta da @0!",
+		"@1 wurde von @0 zurückgerufen!",
+		"@0: ¡@1, retírate!"
+	],
+	"Hit @0 time(s)!": [
+		"@0かい　あたった！",
+		"Touché @0 fois!",
+		"Colpi inflitti: @0!",
+		"@0-mal getroffen!",
+		"N.º de golpes: @0."
+	],
+	"@0 used the @1.": [
+		"@0は @1を　つかった！",
+		"@0 utilise @1!",
+		"@0 usa @1!",
+		"@0 setzt @1 ein.",
+		"¡@0 ha usado @1!"
+	],
+	"@0 @1 used one @2!": [
+		"@0の　@1は @2を　つかった！",
+		"@0 @1 utilise @2!",
+		"@1 (@0) ha usato lo strumento @2!",
+		"@0 @1 setzt @2 ein!",
+		"¡@0 @1 ha usado @2!"
+	],
+	"@0 launched the @2 toward @1!": [
+		"@0が　@1に @2を　シュートした！！",
+		"@0 a tiré l'objet @2 sur @1!",
+		"@0 lancia @2 verso @1!",
+		"@0 feuert @2 auf @1 ab!",
+		"¡@0 ha lanzado @2 a @1!"
+	],
+	"You cannot use your Wonder Launcher now!": [
+		"いまは　ミラクルシューターを つかうことが　できない！",
+		"Vous ne pouvez pas utiliser le Shooter-Miracle pour le moment!",
+		"Non puoi usare il Mirabilancere adesso!",
+		"Du kannst den Wunderwerfer jetzt nicht einsetzen!",
+		"¡Ahora no puedes usar el Superlanzador!"
+	],
+	"@0's Pokémon rotated to the left!": [
+		"@0の　ポケモンが ひだりへ　ローテーション！",
+		"@0 envoie son Pokémon à gauche!",
+		"I Pokémon di @0 ruotano verso sinistra!",
+		"Die Pokémon von @0 werden nach links gedreht!",
+		"¡El Pokémon de @0 rota hacia la izquierda!"
+	],
+	"@0's Pokémon rotated to the right!": [
+		"@0の　ポケモンが みぎへ　ローテーション！",
+		"@0 envoie son Pokémon à droite!",
+		"I Pokémon di @0 ruotano verso destra!",
+		"Die Pokémon von @0 werden nach rechts gedreht!",
+		"¡El Pokémon de @0 rota hacia la derecha!"
+	],
+	"@0 gained @1 Exp. Points!": [
+		"@0は @1 けいけんちを　もらった！",
+		"@0 a gagné @1 points Exp.!",
+		"Punti Esperienza ricevuti da @0: @1!",
+		"@0 erhält @1 E.-Punkt(e)!",
+		"¡@0 ha ganado @1 Puntos de Experiencia!"
+	],
+	"@0 gained a boosted @1 Exp. Points!": [
+		"@0は　おおめに @1 けいけんちを　もらった！",
+		"@0 a gagné un bonus de @1 points Exp.!",
+		"Bonus Punti Esperienza ricevuto da @0: @1!",
+		"@0 erhält @1 spezielle(n) E.-Punkt(e)!",
+		"¡@0 ha ganado @1 Puntos de Experiencia adicionales!"
+	],
+	"Player defeated @0 @1!": [
+		"@0の　@1 との　しょうぶに　かった！",
+		"Vous avez battu @0 @1!",
+		"Hai avuto la meglio su @1 (@0)!",
+		"Spieler besiegt @0 @1!",
+		"¡Has ganado a @0 @1!"
+	],
+	"Player beat @0 @1 and @2 @3!": [
+		"@0の　@1と @2の　@3 との　しょうぶに　かった！",
+		"@0 @1 et @2 @3 ont perdu!",
+		"Hai sconfitto @1 (@0) e @3 (@2)!",
+		"@0 @1 und @2 @3 sind besiegt!",
+		"¡@0 @1 ha perdido! ¡@2 @3, también!"
+	],
+	"Player lost against @0 @1!": [
+		"@0の　@1 との　しょうぶに　まけた！",
+		"@0 @1 a gagné!",
+		"La sfida è stata vinta da @1 (@0)!",
+		"Spieler verliert gegen @0 @1!",
+		"¡Has perdido! ¡La victoria es para @0 @1!"
+	],
+	"Player battled to a draw against @0 @1!": [
+		"@0の　@1 との　しょうぶは　ひきわけだ！",
+		"Égalité avec @0 @1!",
+		"La sfida contro @1 (@0) si è conclusa in parità!",
+		"Patt zwischen Spieler und @0 @1!",
+		"¡Has empatado con @0 @1!"
+	],
+	"Player defeated @0!": [
+		"@0との しょうぶに　かった！",
+		"@0 a perdu!",
+		"Hai avuto la meglio su @0!",
+		"Spieler besiegt @0!",
+		"¡Has derrotado a @0!"
+	],
+	"Player defeated @0 and @1!": [
+		"@0と　@1との しょうぶに　かった！",
+		"@0 et @1 ont perdu!",
+		"@1 e @0 hanno perso la sfida!",
+		"Spieler besiegt @0 und @1!",
+		"¡Has derrotado a @1 y @0!"
+	],
+	"Player lost against @0!": [
+		"@0との しょうぶに　まけた！",
+		"@0 a gagné!",
+		"@0 ha vinto la sfida!",
+		"Spieler verliert gegen @0!",
+		"¡Has perdido contra @0!"
+	],
+	"Player lost to @0 and @1!": [
+		"@0と　@1との しょうぶに　まけた！",
+		"@0 et @1 ont gagné!",
+		"@1 e @0 hanno vinto la sfida!",
+		"Spieler verliert gegen @0 und @1!",
+		"¡Has perdido contra @1 y @0!"
+	],
+	"Player battled to a draw against @0!": [
+		"@0との しょうぶは　ひきわけだ！",
+		"Égalité avec @0!",
+		"La sfida contro @0 si è conclusa in parità!",
+		"Patt zwischen Spieler und @0!",
+		"¡Has empatado con @0!"
+	],
+	"Player battled to a draw against @0 and @1!": [
+		"@0と　@1との しょうぶは　ひきわけだ！",
+		"Égalité avec @0 et @1!",
+		"La sfida contro @1 e @0 si è conclusa in parità!",
+		"Patt zwischen Spieler, @0 und @1!",
+		"¡Has empatado con @1 y @0!"
+	],
+	"@0 is out of usable Pokémon!": [
+		"@0の　てもとには たたかえる　ポケモンが　いない！",
+		"@0 n'a plus de Pokémon en forme!",
+		"@0 non ha più Pokémon disponibili!",
+		"@0 hat kein kampffähiges Pokémon mehr!",
+		"¡A @0 no le quedan Pokémon!"
+	],
+	"@0 dropped $@1 in panic...": [
+		"@0は　あわてて @1円　なくしてしまった……",
+		"@0 fait tomber @1 $ dans la panique!",
+		"Nella confusione @0 fa cadere $@1!",
+		"@0 gerät in Panik und verliert @1 $...",
+		"¡@0 se ha desconcertado y se le han caído @1 $!"
+	],
+	"@0 paid out $@1 to the winner...": [
+		"@0は　しょうきんとして @1円　しはらった…",
+		"@0 donne @1 $ au vainqueur.",
+		"@0 ha sborsato $@1 al vincitore!",
+		"@0 gibt @1 $ Preisgeld...",
+		"¡@0 paga @1 $ por haber perdido el combate!"
+	],
+	"@0 blacked out!": [
+		"……　……　…… ……　……　…… @0は めのまえが　まっくらに　なった！",
+		"... ... @0 est hors-jeu!",
+		"@0 si trova alle strette...",
+		"... @0 wird schwarz vor Augen!",
+		"... @0 está fuera de combate."
+	],
+	"@0 got $@1 for winning!": [
+		"@0は　しょうきんとして @1円　てにいれた！",
+		"@0 remporte @1 $!",
+		"@0 ha vinto $@1!",
+		"@0 gewinnt @1 $!",
+		"¡@0 gana @1 $ por vencer!"
+	],
+	"@0 picked up $@1!": [
+		"@0は　@1円　ひろった！",
+		"@0 obtient @1 $!",
+		"@0 ha raccolto $@1!",
+		"@0 hebt @1 $ auf!",
+		"¡@0 ha recogido @1 $!"
+	],
+	"@0 grew to Lv. @1!": [
+		"@0は レベル@1　に　あがった！",
+		"@0 monte au N. @1!",
+		"@0 è salito al livello @1!",
+		"@0 erreicht Lv. @1!",
+		"¡@0 ha subido al Nivel @1!"
+	],
+	"Oh, no! The Pokémon broke free!": [
+		"だめだ！　ポケモンが ボールから　でてしまった！",
+		"Oh, non! Le Pokémon s'est libéré!",
+		"Oh, no! Il Pokémon si è liberato!",
+		"Mist! Das Pokémon hat sich befreit!",
+		"¡Oh, no! ¡El Pokémon se ha escapado!"
+	],
+	"Aww! It appeared to be caught!": [
+		"ああ！ つかまえたと　おもったのに！",
+		"Raaah! Ça y était presque!",
+		"Ah! Sembrava preso, eh? E invece no!",
+		"Oh! Fast hätte es geklappt!",
+		"¡Vaya! ¡Parecía que lo habías atrapado!"
+	],
+	"Aargh! Almost had it!": [
+		"ざんねん！ もうすこしで　つかまえられたのに！",
+		"Aaaaah! Presque!",
+		"Grrr! Per un pelo!",
+		"Mist! Das war knapp!",
+		"¡Qué pena! ¡Te ha faltado poco!"
+	],
+	"Shoot! It was so close, too!": [
+		"おしい！ あとちょっとの　ところだったのに！",
+		"Mince! Ça y était presque!",
+		"Nooo! Era così vicino!",
+		"Verflixt! Es hätte beinahe geklappt!",
+		"¡Huy! ¡Casi lo consigues!"
+	],
+	"Gotcha! @0 was caught!": [
+		"やったー！ @0を　つかまえたぞ！",
+		"Et hop! @0 attrapé!",
+		"Preso! @0 è stato catturato!",
+		"Klasse! @0 wurde gefangen!",
+		"¡Ya está! ¡@0 atrapado!"
+	],
+	"@0's data was added to the Pokédex.": [
+		"@0のデータが　あたらしく ポケモンずかんに　とうろく　されます！",
+		"Les données de @0 sont ajoutées au Pokédex.",
+		"I dati di @0 sono stati inseriti nel Pokédex.",
+		"Für @0 wurde ein Eintrag im Pokédex angelegt.",
+		"Los datos de @0 se han registrado en la Pokédex."
+	],
+	"The Trainer blocked the Ball! Don't be a thief!": [
+		"トレーナーに　ボールをはじかれた！ ひとのものを　とったら　どろぼう！",
+		"Le Dresseur détourne la Ball! Voler, c'est mal!",
+		"La Poké Ball è stata respinta! Non puoi prendere i Pokémon altrui: è come rubare!",
+		"Der Trainer hat den Ball abgeblockt! Sei kein Dieb!",
+		"¡El Entrenador ha devuelto la Poké Ball! ¡No cojas lo que no es tuyo!"
+	],
+	"But it had no effect!": [
+		"しかし　こうかが　なかった！",
+		"Mais ça n'a aucun effet!",
+		"Ma è inefficace!",
+		"Es ist wirkungslos!",
+		"¡Pero no ha surtido efecto!"
+	],
+	"What will @0 do?": [
+		"@0は　どうする？",
+		"Que doit faire @0?",
+		"Tocca a @0. Cosa deve fare?",
+		"Was soll @0 tun?",
+		"¿Qué debería hacer @0?"
+	],
+	"<But it failed!": [
+		"<しかし　うまく　きまらなかった！！",
+		"<Mais cela échoue!",
+		"<Ma fallisce!",
+		"<Es ist fehlgeschlagen!",
+		"<¡Pero ha fallado!"
+	],
+	"Got away safely!": [
+		"うまく　にげきれた！",
+		"Vous prenez la fuite!",
+		"Scampato pericolo!",
+		"Du bist entkommen!",
+		"¡Escapas sin problemas!"
+	],
+	"Couldn't get away!": [
+		"にげられなかった！",
+		"Vous n'avez pas réussi à fuir.",
+		"Tentativo di fuga non riuscito!",
+		"Flucht gescheitert!",
+		"¡No has podido escapar!"
+	],
+	"Can't escape!": [
+		"にげることが　できない！",
+		"Fuite impossible!",
+		"Non si scappa!",
+		"Flucht unmöglich!",
+		"¡No puedes huir!"
+	],
+	"No! There's no running from a Trainer battle!": [
+		"ダメだ！　しょうぶのさいちゅうに あいてに　せなかを　みせられない！",
+		"On ne s'enfuit pas d'un combat de Dresseurs!",
+		"Non puoi sottrarti alla lotta con un Allenatore!",
+		"Du kannst aus Trainer-Kämpfen nicht fliehen!",
+		"¡No puedes huir de un combate contra un Entrenador!"
+	],
+	"Would you like to forfeit the match and quit now?": [
+		"しょうぶを　あきらめて こうさん　しますか？",
+		"Voulez-vous abandonner et quitter le combat?",
+		"Vuoi rinunciare all'incontro e uscire ora?",
+		"Möchtest du den Kampf jetzt aufgeben?",
+		"¿Quieres abandonar el combate y salir?"
+	],
+	"It's super effective!": [
+		"こうかは　ばつぐんだ！",
+		"C'est super efficace!",
+		"È superefficace!",
+		"Das ist sehr effektiv!",
+		"¡Es muy eficaz!"
+	],
+	"It's not very effective...": [
+		"こうかは　いまひとつ　のようだ……",
+		"Ce n'est pas très efficace...",
+		"Non è molto efficace...",
+		"Das ist nicht sehr effektiv...",
+		"No es muy eficaz..."
+	],
+	"It hurt itself in its confusion!": [
+		"わけも　わからず じぶんを　こうげきした！",
+		"Il se blesse dans sa confusion.",
+		"È così confuso da colpirsi da solo!",
+		"Es hat sich vor Verwirrung selbst verletzt!",
+		"¡Está tan confuso que se ha herido a sí mismo!"
+	],
+	"A critical hit!": [
+		"きゅうしょに　あたった！",
+		"Coup critique!",
+		"Brutto colpo!",
+		"Ein Volltreffer!",
+		"¡Un golpe crítico!"
+	],
+	"But there was no PP left for the move!": [
+		"しかし　わざの　のこりポイントが なかった！",
+		"Mais il n'y a plus de PP pour cette capacité!",
+		"Ma non ha Punti Potenza per sferrare la mossa!",
+		"Es sind keine AP mehr für diese Attacke übrig!",
+		"¡Pero no le quedan más PP para realizar ese movimiento!"
+	],
+	"@0 came to the rescue to restore @1's health!": [
+		"たすけにきた　@0の　おかげで @1の たいりょくが　かいふくした！",
+		"@0 vient au secours de @1 et restaure ses PV!",
+		"Grazie all'intervento di @0, @1 recupera Punti Salute!",
+		"Die KP von @1 wurden dank des heldenhaften Einsatzes von @0 aufgefrischt!",
+		"Gracias a que @0 ha venido a ayudarte, @1 ha recuperado PS."
+	],
+	"The sunlight turned harsh!": [
+		"ひざしが　つよくなった！",
+		"Les rayons du soleil brillent!",
+		"La luce solare diventa intensa!",
+		"Das Sonnenlicht wird stärker!",
+		"¡El sol pega fuerte!"
+	],
+	"It started to rain!": [
+		"あめが　ふりはじめた！",
+		"Il commence à pleuvoir!",
+		"Inizia a piovere!",
+		"Es fängt an zu regnen!",
+		"¡Ha empezado a llover!"
+	],
+	"A sandstorm kicked up!": [
+		"すなあらしが　ふきはじめた！",
+		"Une tempête de sable se prépare!",
+		"È iniziata una tempesta di sabbia!",
+		"Ein Sandsturm kommt auf!",
+		"¡Se ha desatado una tormenta de arena!"
+	],
+	"It started to hail!": [
+		"あられが　ふりはじめた！",
+		"Il commence à grêler!",
+		"Inizia a grandinare!",
+		"Es fängt an zu hageln!",
+		"¡Ha empezado a granizar!"
+	],
+	"Fog crept up as thick as soup!": [
+		"きりが　ただよいはじめた！",
+		"Le brouillard devient épais...",
+		"La nebbia comincia ad addensarsi!",
+		"Ein dichter Nebel breitet sich aus!",
+		"¡La niebla empieza a cubrir la zona!"
+	],
+	"The sunlight faded.": [
+		"ひざしが　もとに　もどった！",
+		"Les rayons du soleil s'affaiblissent!",
+		"La luce solare torna normale!",
+		"Das Sonnenlicht verliert wieder an Intensität!",
+		"¡El sol vuelve a brillar como siempre!"
+	],
+	"The rain stopped.": [
+		"あめが　あがった！",
+		"La pluie s'est arrêtée!",
+		"Ha smesso di piovere!",
+		"Der Regen lässt nach!",
+		"¡Ha dejado de llover!"
+	],
+	"The sandstorm subsided.": [
+		"すなあらしが　おさまった！",
+		"La tempête de sable se calme!",
+		"La tempesta di sabbia cessa!",
+		"Der Sandsturm legt sich!",
+		"¡La tormenta de arena se ha apaciguado!"
+	],
+	"The hail stopped.": [
+		"あられが　やんだ！",
+		"La grêle s'est arrêtée!",
+		"Ha smesso di grandinare!",
+		"Es hat aufgehört zu hageln!",
+		"¡Ha dejado de granizar!"
+	],
+	"The fog lifted.": [
+		"きりが　はれた！",
+		"Le brouillard s'est dissipé!",
+		"La nebbia si è diradata!",
+		"Der Nebel verschwindet!",
+		"¡Ya no hay niebla!"
+	],
+	"The effects of weather disappeared.": [
+		"てんこうの　えいきょうが　なくなった！",
+		"Les effets de la météo se dissipent!",
+		"Le condizioni climatiche non hanno più effetto!",
+		"Die wetterbedingten Effekte wurden aufgehoben!",
+		"El tiempo ya no ejerce ninguna influencia."
+	],
+	"The sandstorm rages.": [
+		"すなあらしが　ふきあれる！",
+		"La tempête de sable fait rage.",
+		"La tempesta di sabbia imperversa!",
+		"Der Sandsturm tobt!",
+		"La tormenta de arena arrecia..."
+	],
+	"The hail crashes down.": [
+		"あられが　ふきすさぶ！",
+		"Il y a un déluge de grêle.",
+		"La grandine imperversa!",
+		"Der Hagelsturm tobt!",
+		"¡El granizo cae con violencia!"
+	],
+	"It's a one-hit KO!": [
+		"いちげきひっさつ！",
+		"K.O. en un coup!",
+		"È un colpo da KO!",
+		"Ein K.O.-Treffer!",
+		"¡K.O. en un golpe!"
+	],
+	"The @0 weakened @1's power!": [
+		"@0は @1の　いりょくを　よわめた！",
+		"@0 affaiblit @1!",
+		"@0 indebolisce la potenza di @1!",
+		"@0 schwächt Kraft von @1!",
+		"¡@0 debilitó el poder de @1!"
+	],
+	"The @0 allows the use of only @1!": [
+		"@0の　こうかで @1しか　だせない！",
+		"Avec @0, seule la capacité @1 peut être utilisée!",
+		"@0 consente di usare soltanto @1!",
+		"@0 erlaubt nur den Einsatz von @1!",
+		"¡Con @0, solo se puede usar @1!"
+	],
+	"@0 can use only @1!": [
+		"@0は @1しか　だせない！",
+		"@0 ne peut utiliser que @1!",
+		"@0 può usare solo @1!",
+		"@0 kann keine andere Attacke als @1 einsetzen!",
+		"¡@0 solo puede usar @1!"
+	],
+	"All stat changes were eliminated!": [
+		"すべてのステータスが もとに　もどった！",
+		"Les changements de stats ont tous été annulés!",
+		"Tutte le modifiche alle statistiche sono state annullate!",
+		"Alle Statusveränderungen wurden entfernt!",
+		"¡Se han eliminado todos los cambios en las características!"
+	],
+	"But nothing happened!": [
+		"しかし　なにもおこらない！",
+		"Mais rien ne se passe!",
+		"Ma non è successo nulla!",
+		"Nichts geschieht!",
+		"¡Pero no ha tenido ningún efecto!"
+	],
+	"@0's @1": [
+		"@0の @1",
+		"@1 de @0",
+		"@1 di @0",
+		"@1 von @0 wirkt!",
+		"@1 de @0"
+	],
+	"Magnitude @0!": [
+		"マグニチュード@0！",
+		"Ampleur @0!",
+		"Magnitudo @0!",
+		"Intensität @0!",
+		"¡Magnitud @0!"
+	],
+	"A bell chimed!": [
+		"すずのねが　ひびきわたった！",
+		"Un grelot sonne!",
+		"Una campana ha suonato!",
+		"Eine Glocke läutet!",
+		"¡Ha repicado una campana!"
+	],
+	"A soothing aroma wafted through the area!": [
+		"ここちよい　かおりが　ひろがった！",
+		"Une odeur apaisante flotte dans les airs!",
+		"Un gradevole profumo si è diffuso nell'aria!",
+		"Ein wohltuendes Aroma breitet sich aus!",
+		"¡Un aroma balsámico flota en el aire!"
+	],
+	"The battlers shared their pain!": [
+		"おたがいの　たいりょくを　わかちあった！",
+		"Les adversaires se partagent les dégâts!",
+		"I Pokémon si dividono i danni!",
+		"Die Kontrahenten teilen ihr Leid!",
+		"¡Los combatientes comparten el daño sufrido!"
+	],
+	"Fire's power was weakened!": [
+		"ほのおの　いりょくが　よわまった！",
+		"La puissance du feu est affaiblie!",
+		"La potenza del fuoco è stata indebolita!",
+		"Die Stärke des Feuers wurde geschwächt!",
+		"¡Se han debilitado los ataques de tipo Fuego!"
+	],
+	"Electricity's power was weakened!": [
+		"でんきの　いりょくが　よわまった！",
+		"La puissance de l'électricité est affaiblie!",
+		"La potenza dell'elettricità è stata indebolita!",
+		"Die Stärke der Elektrizität wurde geschwächt!",
+		"¡Se han debilitado los ataques de tipo Eléctrico!"
+	],
+	"The twisted dimensions returned to normal!": [
+		"ゆがんだ　じくうが　もとに　もどった！",
+		"Les dimensions faussées redeviennent normales!",
+		"La dimensione distorta torna alla normalità!",
+		"Die verdrehte Dimension ist wieder normal!",
+		"¡Se han restaurado las dimensiones alteradas!"
+	],
+	"Gravity intensified!": [
+		"じゅうりょくが　つよくなった！",
+		"La Gravité est intensifiée!",
+		"La gravità si intensifica!",
+		"Erdanziehung wurde verstärkt!",
+		"¡La gravedad se ha incrementado!"
+	],
+	"Gravity returned to normal!": [
+		"じゅうりょくが　もとにもどった！",
+		"La Gravité est revenue à la normale!",
+		"La gravità torna normale!",
+		"Die Erdanziehung ist wieder normal!",
+		"¡La gravedad ha vuelto a su estado normal!"
+	],
+	"All Pokémon hearing the song will faint in three turns!": [
+		"ほろびのうたを　きいた　ポケモンは ３ターンごに　ほろびてしまう！",
+		"Les Pokémon au combat seront K.O. dans 3 tours!",
+		"Tutti i Pokémon che ascoltano Ultimocanto saranno esausti in tre turni!",
+		"Alle betroffenen Pokémon werden in 3 Runden K.O. gehen!",
+		"¡Los Pokémon que oigan Canto Mortal se debilitarán dentro de tres turnos!"
+	],
+	"Waggling a finger let it use @0!": [
+		"ゆびをふったら　@0がでた！",
+		"Métronome lance @0!",
+		"Grazie a Metronomo, il Pokémon può sferrare la mossa @0!",
+		"Es lässt den Finger schwingen und schon setzt @0 ein!",
+		"¡Metrónomo actúa como @0!"
+	],
+	"Nature Power turned into @0!": [
+		"しぜんのちからは @0　になった！",
+		"Force-Nature provoque @0.",
+		"Naturforza risulta in @0!",
+		"Natur-Kraft löst @0 aus!",
+		"¡Adaptación actúa como @0!"
+	],
+	"Coins were scattered everywhere!": [
+		"こばんが　あたりに　ちらばった！",
+		"Une pluie de pièces!",
+		"Ci sono monete sparse ovunque!",
+		"Es sind überall Münzen verstreut!",
+		"¡Hay monedas por todas partes!"
+	],
+	"It was too weak to make a substitute!": [
+		"しかし　みがわりを　だすには たいりょくが　たりなかった！",
+		"Trop faible pour créer un clone!",
+		"Troppo debole! Non può creare un sostituto!",
+		"Zu schwach, um einen Delegator einzusetzen!",
+		"¡Está demasiado débil para crear un sustituto!"
+	],
+	"Reflect raised your team's Defense!": [
+		"みかたは　リフレクターで ぶつりに　つよくなった！",
+		"Protection augmente la Défense de l'équipe!",
+		"Con Riflesso la tua squadra aumenta la propria Difesa!",
+		"Reflektor stärkt Pokémon auf deiner Seite gegen physische Attacken!",
+		"¡Reflejo ha subido la Defensa de tu equipo!"
+	],
+	"Reflect raised the opposing team's Defense!": [
+		"あいては　リフレクターで ぶつりに　つよくなった！",
+		"Protection augmente la Défense de l'équipe ennemie!",
+		"Con Riflesso il nemico aumenta la Difesa della propria squadra!",
+		"Reflektor stärkt Pokémon des Gegners gegen physische Attacken!",
+		"¡Reflejo ha subido la Defensa del equipo enemigo!"
+	],
+	"Your team's Reflect wore off!": [
+		"みかたの　リフレクターが なくなった！",
+		"Protection n'a plus d'effet sur l'équipe!",
+		"L'effetto di Riflesso sulla tua squadra è finito!",
+		"Die Wirkung von Reflektor auf Pokémon, die auf deiner Seite kämpfen, lässt nach!",
+		"¡El efecto de Reflejo en tu equipo se ha disipado!"
+	],
+	"The opposing team's Reflect wore off!": [
+		"あいての　リフレクターが なくなった！",
+		"Protection n'a plus d'effet sur l'équipe ennemie!",
+		"L'effetto di Riflesso sulla squadra avversaria è finito!",
+		"Die Wirkung von Reflektor auf Pokémon, die für den Gegner kämpfen, lässt nach!",
+		"¡El efecto de Reflejo en el equipo enemigo se ha disipado!"
+	],
+	"Light Screen raised your team's Special Defense!": [
+		"みかたは　ひかりのかべで とくしゅに　つよくなった！",
+		"Mur Lumière augmente la Défense Spéciale de l'équipe!",
+		"Con Schermoluce la tua squadra aumenta la propria Difesa Speciale!",
+		"Lichtschild stärkt Pokémon, die auf deiner Seite kämpfen, gegen Spezial-Attacken!",
+		"¡Pantalla de Luz ha subido la Defensa Especial de tu equipo!"
+	],
+	"Light Screen raised the opposing team's Special Defense!": [
+		"あいては　ひかりのかべで とくしゅに　つよくなった！",
+		"Mur Lumière augmente la Défense Spéciale de l'équipe ennemie!",
+		"Con Schermoluce il nemico aumenta la Difesa Speciale della propria squadra!",
+		"Lichtschild stärkt Pokémon, die für den Gegner kämpfen, gegen Spezial-Attacken!",
+		"¡Pantalla de Luz ha subido la Defensa Especial del equipo enemigo!"
+	],
+	"Your team's Light Screen wore off!": [
+		"みかたの　ひかりのかべが なくなった！",
+		"Mur Lumière n'a plus d'effet sur l'équipe!",
+		"L'effetto di Schermoluce sulla tua squadra è finito!",
+		"Die Wirkung von Lichtschild auf Pokémon, die auf deiner Seite kämpfen, lässt nach!",
+		"¡El efecto de Pantalla de Luz en tu equipo se ha disipado!"
+	],
+	"The opposing team's Light Screen wore off!": [
+		"あいての　ひかりのかべが なくなった！",
+		"Mur Lumière n'a plus d'effet sur l'équipe ennemie!",
+		"L'effetto di Schermoluce sulla squadra avversaria è finito!",
+		"Die Wirkung von Lichtschild auf Pokémon, die für den Gegner kämpfen, lässt nach!",
+		"¡El efecto de Pantalla de Luz en el equipo enemigo se ha disipado!"
+	],
+	"Your team became cloaked in a mystical veil!": [
+		"みかたは しんぴのベールに　つつまれた！",
+		"Votre équipe est recouverte par un voile!",
+		"Un velo mistico ricopre la tua squadra!",
+		"Das Team des Anwenders wird von einem Schleier umhüllt!",
+		"¡Tu equipo se ha protegido con Velo Sagrado!"
+	],
+	"The foe's team became cloaked in a mystical veil!": [
+		"あいては しんぴのベールに　つつまれた！",
+		"L'équipe ennemie est recouverte par un voile!",
+		"Un velo mistico ricopre la squadra avversaria!",
+		"Das Team des Gegners wird von einem Schleier umhüllt!",
+		"¡El equipo enemigo se ha protegido con Velo Sagrado!"
+	],
+	"Your team is no longer protected by Safeguard!": [
+		"みかたを　つつんでいた しんぴのベールが　なくなった！",
+		"Votre équipe n'est plus protégée par Rune Protect!",
+		"La tua squadra non è più protetta da Salvaguardia!",
+		"Der mystische Schleier, der dein Team umgab, hat sich gelüftet!",
+		"¡El efecto de Velo Sagrado en tu equipo se ha disipado!"
+	],
+	"The foe's team is no longer protected by Safeguard!": [
+		"あいてを　つつんでいた しんぴのベールが　なくなった！",
+		"L'équipe ennemie n'est plus protégée par Rune Protect!",
+		"La squadra avversaria non è più protetta da Salvaguardia!",
+		"Der mystische Schleier, der das Team des Gegners umgab, hat sich gelüftet!",
+		"¡El efecto de Velo Sagrado en el equipo enemigo se ha disipado!"
+	],
+	"Your team became shrouded in mist!": [
+		"みかたは しろいきりに　つつまれた！",
+		"Votre équipe s'entoure de Brume!",
+		"La tua squadra è avvolta dalla nebbia!",
+		"Pokémon, die auf deiner Seite kämpfen, werden in Weißnebel gehüllt!",
+		"¡Neblina ha cubierto a tu equipo!"
+	],
+	"The foe's team became shrouded in mist!": [
+		"あいては しろいきりに　つつまれた！",
+		"L'équipe ennemie s'entoure de Brume!",
+		"La squadra avversaria è avvolta dalla nebbia!",
+		"Pokémon, die für den Gegner kämpfen, werden in Weißnebel gehüllt!",
+		"¡Neblina ha cubierto al equipo enemigo!"
+	],
+	"Your team is no longer protected by mist!": [
+		"みかたを　つつんでいた しろいきりが　なくなった！",
+		"La Brume de l'équipe s'est dissipée!",
+		"La nebbia intorno alla tua squadra si è diradata!",
+		"Der Weißnebel, der die Pokémon auf deiner Seite umgab, hat sich gelichtet!",
+		"¡El efecto de Neblina en tu equipo se ha disipado!"
+	],
+	"The foe's team is no longer protected by mist!": [
+		"あいてを　つつんでいた しろいきりが　なくなった！",
+		"La Brume de l'équipe ennemie s'est dissipée!",
+		"La nebbia intorno alla squadra avversaria si è diradata!",
+		"Der Weißnebel, der die Pokémon auf der Seite des Gegners umgab, hat sich gelichtet!",
+		"¡El efecto de Neblina en el equipo enemigo se ha disipado!"
+	],
+	"The tailwind blew from behind your team!": [
+		"みかたに おいかぜが　ふきはじめた！",
+		"Un Vent Arrière souffle sur votre équipe!",
+		"Comincia a soffiare Ventoincoda sulla tua squadra!",
+		"Die Pokémon, die auf deiner Seite kämpfen, erhalten Rückenwind!",
+		"¡Viento Afín empieza a soplar sobre tu equipo!"
+	],
+	"The tailwind blew from behind the foe's team!": [
+		"あいてに おいかぜが　ふきはじめた！",
+		"Un Vent Arrière souffle sur l'équipe ennemie!",
+		"Comincia a soffiare Ventoincoda sulla squadra avversaria!",
+		"Die Pokémon, die auf der Seite des Gegners kämpfen, erhalten Rückenwind!",
+		"¡Viento Afín empieza a soplar sobre el equipo rival!"
+	],
+	"Your team's tailwind petered out!": [
+		"みかたの おいかぜが　やんだ！",
+		"Le Vent Arrière de votre équipe s'arrête!",
+		"Ventoincoda non soffia più sulla tua squadra!",
+		"Der Rückenwind auf deiner Seite lässt nach.",
+		"¡Ha cesado el Viento Afín de tu equipo!"
+	],
+	"The foe's team's tailwind petered out!": [
+		"あいての おいかぜが　やんだ！",
+		"Le Vent Arrière de l'équipe ennemie s'arrête!",
+		"Ventoincoda non soffia più sulla squadra avversaria!",
+		"Der Rückenwind auf gegnerischer Seite lässt nach!",
+		"¡Ha cesado el Viento Afín del equipo rival!"
+	],
+	"The Lucky Chant shielded your team from critical hits!": [
+		"おまじないの　ちからで みかたの　きゅうしょが　かくれた！",
+		"L'Air Veinard immunise votre équipe contre les coups critiques!",
+		"Fortuncanto protegge la tua squadra dai brutti colpi!",
+		"Beschwörung schützt dein Team vor Volltreffern!",
+		"¡Conjuro protege a tu equipo de los golpes críticos!"
+	],
+	"The Lucky Chant shielded the opposing team from critical hits!": [
+		"おまじないの　ちからで あいての　きゅうしょが　かくれた！",
+		"L'Air Veinard immunise l'ennemi contre les coups critiques!",
+		"Fortuncanto protegge la squadra avversaria dai brutti colpi!",
+		"Beschwörung schützt das gegnerische Team vor Volltreffern!",
+		"¡Conjuro protege al equipo rival de los golpes críticos!"
+	],
+	"Your team's Lucky Chant wore off!": [
+		"みかたの　おまじないが　とけた！",
+		"L'Air Veinard de votre équipe prend fin!",
+		"Finito l'effetto di Fortuncanto sulla tua squadra!",
+		"Beschwörung deines Teams lässt nach!",
+		"¡El conjuro de tu equipo se ha desvanecido!"
+	],
+	"The opposing team's Lucky Chant wore off!": [
+		"あいての　おまじないが　とけた！",
+		"L'Air Veinard de l'équipe ennemie prend fin!",
+		"Finito l'effetto di Fortuncanto sulla squadra avversaria!",
+		"Beschwörung des gegnerischen Teams lässt nach!",
+		"¡El conjuro del equipo enemigo se ha desvanecido!"
+	],
+	"Spikes were scattered all around your team's feet!": [
+		"みかたの　あしもとに まきびしが　ちらばった！",
+		"Des Picots s'éparpillent autour de votre équipe!",
+		"Ai piedi della tua squadra c'è una trappola di Punte!",
+		"Die Pokémon auf deiner Seite sind von Stacheln umgeben!",
+		"¡Tu equipo ha sido rodeado de púas!"
+	],
+	"Spikes were scattered all around the feet of the foe's team!": [
+		"あいての　あしもとに まきびしが　ちらばった！",
+		"Des Picots s'éparpillent autour de l'équipe ennemie!",
+		"Ai piedi della squadra nemica c'è una trappola di Punte!",
+		"Die Pokémon auf gegnerischer Seite sind von Stacheln umgeben!",
+		"¡El equipo enemigo ha sido rodeado de púas!"
+	],
+	"The spikes disappeared from around your team's feet!": [
+		"みかたの　あしもとの まきびしが　きえさった！",
+		"Il n'y a plus de Picots autour de votre équipe!",
+		"Ai piedi della tua squadra non c'è più la trappola di Punte!",
+		"Die Stacheln, die auf deiner Seite herumlagen, sind verschwunden!",
+		"¡Las púas lanzadas a tu equipo han desaparecido!"
+	],
+	"The spikes disappeared from around the foe's team's feet!": [
+		"あいての　あしもとの まきびしが　きえさった！",
+		"Il n'y a plus de Picots autour de l'équipe ennemie!",
+		"Ai piedi della squadra nemica non c'è più la trappola di Punte!",
+		"Die Stacheln, die auf der gegnerischen Seite herumlagen, sind verschwunden!",
+		"¡Las púas lanzadas al equipo enemigo han desaparecido!"
+	],
+	"Poison spikes were scattered all around your team's feet!": [
+		"みかたの　あしもとに どくびしが　ちらばった！",
+		"Des pics toxiques se répandent autour de votre équipe!",
+		"Ai piedi della tua squadra c'è una trappola di Fielepunte!",
+		"Die Pokémon auf deiner Seite sind überall von giftigen Stacheln umgeben!",
+		"¡Tu equipo ha sido rodeado de púas tóxicas!"
+	],
+	"Poison spikes were scattered all around the foe's team's feet!": [
+		"あいての　あしもとに どくびしが　ちらばった！",
+		"Des pics toxiques se répandent autour de l'équipe ennemie!",
+		"Ai piedi della squadra nemica c'è una trappola di Fielepunte!",
+		"Die Pokémon auf gegnerischer Seite sind überall von giftigen Stacheln umgeben!",
+		"¡El equipo enemigo ha sido rodeado de púas tóxicas!"
+	],
+	"The poison spikes disappeared from around your team's feet!": [
+		"みかたの　あしもとの どくびしが　きえさった！",
+		"Il n'y a plus de pics toxiques autour de votre équipe!",
+		"Ai piedi della tua squadra non c'è più la trappola di Fielepunte!",
+		"Die giftigen Stacheln, die um die Pokémon auf deiner Seite lagen, sind verschwunden!",
+		"¡Las púas tóxicas lanzadas a tu equipo han desaparecido!"
+	],
+	"The poison spikes disappeared from around the foe's team's feet!": [
+		"あいての　あしもとの どくびしが　きえさった！",
+		"Il n'y a plus de pics toxiques autour de l'équipe ennemie!",
+		"Ai piedi della squadra nemica non c'è più la trappola di Fielepunte!",
+		"Die giftigen Stacheln, die um die Pokémon auf der gegn. Seite lagen, sind verschwunden!",
+		"¡Las púas tóxicas lanzadas al equipo enemigo han desaparecido!"
+	],
+	"Pointed stones float in the air around your team!": [
+		"みかたの　まわりに とがった　いわが　ただよいはじめた！",
+		"Des pierres pointues flottent en l'air autour de votre équipe!",
+		"La tua squadra è circondata da rocce aguzze sospese in aria!",
+		"Um die Pokémon auf deiner Seite schweben spitze Steine!",
+		"¡Tu equipo está rodeado de piedras puntiagudas!"
+	],
+	"Pointed stones float in the air around your foe's team!": [
+		"あいての　まわりに とがった　いわが　ただよいはじめた！",
+		"Des pierres pointues flottent en l'air autour de l'équipe ennemie!",
+		"La squadra avversaria è circondata da rocce aguzze sospese in aria!",
+		"Um die Pokémon auf gegnerischer Seite schweben spitze Steine!",
+		"¡El equipo enemigo está rodeado de piedras puntiagudas!"
+	],
+	"The pointed stones disappeared from around your team!": [
+		"みかたの　まわりの ステルスロックが　きえさった！",
+		"Les pierres pointues autour de votre équipe ont disparu!",
+		"Levitoroccia non ha più effetto sulla tua squadra!",
+		"Die spitzen Steine um die Pokémon auf deiner Seite sind verschwunden!",
+		"¡Las piedras puntiagudas lanzadas a tu equipo han desaparecido!"
+	],
+	"The pointed stones disappeared from around the foe's team!": [
+		"あいての　まわりの ステルスロックが　きえさった！",
+		"Les pierres pointues autour de l'équipe ennemie ont disparu!",
+		"Levitoroccia non ha più effetto sulla squadra avversaria!",
+		"Die spitzen Steine um die Pokémon auf der gegnerischen Seite sind verschwunden!",
+		"¡Las piedras puntiagudas lanzadas al equipo enemigo han desaparecido!"
+	],
+	"Wide Guard protected your team!": [
+		"みかたの　まわりを ワイドガードが　まもっている！",
+		"Votre équipe est protégée par Garde Large!",
+		"La tua squadra è protetta da Bodyguard!",
+		"Die Pokémon auf deiner Seite werden von Rundumschutz behütet!",
+		"¡Vastaguardia protege a tu equipo!"
+	],
+	"Wide Guard protected the foe's team!": [
+		"あいての　まわりを ワイドガードが　まもっている！",
+		"L'équipe ennemie est protégée par Garde Large!",
+		"La squadra avversaria è protetta da Bodyguard!",
+		"Die Pokémon auf der gegnerischen Seite werden von Rundumschutz behütet!",
+		"¡Vastaguardia protege al equipo rival!"
+	],
+	"Quick Guard protected your team!": [
+		"みかたの　まわりを ファストガードが　まもっている！",
+		"Votre équipe est protégée par Prévention!",
+		"La tua squadra è protetta da Anticipo!",
+		"Die Pokémon auf deiner Seite werden von Rapidschutz behütet!",
+		"¡Anticipo protege a tu equipo!"
+	],
+	"Quick Guard protected the foe's team!": [
+		"あいての　まわりを ファストガードが　まもっている！",
+		"L'équipe ennemie est protégée par Prévention!",
+		"La squadra avversaria è protetta da Anticipo!",
+		"Die Pokémon auf der gegnerischen Seite werden von Rapidschutz behütet!",
+		"¡Anticipo protege al equipo rival!"
+	],
+	"A rainbow appeared in the sky on your team's side!": [
+		"みかたの　そらに　にじが　かかった！",
+		"Un arc-en-ciel apparaît dans votre ciel!",
+		"Appare un arcobaleno sulla tua squadra!",
+		"Ein Regenbogen erscheint am Himmel über den Pokémon auf deiner Seite!",
+		"¡Ha aparecido un arcoíris sobre tu equipo!"
+	],
+	"A rainbow appeared in the sky on the foe's team's side!": [
+		"あいての　そらに　にじが　かかった！",
+		"Un arc-en-ciel apparaît dans le ciel de l'équipe ennemie!",
+		"Appare un arcobaleno sulla squadra avversaria!",
+		"Ein Regenbogen erscheint am Himmel über den Pokémon auf der gegnerischen Seite!",
+		"¡Ha aparecido un arcoíris sobre el equipo rival!"
+	],
+	"The rainbow on your team's side disappeared!": [
+		"みかたの　そらから　にじが　きえた！",
+		"L'arc-en-ciel a disparu de votre ciel!",
+		"Scompare l'arcobaleno sulla tua squadra!",
+		"Der Regenbogen über den Pokémon auf deiner Seite ist verschwunden!",
+		"¡El arcoíris sobre tu equipo ha desaparecido!"
+	],
+	"The rainbow on the foe's team's side disappeared!": [
+		"あいての　そらから　にじが　きえた！",
+		"L'arc-en-ciel a disparu du ciel de l'équipe ennemie!",
+		"Scompare l'arcobaleno sulla squadra avversaria!",
+		"Der Regenbogen über den Pokémon auf der gegnerischen Seite ist verschwunden!",
+		"¡El arcoíris sobre el equipo rival ha desaparecido!"
+	],
+	"A sea of fire enveloped your team!": [
+		"みかたの　まわりが ひのうみに　つつまれた！",
+		"Votre équipe est cernée par une mer de feu!",
+		"La tua squadra è avvolta da un muro di fiamme!",
+		"Um die Pokémon auf deiner Seite erstreckt sich ein Meer aus Feuer!",
+		"¡Tu equipo se ve rodeado por un mar de llamas!"
+	],
+	"A sea of fire enveloped the foe's team!": [
+		"あいての　まわりが ひのうみに　つつまれた！",
+		"L'équipe ennemie est cernée par une mer de feu!",
+		"La squadra avversaria è avvolta da un muro di fiamme!",
+		"Um die Pokémon auf der gegnerischen Seite erstreckt sich ein Meer aus Feuer!",
+		"¡El equipo rival se ve rodeado por un mar de llamas!"
+	],
+	"The sea of fire around your team disappeared!": [
+		"みかたの　まわりの ひのうみが　きえさった！",
+		"La mer de feu autour de votre équipe a disparu!",
+		"Il muro di fiamme non avvolge più la tua squadra!",
+		"Das Meer aus Feuer um die Pokémon auf deiner Seite ist verschwunden!",
+		"¡El mar de llamas que rodeaba a tu equipo ha desaparecido!"
+	],
+	"The sea of fire around the foe's team disappeared!": [
+		"あいての　まわりの ひのうみが　きえさった！",
+		"La mer de feu autour de l'équipe ennemie a disparu!",
+		"Il muro di fiamme non avvolge più la squadra avversaria!",
+		"Das Meer aus Feuer um die Pokémon auf der gegnerischen Seite ist verschwunden!",
+		"¡El mar de llamas que rodeaba al equipo rival ha desaparecido!"
+	],
+	"A swamp enveloped your team!": [
+		"みかたの　まわりに しつげんが　ひろがった！",
+		"Votre équipe est cernée par un marécage!",
+		"La tua squadra è circondata da una palude!",
+		"Ein Sumpf tut sich um die Pokémon auf deiner Seite auf!",
+		"¡Ha aparecido un pantano alrededor de tu equipo!"
+	],
+	"A swamp enveloped the foe's team!": [
+		"あいての　まわりに しつげんが　ひろがった！",
+		"L'équipe ennemie est cernée par un marécage!",
+		"La squadra avversaria è circondata da una palude!",
+		"Ein Sumpf tut sich um die Pokémon auf der gegnerischen Seite auf!",
+		"¡Ha aparecido un pantano alrededor del equipo rival!"
+	],
+	"The swamp around your team disappeared!": [
+		"みかたの　まわりの しつげんが　きえさった！",
+		"Le marécage autour de votre équipe a disparu!",
+		"La tua squadra non è più circondata dalla palude!",
+		"Der Sumpf um die Pokémon auf deiner Seite ist verschwunden!",
+		"¡El pantano que rodeaba a tu equipo ha desaparecido!"
+	],
+	"The swamp around the foe's team disappeared!": [
+		"あいての　まわりの しつげんが　きえさった！",
+		"Le marécage autour de l'équipe ennemie a disparu!",
+		"La squadra avversaria non è più circondata dalla palude!",
+		"Der Sumpf um die Pokémon auf der gegnerischen Seite ist verschwunden!",
+		"¡El pantano que rodeaba al equipo rival ha desaparecido!"
+	],
+	"Your team is too nervous to eat Berries!": [
+		"みかたは　きんちょうして きのみが　たべられなくなった！",
+		"Votre équipe est tendue et ne peut plus manger de Baies!",
+		"I Pokémon della tua squadra non riescono a mangiare le Bacche per l'emozione!",
+		"Die Pokémon auf deiner Seite kriegen vor Anspannung keine Beeren mehr runter!",
+		"¡Tu equipo está muy nervioso y no puede tomar Bayas!"
+	],
+	"The foe's team is too nervous to eat Berries!": [
+		"あいては　きんちょうして きのみが　たべられなくなった！",
+		"L'équipe ennemie est tendue et ne peut plus manger de Baies!",
+		"I Pokémon della squadra nemica non riescono a mangiare le Bacche per l'emozione!",
+		"Die Pokémon auf der gegn. Seite kriegen vor Anspannung keine Beeren mehr runter!",
+		"¡El equipo rival está muy nervioso y no puede tomar Bayas!"
+	],
+	"It created a bizarre area in which the Defense and Sp. Def stats are swapped!": [
+		"ぼうぎょと　とくぼうが　いれかわる くうかんを　つくりだした！",
+		"La Défense et la Défense Spéciale sont interverties!",
+		"Ha creato una dimensione in cui Difesa e Difesa Speciale vengono scambiate!",
+		"Es entsteht ein Raum, wo Vert. und Sp.-Ver. miteinander vertauscht sind!",
+		"¡Se ha creado un espacio en el que Defensa y Defensa Especial se invierten!"
+	],
+	"Wonder Room wore off, and the Defense and Sp. Def stats returned to normal!": [
+		"ワンダールームが　かいじょされ ぼうぎょと　とくぼうが　もとにもどった！",
+		"La Défense et la Défense Spéciale sont revenues à la normale!",
+		"La dimensione non è più alterata: Difesa e Difesa Speciale sono tornate alla normalità!",
+		"Der Wunderraum verpufft. Vert. und Sp.-Ver. werden wieder zurückgesetzt!",
+		"¡Los efectos de Zona Extraña sobre la Defensa y la Def. Esp. han desaparecido!"
+	],
+	"It created a bizarre area in which Pokémon's held items lose their effects!": [
+		"もたせた　どうぐの　こうかが なくなる　くうかんを　つくりだした！",
+		"L'effet des objets tenus est neutralisé!",
+		"Ha creato una dimensione in cui svaniscono gli effetti degli strumenti!",
+		"Es entsteht ein Raum, wo getragene Items ihre Wirkung verlieren!",
+		"¡Se ha creado un espacio en el que los efectos de los objetos desaparecen!"
+	],
+	"Magic Room wore off, and the held items' effects returned to normal!": [
+		"マジックルームが　かいじょされ どうぐの　こうかが　もとにもどった！",
+		"L'effet des objets tenus est rétabli!",
+		"La dimensione non è più alterata e gli strumenti tornano ad avere effetto!",
+		"Der Magieraum verpufft. Getragene Items erhalten ihre Wirkung zurück!",
+		"¡Los efectos de Zona Mágica sobre los objetos han desaparecido!"
+	],
+	"The @0 strengthened @1's power!": [
+		"@0は　@1の いりょくを　つよめた！",
+		"@0 renforce @1!",
+		"@0 incrementa la potenza di @1!",
+		"@0 erhöht die Kraft von @1!",
+		"¡@0 refuerza el poder de @1!"
+	],
+	"The time limit is up! The battle will end!": [
+		"せいげんじかんが　なくなりました！ たいせんを　しゅうりょう　します！",
+		"La limite de temps est dépassée! Fin du combat!",
+		"Il tempo è scaduto! La lotta finisce qui.",
+		"Die Zeit ist abgelaufen! Der Kampf wird beendet.",
+		"¡Se ha acabado el tiempo! ¡Fin del combate!"
+	],
+	"The battle is too long. Playback canceled.": [
+		"しょうぶの　じかんが　ながすぎるため さいせいを　ちゅうだん　します！",
+		"Le combat est trop long. Fin de la retransmission!",
+		"La lotta è durata troppo a lungo, perciò la riproduzione viene interrotta qui!",
+		"Der Kampf dauert zu lange, um weiter aufgezeichnet werden zu können.",
+		"El combate dura demasiado. Se ha detenido la reproducción."
+	],
+	"Zen Mode triggered!": [
+		"ダルマモード　はつどう！",
+		"Mode Transe!",
+		"Forma Zen attivata!",
+		"Es verfällt in den Trance-Modus!",
+		"¡Modo Daruma activado!"
+	],
+	"Zen Mode ended!": [
+		"ダルマモード　かいじょ！",
+		"Mode Normal!",
+		"Forma Zen disattivata!",
+		"Es verlässt den Trance-Modus!",
+		"¡Modo Daruma desactivado!"
+	],
+	"The two moves are joined! It's a combined move!": [
+		"２つのわざが　ひとつになった！ コンビネーションわざだ！",
+		"Les deux capacités se sont combinées!",
+		"Formidabile! Due mosse che diventano una! Che combinazione fantastica!",
+		"Zwei Attacken bilden zusammen eine Kombi-Attacke!",
+		"¡Los dos movimientos se han unido! ¡Es un movimiento combinado!"
+	],
+	"@0 won't obey!": [
+		"@0は　いうことを　きかない！",
+		"@0 n'obéit pas!",
+		"@0 non obbedisce!",
+		"@0 ist ungehorsam!",
+		"¡@0 no quiere obedecer!"
+	],
+	"@0 is loafing around!": [
+		"@0は なまけている",
+		"@0 paresse!",
+		"@0 sta ciondolando!",
+		"@0 faulenzt!",
+		"¡@0 está holgazaneando!"
+	],
+	"@0 turned away!": [
+		"@0は　そっぽをむいた！",
+		"@0 tourne le dos!",
+		"@0 ti dà le spalle!",
+		"@0 wendet sich ab!",
+		"¡@0 te da la espalda!"
+	],
+	"@0 pretended not to notice!": [
+		"@0は　しらんぷりした！",
+		"@0 fait semblant de ne rien remarquer!",
+		"@0 fa finta di niente!",
+		"@0 gibt vor, nichts zu bemerken!",
+		"¡@0 se hace el tonto!"
+	],
+	"@0 ignored orders!": [
+		"@0は　めいれいを　むしした！",
+		"@0 ignore les ordres!",
+		"@0 ignora gli ordini!",
+		"@0 ignoriert den Befehl!",
+		"¡@0 ignora las órdenes!"
+	],
+	"@0 began to nap!": [
+		"@0は　ひるねを　はじめた！",
+		"@0 fait la sieste!",
+		"@0 fa un riposino!",
+		"@0 macht ein Nickerchen!",
+		"¡@0 ha decidido echarse una siesta!"
+	],
+	"@0 ignored orders while asleep!": [
+		"@0は　ねむったまま めいれいを　むしした！",
+		"@0 ignore les ordres et dort toujours!",
+		"@0 ignora gli ordini. Sta dormendo!",
+		"@0 ignoriert die Befehle. Es schläft!",
+		"¡@0 ignora las órdenes y sigue durmiendo!"
+	],
+	"Automatic center!": [
+		"リセットムーブ！！",
+		"Réinitialisation!",
+		"Centramento!",
+		"Mittig setzen!",
+		"CENTRANDO POKÉMON"
+	],
+	"But it's not where this item can be used!": [
+		"しかし　この　どうぐを つかえる　ばしょに　いなかった！",
+		"Mais cet objet n'est pas utilisable sur cette cible!",
+		"Ma qui non puoi usare questo strumento!",
+		"Es befindet sich nicht an einer geeigneten Stelle, um dieses Item einzusetzen!",
+		"¡Pero ese objeto no puede usarse con este Pokémon!"
+	],
+	"Sky Drop won't let @0 go!": [
+		"@0は　フリーフォールで じゆうに　ならない！",
+		"@0 est en Chute Libre! Cette action est impossible!",
+		"@0 è intrappolato da Cadutalibera!",
+		"Der Handlungsspielraum von @0 ist aufgrund von Freier Fall eingeschränkt!",
+		"¡@0 está bajo los efectos de Caída Libre! No puede actuar libremente."
+	],
+	"The match was forfeited.": [
+		"こうさんが　えらばれました",
+		"Le combat se termine par un forfait.",
+		"La lotta finisce per abbandono.",
+		"Ein Spieler hat den Kampf aufgegeben.",
+		"El combate ha finalizado por una retirada."
+	],
+	"(@0)'s Metronome @1:@2": [
+		"（@0）のゆびをふる　@1：@2",
+		"Métronome de (@0) @1: @2",
+		"(DEBUG) (@0) Metronomo @1:@2",
+		"(@0) Metronom @1: @2",
+		"Metrónomo de (@0) @1: @2"
+	],
+	"@0 used @1!": [
+		"@0の @1！",
+		"@0 utilise @1!",
+		"@0 usa @1!",
+		"@0 setzt @1 ein!",
+		"¡@0 ha usado @1!"
+	],
+	"The foe's @0 used @1!": [
+		"あいての　@0の @1！",
+		"Le @0 ennemi utilise @1!",
+		"@0 nemico usa @1!",
+		"@0 (Gegner) setzt @1 ein!",
+		"¡El @0 enemigo ha usado @1!"
+	],
+	"@0 fainted!": [
+		"@0は　たおれた！",
+		"@0 est K.O.!",
+		"@0 è esausto!",
+		"@0 wurde besiegt!",
+		"¡@0 se ha debilitado!"
+	],
+	"The foe's @0 fainted!": [
+		"あいての　@0は　たおれた！",
+		"Le @0 ennemi est K.O.!",
+		"@0 nemico è esausto!",
+		"@0 (Gegner) wurde besiegt!",
+		"¡El @0 enemigo se ha debilitado!"
+	],
+	"@0 recovered from fainting!": [
+		"@0は げんきを　とりもどした！",
+		"@0 n'est plus K.O.!",
+		"@0 è ritornato in forze!",
+		"@0 hat sich wieder erholt!",
+		"¡@0 ya no está debilitado!"
+	],
+	"The foe's @0 recovered from fainting!": [
+		"あいての　@0は げんきを　とりもどした！",
+		"Le @0 ennemi n'est plus K.O.!",
+		"@0 nemico è ritornato in forze!",
+		"@0 (Gegner) hat sich wieder erholt!",
+		"¡El @0 enemigo ya no está debilitado!"
+	],
+	"It's super effective on @0!": [
+		"@0に こうかは　ばつぐんだ！",
+		"C'est super efficace sur @0!",
+		"È superefficace su @0!",
+		"Das ist sehr effektiv gegen @0!",
+		"¡Es muy eficaz contra @0!"
+	],
+	"It's super effective on the foe's @0!": [
+		"あいての　@0に こうかは　ばつぐんだ！",
+		"C'est super efficace sur le @0 ennemi!",
+		"È superefficace su @0 nemico!",
+		"Das ist sehr effektiv gegen @0 (Gegner)!",
+		"¡Es muy eficaz contra el @0 enemigo!"
+	],
+	"It's super effective on @0 and @1!": [
+		"@0と　@1に こうかは　ばつぐんだ！",
+		"C'est super efficace sur @0 et @1!",
+		"È superefficace su @0 e @1!",
+		"Das ist sehr effektiv gegen @0 und @1!",
+		"¡Es muy eficaz contra @0 y @1!"
+	],
+	"It's super effective on the foe's @0 and @1!": [
+		"あいての　@0と　@1に こうかは　ばつぐんだ！",
+		"C'est super efficace sur les @0 et @1 ennemis!",
+		"È superefficace su @0 e @1 nemici!",
+		"Das ist sehr effektiv gegen @0 und @1 (Gegner)!",
+		"¡Es muy eficaz contra el @0 y el @1 enemigos!"
+	],
+	"It's super effective on @0, @1, and @2!": [
+		"@0と　@1と @2に　こうかは　ばつぐんだ！",
+		"C'est super efficace sur @0, @1 et @2!",
+		"È superefficace su @0, @1 e @2!",
+		"Das ist sehr effektiv gegen @0, @1 und @2!",
+		"¡Es muy eficaz contra @0, @1 y @2!"
+	],
+	"It's super effective on the foe's @0, @1, and @2!": [
+		"あいての　@0と　@1と @2に　こうかは　ばつぐんだ！",
+		"C'est super efficace sur les @0, @1 et @2 ennemis!",
+		"È superefficace su @0, @1 e @2 nemici!",
+		"Das ist sehr effektiv gegen @0, @1 und @2 (Gegner)!",
+		"¡Es muy eficaz contra el @0, el @1 y el @2 enemigos!"
+	],
+	"It's not very effective on @0.": [
+		"@0に こうかは　いまひとつだ",
+		"Ce n'est pas très efficace sur @0...",
+		"Non è molto efficace su @0...",
+		"Das ist nicht sehr effektiv gegen @0...",
+		"No es muy eficaz contra @0..."
+	],
+	"It's not very effective on the foe's @0.": [
+		"あいての　@0に こうかは　いまひとつだ",
+		"Ce n'est pas très efficace sur le @0 ennemi...",
+		"Non è molto efficace su @0 nemico...",
+		"Das ist nicht sehr effektiv gegen @0 (Gegner)...",
+		"No es muy eficaz contra el @0 enemigo..."
+	],
+	"It's not very effective on @0 or @1.": [
+		"@0と　@1に こうかは　いまひとつだ",
+		"Ce n'est pas très efficace sur @0 ni sur @1...",
+		"Non è molto efficace su @0 e @1...",
+		"Das ist nicht sehr effektiv gegen @0 und @1...",
+		"No es muy eficaz contra @0 ni @1..."
+	],
+	"It's not very effective on the foe's @0 or @1.": [
+		"あいての　@0と　@1に こうかは　いまひとつだ",
+		"Ce n'est pas très efficace sur @0 ni sur @1...",
+		"Non è molto efficace su @0 e @1 nemici...",
+		"Das ist nicht sehr effektiv gegen @0 und @1 (Gegner)...",
+		"No es muy eficaz contra el @0 ni el @1 enemigos..."
+	],
+	"It's not very effective on @0, @1, or @2!": [
+		"@0と　@1と @2に　こうかは　いまひとつだ",
+		"Ce n'est pas très efficace sur @0 ni sur @1, ni sur @2...",
+		"Non è molto efficace su @0, @1 e @2...",
+		"Das ist nicht sehr effektiv gegen @0, @1 und @2...",
+		"No es muy eficaz contra @0, ni @1 ni @2..."
+	],
+	"It's not very effective on the foe's @0, @1, or @2!": [
+		"あいての　@0と　@1と @2に　こうかは　いまひとつだ",
+		"Ce n'est pas très efficace sur @0 ni sur @1, ni sur @2...",
+		"Non è molto efficace su @0, @1 e @2 nemici...",
+		"Das ist nicht sehr effektiv gg. @0, @1 und @2 (Gegner)...",
+		"No es muy eficaz contra el @0, ni el @1 ni el @2 enemigos..."
+	],
+	"But it failed to affect @0!": [
+		"しかし　@0には うまく　きまらなかった！",
+		"Mais cela échoue sur @0!",
+		"Ma fallisce su @0!",
+		"Aber der Einsatz bei @0 schlug fehl!",
+		"Desgraciadamente, no ha logrado impactar en @0..."
+	],
+	"But it failed to affect the foe's @0!": [
+		"しかし　あいての　@0には うまく　きまらなかった！",
+		"Mais cela échoue sur le @0 ennemi!",
+		"Ma fallisce su @0 nemico!",
+		"Aber der Einsatz bei @0 (Gegner) schlug fehl!",
+		"Desgraciadamente, no ha logrado impactar en el @0 enemigo..."
+	],
+	"@0's Attack rose!": [
+		"@0の こうげきが　あがった！",
+		"L'Attaque de @0 augmente!",
+		"L'Attacco di @0 aumenta!",
+		"Angriff von @0 steigt.",
+		"¡El Ataque de @0 ha subido!"
+	],
+	"The foe's @0's Attack rose!": [
+		"あいての　@0の こうげきが　あがった！",
+		"L'Attaque du @0 ennemi augmente!",
+		"L'Attacco di @0 nemico aumenta!",
+		"Angriff von @0 (Gegner) steigt.",
+		"¡El Ataque del @0 enemigo ha subido!"
+	],
+	"@0's Defense rose!": [
+		"@0の ぼうぎょが　あがった！",
+		"La Défense de @0 augmente!",
+		"La Difesa di @0 aumenta!",
+		"Verteidigung von @0 steigt.",
+		"¡La Defensa de @0 ha subido!"
+	],
+	"The foe's @0's Defense rose!": [
+		"あいての　@0の ぼうぎょが　あがった！",
+		"La Défense du @0 ennemi augmente!",
+		"La Difesa di @0 nemico aumenta!",
+		"Verteidigung von @0 (Gegner) steigt.",
+		"¡La Defensa del @0 enemigo ha subido!"
+	],
+	"@0's Special Attack rose!": [
+		"@0の とくこうが　あがった！",
+		"L'Attaque Spéciale de @0 augmente!",
+		"L'Attacco Speciale di @0 aumenta!",
+		"Spezial-Angriff von @0 steigt.",
+		"¡El Ataque Especial de @0 ha subido!"
+	],
+	"The foe's @0's Special Attack rose!": [
+		"あいての　@0の とくこうが　あがった！",
+		"L'Attaque Spéciale du @0 ennemi augmente!",
+		"L'Attacco Speciale di @0 nemico aumenta!",
+		"Spezial-Angriff von @0 (Gegner) steigt.",
+		"¡El Ataque Especial del @0 enemigo ha subido!"
+	],
+	"@0's Special Defense rose!": [
+		"@0の とくぼうが　あがった！",
+		"La Défense Spéciale de @0 augmente!",
+		"La Difesa Speciale di @0 aumenta!",
+		"Spezial-Verteidigung von @0 steigt.",
+		"¡La Defensa Especial de @0 ha subido!"
+	],
+	"The foe's @0's Special Defense rose!": [
+		"あいての　@0の とくぼうが　あがった！",
+		"La Défense Spéciale du @0 ennemi augmente!",
+		"La Difesa Speciale di @0 nemico aumenta!",
+		"Spezial-Verteidigung von @0 (Gegner) steigt.",
+		"¡La Defensa Especial del @0 enemigo ha subido!"
+	],
+	"@0's Speed rose!": [
+		"@0の すばやさが　あがった！",
+		"La Vitesse de @0 augmente!",
+		"La Velocità di @0 aumenta!",
+		"Initiative von @0 steigt.",
+		"¡La Velocidad de @0 ha subido!"
+	],
+	"The foe's @0's Speed rose!": [
+		"あいての　@0の すばやさが　あがった！",
+		"La Vitesse du @0 ennemi augmente!",
+		"La Velocità di @0 nemico aumenta!",
+		"Initiative von @0 (Gegner) steigt.",
+		"¡La Velocidad del @0 enemigo ha subido!"
+	],
+	"@0's accuracy rose!": [
+		"@0の めいちゅうりつが　あがった！",
+		"La Précision de @0 augmente!",
+		"La precisione di @0 aumenta!",
+		"Genauigkeit von @0 steigt.",
+		"¡La Precisión de @0 ha subido!"
+	],
+	"The foe's @0's accuracy rose!": [
+		"あいての　@0の めいちゅうりつが　あがった！",
+		"La Précision du @0 ennemi augmente!",
+		"La precisione di @0 nemico aumenta!",
+		"Genauigkeit von @0 (Gegner) steigt.",
+		"¡La Precisión del @0 enemigo ha subido!"
+	],
+	"@0's evasiveness rose!": [
+		"@0の かいひりつが　あがった！",
+		"L'Esquive de @0 augmente!",
+		"L'elusione di @0 aumenta!",
+		"Fluchtwert von @0 steigt.",
+		"¡La Evasión de @0 ha subido!"
+	],
+	"The foe's @0's evasiveness rose!": [
+		"あいての　@0の かいひりつが　あがった！",
+		"L'Esquive du @0 ennemi augmente!",
+		"L'elusione di @0 nemico aumenta!",
+		"Fluchtwert von @0 (Gegner) steigt.",
+		"¡La Evasión del @0 enemigo ha subido!"
+	],
+	"@0's Attack rose sharply!": [
+		"@0の こうげきが　ぐーんと　あがった！",
+		"L'Attaque de @0 augmente beaucoup!",
+		"L'Attacco di @0 aumenta di molto!",
+		"Angriff von @0 steigt stark!",
+		"¡El Ataque de @0 ha subido mucho!"
+	],
+	"The foe's @0's Attack rose sharply!": [
+		"あいての　@0の こうげきが　ぐーんと　あがった！",
+		"L'Attaque du @0 ennemi augmente beaucoup!",
+		"L'Attacco di @0 nemico aumenta di molto!",
+		"Angriff von @0 (Gegner) steigt stark!",
+		"¡El Ataque del @0 enemigo ha subido mucho!"
+	],
+	"@0's Defense rose sharply!": [
+		"@0の ぼうぎょが　ぐーんと　あがった！",
+		"La Défense de @0 augmente beaucoup!",
+		"La Difesa di @0 aumenta di molto!",
+		"Verteidigung von @0 steigt stark!",
+		"¡La Defensa de @0 ha subido mucho!"
+	],
+	"The foe's @0's Defense rose sharply!": [
+		"あいての　@0の ぼうぎょが　ぐーんと　あがった！",
+		"La Défense du @0 ennemi augmente beaucoup!",
+		"La Difesa di @0 nemico aumenta di molto!",
+		"Verteidigung von @0 (Gegner) steigt stark!",
+		"¡La Defensa del @0 enemigo ha subido mucho!"
+	],
+	"@0's Special Attack rose sharply!": [
+		"@0の とくこうが　ぐーんと　あがった！",
+		"L'Attaque Spéciale de @0 augmente beaucoup!",
+		"L'Attacco Speciale di @0 aumenta di molto!",
+		"Spezial-Angriff von @0 steigt stark!",
+		"¡El Ataque Especial de @0 ha subido mucho!"
+	],
+	"The foe's @0's Special Attack rose sharply!": [
+		"あいての　@0の とくこうが　ぐーんと　あがった！",
+		"L'Attaque Spéciale du @0 ennemi augmente beaucoup!",
+		"L'Attacco Speciale di @0 nemico aumenta di molto!",
+		"Spezial-Angriff von @0 (Gegner) steigt stark!",
+		"¡El Ataque Especial del @0 enemigo ha subido mucho!"
+	],
+	"@0's Special Defense rose sharply!": [
+		"@0の とくぼうが　ぐーんと　あがった！",
+		"La Défense Spéciale de @0 augmente beaucoup!",
+		"La Difesa Speciale di @0 aumenta di molto!",
+		"Spezial-Verteidigung von @0 steigt stark!",
+		"¡La Defensa Especial de @0 ha subido mucho!"
+	],
+	"The foe's @0's Special Defense rose sharply!": [
+		"あいての　@0の とくぼうが　ぐーんと　あがった！",
+		"La Défense Spéciale du @0 ennemi augmente beaucoup!",
+		"La Difesa Speciale di @0 nemico aumenta di molto!",
+		"Spezial-Verteidigung von @0 (Gegner) steigt stark!",
+		"¡La Defensa Especial del @0 enemigo ha subido mucho!"
+	],
+	"@0's Speed rose sharply!": [
+		"@0の すばやさが　ぐーんと　あがった！",
+		"La Vitesse de @0 augmente beaucoup!",
+		"La Velocità di @0 aumenta di molto!",
+		"Initiative von @0 steigt stark!",
+		"¡La Velocidad de @0 ha subido mucho!"
+	],
+	"The foe's @0's Speed rose sharply!": [
+		"あいての　@0の すばやさが　ぐーんと　あがった！",
+		"La Vitesse du @0 ennemi augmente beaucoup!",
+		"La Velocità di @0 nemico aumenta di molto!",
+		"Initiative von @0 (Gegner) steigt stark!",
+		"¡La Velocidad del @0 enemigo ha subido mucho!"
+	],
+	"@0's accuracy rose sharply!": [
+		"@0の めいちゅうりつが　ぐーんと　あがった！",
+		"La Précision de @0 augmente beaucoup!",
+		"La precisione di @0 aumenta di molto!",
+		"Genauigkeit von @0 steigt stark!",
+		"¡La Precisión de @0 ha subido mucho!"
+	],
+	"The foe's @0's accuracy rose sharply!": [
+		"あいての　@0の めいちゅうりつが　ぐーんと　あがった！",
+		"La Précision du @0 ennemi augmente beaucoup!",
+		"La precisione di @0 nemico aumenta di molto!",
+		"Genauigkeit von @0 (Gegner) steigt stark!",
+		"¡La Precisión del @0 enemigo ha subido mucho!"
+	],
+	"@0's evasiveness rose sharply!": [
+		"@0の かいひりつが　ぐーんと　あがった！",
+		"L'Esquive de @0 augmente beaucoup!",
+		"L'elusione di @0 aumenta di molto!",
+		"Fluchtwert von @0 steigt stark!",
+		"¡La Evasión de @0 ha subido mucho!"
+	],
+	"The foe's @0's evasiveness rose sharply!": [
+		"あいての　@0の かいひりつが　ぐーんと　あがった！",
+		"L'Esquive du @0 ennemi augmente beaucoup!",
+		"L'elusione di @0 nemico aumenta di molto!",
+		"Fluchtwert von @0 (Gegner) steigt stark!",
+		"¡La Evasión del @0 enemigo ha subido mucho!"
+	],
+	"@0's Attack rose drastically!": [
+		"@0の こうげきが　ぐぐーんと　あがった！",
+		"L'Attaque de @0 augmente énormément!",
+		"L'Attacco di @0 aumenta moltissimo!",
+		"Angriff von @0 steigt drastisch!",
+		"¡El Ataque de @0 ha subido muchísimo!"
+	],
+	"The foe's @0's Attack rose drastically!": [
+		"あいての　@0の こうげきが　ぐぐーんと　あがった！",
+		"L'Attaque du @0 ennemi augmente énormément!",
+		"L'Attacco di @0 nemico aumenta moltissimo!",
+		"Angriff von @0 (Gegner) steigt drastisch!",
+		"¡El Ataque del @0 enemigo ha subido muchísimo!"
+	],
+	"@0's Defense rose drastically!": [
+		"@0の ぼうぎょが　ぐぐーんと　あがった！",
+		"La Défense de @0 augmente énormément!",
+		"La Difesa di @0 aumenta moltissimo!",
+		"Verteidigung von @0 steigt drastisch!",
+		"¡La Defensa de @0 ha subido muchísimo!"
+	],
+	"The foe's @0's Defense rose drastically!": [
+		"あいての　@0の ぼうぎょが　ぐぐーんと　あがった！",
+		"La Défense du @0 ennemi augmente énormément!",
+		"La Difesa di @0 nemico aumenta moltissimo!",
+		"Verteidigung von @0 (Gegner) steigt drastisch!",
+		"¡La Defensa del @0 enemigo ha subido muchísimo!"
+	],
+	"@0's Special Attack rose drastically!": [
+		"@0の とくこうが　ぐぐーんと　あがった！",
+		"L'Attaque Spéciale de @0 augmente énormément!",
+		"L'Attacco Speciale di @0 aumenta moltissimo!",
+		"Spezial-Angriff von @0 steigt drastisch!",
+		"¡El Ataque Especial de @0 ha subido muchísimo!"
+	],
+	"The foe's @0's Special Attack rose drastically!": [
+		"あいての　@0の とくこうが　ぐぐーんと　あがった！",
+		"L'Attaque Spéciale du @0 ennemi augmente énormément!",
+		"L'Attacco Speciale di @0 nemico aumenta moltissimo!",
+		"Spezial-Angriff von @0 (Gegner) steigt drastisch!",
+		"¡El Ataque Especial del @0 enemigo ha subido muchísimo!"
+	],
+	"@0's Special Defense rose drastically!": [
+		"@0の とくぼうが　ぐぐーんと　あがった！",
+		"La Défense Spéciale de @0 augmente énormément!",
+		"La Difesa Speciale di @0 aumenta moltissimo!",
+		"Spezial-Verteidigung von @0 steigt drastisch!",
+		"¡La Defensa Especial de @0 ha subido muchísimo!"
+	],
+	"The foe's @0's Special Defense rose drastically!": [
+		"あいての　@0の とくぼうが　ぐぐーんと　あがった！",
+		"La Défense Spéciale du @0 ennemi augmente énormément!",
+		"La Difesa Speciale di @0 nemico aumenta moltissimo!",
+		"Spezial-Verteidigung von @0 (Gegner) steigt drastisch!",
+		"¡La Defensa Especial del @0 enemigo ha subido muchísimo!"
+	],
+	"@0's Speed rose drastically!": [
+		"@0の すばやさが　ぐぐーんと　あがった！",
+		"La Vitesse de @0 augmente énormément!",
+		"La Velocità di @0 aumenta moltissimo!",
+		"Initiative von @0 steigt drastisch!",
+		"¡La Velocidad de @0 ha subido muchísimo!"
+	],
+	"The foe's @0's Speed rose drastically!": [
+		"あいての　@0の すばやさが　ぐぐーんと　あがった！",
+		"La Vitesse du @0 ennemi augmente énormément!",
+		"La Velocità di @0 nemico aumenta moltissimo!",
+		"Initiative von @0 (Gegner) steigt drastisch!",
+		"¡La Velocidad del @0 enemigo ha subido muchísimo!"
+	],
+	"@0's accuracy rose drastically!": [
+		"@0の めいちゅうりつが　ぐぐーんと　あがった！",
+		"La Précision de @0 augmente énormément!",
+		"La precisione di @0 aumenta moltissimo!",
+		"Genauigkeit von @0 steigt drastisch!",
+		"¡La Precisión de @0 ha subido muchísimo!"
+	],
+	"The foe's @0's accuracy rose drastically!": [
+		"あいての　@0の めいちゅうりつが　ぐぐーんと　あがった！",
+		"La Précision du @0 ennemi augmente énormément!",
+		"La precisione di @0 nemico aumenta moltissimo!",
+		"Genauigkeit von @0 (Gegner) steigt drastisch!",
+		"¡La Precisión del @0 enemigo ha subido muchísimo!"
+	],
+	"@0's evasiveness rose drastically!": [
+		"@0の かいひりつが　ぐぐーんと　あがった！",
+		"L'Esquive de @0 augmente énormément!",
+		"L'elusione di @0 aumenta moltissimo!",
+		"Fluchtwert von @0 steigt drastisch!",
+		"¡La Evasión de @0 ha subido muchísimo!"
+	],
+	"The foe's @0's evasiveness rose drastically!": [
+		"あいての　@0の かいひりつが　ぐぐーんと　あがった！",
+		"L'Esquive du @0 ennemi augmente énormément!",
+		"L'elusione di @0 nemico aumenta moltissimo!",
+		"Fluchtwert von @0 (Gegner) steigt drastisch!",
+		"¡La Evasión del @0 enemigo ha subido muchísimo!"
+	],
+	"@0's Attack fell!": [
+		"@0の こうげきが　さがった！",
+		"L'Attaque de @0 baisse!",
+		"L'Attacco di @0 diminuisce!",
+		"Angriff von @0 sinkt.",
+		"¡El Ataque de @0 ha bajado!"
+	],
+	"The foe's @0's Attack fell!": [
+		"あいての　@0の こうげきが　さがった！",
+		"L'Attaque du @0 ennemi baisse!",
+		"L'Attacco di @0 nemico diminuisce!",
+		"Angriff von @0 (Gegner) sinkt.",
+		"¡El Ataque del @0 enemigo ha bajado!"
+	],
+	"@0's Defense fell!": [
+		"@0の ぼうぎょが　さがった！",
+		"La Défense de @0 baisse!",
+		"La Difesa di @0 diminuisce!",
+		"Verteidigung von @0 sinkt.",
+		"¡La Defensa de @0 ha bajado!"
+	],
+	"The foe's @0's Defense fell!": [
+		"あいての　@0の ぼうぎょが　さがった！",
+		"La Défense du @0 ennemi baisse!",
+		"La Difesa di @0 nemico diminuisce!",
+		"Verteidigung von @0 (Gegner) sinkt.",
+		"¡La Defensa del @0 enemigo ha bajado!"
+	],
+	"@0's Special Attack fell!": [
+		"@0の とくこうが　さがった！",
+		"L'Attaque Spéciale de @0 baisse!",
+		"L'Attacco Speciale di @0 diminuisce!",
+		"Spezial-Angriff von @0 sinkt.",
+		"¡El Ataque Especial de @0 ha bajado!"
+	],
+	"The foe's @0's Special Attack fell!": [
+		"あいての　@0の とくこうが　さがった！",
+		"L'Attaque Spéciale du @0 ennemi baisse!",
+		"L'Attacco Speciale di @0 nemico diminuisce!",
+		"Spezial-Angriff von @0 (Gegner) sinkt.",
+		"¡El Ataque Especial del @0 enemigo ha bajado!"
+	],
+	"@0's Special Defense fell!": [
+		"@0の とくぼうが　さがった！",
+		"La Défense Spéciale de @0 baisse!",
+		"La Difesa Speciale di @0 diminuisce!",
+		"Spezial-Verteidigung von @0 sinkt.",
+		"¡La Defensa Especial de @0 ha bajado!"
+	],
+	"The foe's @0's Special Defense fell!": [
+		"あいての　@0の とくぼうが　さがった！",
+		"La Défense Spéciale du @0 ennemi baisse!",
+		"La Difesa Speciale di @0 nemico diminuisce!",
+		"Spezial-Verteidigung von @0 (Gegner) sinkt.",
+		"¡La Defensa Especial del @0 enemigo ha bajado!"
+	],
+	"@0's Speed fell!": [
+		"@0の すばやさが　さがった！",
+		"La Vitesse de @0 baisse!",
+		"La Velocità di @0 diminuisce!",
+		"Initiative von @0 sinkt.",
+		"¡La Velocidad de @0 ha bajado!"
+	],
+	"The foe's @0's Speed fell!": [
+		"あいての　@0の すばやさが　さがった！",
+		"La Vitesse du @0 ennemi baisse!",
+		"La Velocità di @0 nemico diminuisce!",
+		"Initiative von @0 (Gegner) sinkt.",
+		"¡La Velocidad del @0 enemigo ha bajado!"
+	],
+	"@0's accuracy fell!": [
+		"@0の めいちゅうりつが　さがった！",
+		"La Précision de @0 baisse!",
+		"La precisione di @0 diminuisce!",
+		"Genauigkeit von @0 sinkt.",
+		"¡La Precisión de @0 ha bajado!"
+	],
+	"The foe's @0's accuracy fell!": [
+		"あいての　@0の めいちゅうりつが　さがった！",
+		"La Précision du @0 ennemi baisse!",
+		"La precisione di @0 nemico diminuisce!",
+		"Genauigkeit von @0 (Gegner) sinkt.",
+		"¡La Precisión del @0 enemigo ha bajado!"
+	],
+	"@0's evasiveness fell!": [
+		"@0の かいひりつが　さがった！",
+		"L'Esquive de @0 baisse!",
+		"L'elusione di @0 diminuisce!",
+		"Fluchtwert von @0 sinkt.",
+		"¡La Evasión de @0 ha bajado!"
+	],
+	"The foe's @0's evasiveness fell!": [
+		"あいての　@0の かいひりつが　さがった！",
+		"L'Esquive du @0 ennemi baisse!",
+		"L'elusione di @0 nemico diminuisce!",
+		"Fluchtwert von @0 (Gegner) sinkt.",
+		"¡La Evasión del @0 enemigo ha bajado!"
+	],
+	"@0's Attack harshly fell!": [
+		"@0の こうげきが　がくっと　さがった！",
+		"L'Attaque de @0 baisse beaucoup!",
+		"L'Attacco di @0 diminuisce di molto!",
+		"Angriff von @0 sinkt stark!",
+		"¡El Ataque de @0 ha bajado mucho!"
+	],
+	"The foe's @0's Attack harshly fell!": [
+		"あいての　@0の こうげきが　がくっと　さがった！",
+		"L'Attaque du @0 ennemi baisse beaucoup!",
+		"L'Attacco di @0 nemico diminuisce di molto!",
+		"Angriff von @0 (Gegner) sinkt stark!",
+		"¡El Ataque del @0 enemigo ha bajado mucho!"
+	],
+	"@0's Defense harshly fell!": [
+		"@0の ぼうぎょが　がくっと　さがった！",
+		"La Défense de @0 baisse beaucoup!",
+		"La Difesa di @0 diminuisce di molto!",
+		"Verteidigung von @0 sinkt stark!",
+		"¡La Defensa de @0 ha bajado mucho!"
+	],
+	"The foe's @0's Defense harshly fell!": [
+		"あいての　@0の ぼうぎょが　がくっと　さがった！",
+		"La Défense du @0 ennemi baisse beaucoup!",
+		"La Difesa di @0 nemico diminuisce di molto!",
+		"Verteidigung von @0 (Gegner) sinkt stark!",
+		"¡La Defensa del @0 enemigo ha bajado mucho!"
+	],
+	"@0's Special Attack harshly fell!": [
+		"@0の とくこうが　がくっと　さがった！",
+		"L'Attaque Spéciale de @0 baisse beaucoup!",
+		"L'Attacco Speciale di @0 diminuisce di molto!",
+		"Spezial-Angriff von @0 sinkt stark!",
+		"¡El Ataque Especial de @0 ha bajado mucho!"
+	],
+	"The foe's @0's Special Attack harshly fell!": [
+		"あいての　@0の とくこうが　がくっと　さがった！",
+		"L'Attaque Spéciale du @0 ennemi baisse beaucoup!",
+		"L'Attacco Speciale di @0 nemico diminuisce di molto!",
+		"Spezial-Angriff von @0 (Gegner) sinkt stark!",
+		"¡El Ataque Especial del @0 enemigo ha bajado mucho!"
+	],
+	"@0's Special Defense harshly fell!": [
+		"@0の とくぼうが　がくっと　さがった！",
+		"La Défense Spéciale de @0 baisse beaucoup!",
+		"La Difesa Speciale di @0 diminuisce di molto!",
+		"Spezial-Verteidigung von @0 sinkt stark!",
+		"¡La Defensa Especial de @0 ha bajado mucho!"
+	],
+	"The foe's @0's Special Defense harshly fell!": [
+		"あいての　@0の とくぼうが　がくっと　さがった！",
+		"La Défense Spéciale du @0 ennemi baisse beaucoup!",
+		"La Difesa Speciale di @0 nemico diminuisce di molto!",
+		"Spezial-Verteidigung von @0 (Gegner) sinkt stark!",
+		"¡La Defensa Especial del @0 enemigo ha bajado mucho!"
+	],
+	"@0's Speed harshly fell!": [
+		"@0の すばやさが　がくっと　さがった！",
+		"La Vitesse de @0 baisse beaucoup!",
+		"La Velocità di @0 diminuisce di molto!",
+		"Initiative von @0 sinkt stark!",
+		"¡La Velocidad de @0 ha bajado mucho!"
+	],
+	"The foe's @0's Speed harshly fell!": [
+		"あいての　@0の すばやさが　がくっと　さがった！",
+		"La Vitesse du @0 ennemi baisse beaucoup!",
+		"La Velocità di @0 nemico diminuisce di molto!",
+		"Initiative von @0 (Gegner) sinkt stark!",
+		"¡La Velocidad del @0 enemigo ha bajado mucho!"
+	],
+	"@0's accuracy harshly fell!": [
+		"@0の めいちゅうりつが　がくっと　さがった！",
+		"La Précision de @0 baisse beaucoup!",
+		"La precisione di @0 diminuisce di molto!",
+		"Genauigkeit von @0 sinkt stark!",
+		"¡La Precisión de @0 ha bajado mucho!"
+	],
+	"The foe's @0's accuracy harshly fell!": [
+		"あいての　@0の めいちゅうりつが　がくっと　さがった！",
+		"La Précision du @0 ennemi baisse beaucoup!",
+		"La precisione di @0 nemico diminuisce di molto!",
+		"Genauigkeit von @0 (Gegner) sinkt stark!",
+		"¡La Precisión del @0 enemigo ha bajado mucho!"
+	],
+	"@0's evasiveness harshly fell!": [
+		"@0の かいひりつが　がくっと　さがった！",
+		"L'Esquive de @0 baisse beaucoup!",
+		"L'elusione di @0 diminuisce di molto!",
+		"Fluchtwert von @0 sinkt stark!",
+		"¡La Evasión de @0 ha bajado mucho!"
+	],
+	"The foe's @0's evasiveness harshly fell!": [
+		"あいての　@0の かいひりつが　がくっと　さがった！",
+		"L'Esquive du @0 ennemi baisse beaucoup!",
+		"L'elusione di @0 nemico diminuisce di molto!",
+		"Fluchtwert von @0 (Gegner) sinkt stark!",
+		"¡La Evasión del @0 enemigo ha bajado mucho!"
+	],
+	"@0's Attack severely fell!": [
+		"@0の こうげきが　がくーんと　さがった！",
+		"L'Attaque de @0 baisse énormément!",
+		"L'Attacco di @0 cala a picco!",
+		"Angriff von @0 sinkt drastisch!",
+		"¡El Ataque de @0 ha bajado muchísimo!"
+	],
+	"The foe's @0's Attack severely fell!": [
+		"あいての　@0の こうげきが　がくーんと　さがった！",
+		"L'Attaque du @0 ennemi baisse énormément!",
+		"L'Attacco di @0 nemico cala a picco!",
+		"Angriff von @0 (Gegner) sinkt drastisch!",
+		"¡El Ataque del @0 enemigo ha bajado muchísimo!"
+	],
+	"@0's Defense severely fell!": [
+		"@0の ぼうぎょが　がくーんと　さがった！",
+		"La Défense de @0 baisse énormément!",
+		"La Difesa di @0 cala a picco!",
+		"Verteidigung von @0 sinkt drastisch!",
+		"¡La Defensa de @0 ha bajado muchísimo!"
+	],
+	"The foe's @0's Defense severely fell!": [
+		"あいての　@0の ぼうぎょが　がくーんと　さがった！",
+		"La Défense du @0 ennemi baisse énormément!",
+		"La Difesa di @0 nemico cala a picco!",
+		"Verteidigung von @0 (Gegner) sinkt drastisch!",
+		"¡La Defensa del @0 enemigo ha bajado muchísimo!"
+	],
+	"@0's Special Attack severely fell!": [
+		"@0の とくこうが　がくーんと　さがった！",
+		"L'Attaque Spéciale de @0 baisse énormément!",
+		"L'Attacco Speciale di @0 cala a picco!",
+		"Spezial-Angriff von @0 sinkt drastisch!",
+		"¡El Ataque Especial de @0 ha bajado muchísimo!"
+	],
+	"The foe's @0's Special Attack severely fell!": [
+		"あいての　@0の とくこうが　がくーんと　さがった！",
+		"L'Attaque Spéciale du @0 ennemi baisse énormément!",
+		"L'Attacco Speciale di @0 nemico cala a picco!",
+		"Spezial-Angriff von @0 (Gegner) sinkt drastisch!",
+		"¡El Ataque Especial del @0 enemigo ha bajado muchísimo!"
+	],
+	"@0's Special Defense severely fell!": [
+		"@0の とくぼうが　がくーんと　さがった！",
+		"La Défense Spéciale de @0 baisse énormément!",
+		"La Difesa Speciale di @0 cala a picco!",
+		"Spezial-Verteidigung von @0 sinkt drastisch!",
+		"¡La Defensa Especial de @0 ha bajado muchísimo!"
+	],
+	"The foe's @0's Special Defense severely fell!": [
+		"あいての　@0の とくぼうが　がくーんと　さがった！",
+		"La Défense Spéciale du @0 ennemi baisse énormément!",
+		"La Difesa Speciale di @0 nemico cala a picco!",
+		"Spezial-Verteidigung von @0 (Gegner) sinkt drastisch!",
+		"¡La Defensa Especial del @0 enemigo ha bajado muchísimo!"
+	],
+	"@0's Speed severely fell!": [
+		"@0の すばやさが　がくーんと　さがった！",
+		"La Vitesse de @0 baisse énormément!",
+		"La Velocità di @0 cala a picco!",
+		"Initiative von @0 sinkt drastisch!",
+		"¡La Velocidad de @0 ha bajado muchísimo!"
+	],
+	"The foe's @0's Speed severely fell!": [
+		"あいての　@0の すばやさが　がくーんと　さがった！",
+		"La Vitesse du @0 ennemi baisse énormément!",
+		"La Velocità di @0 nemico cala a picco!",
+		"Initiative von @0 (Gegner) sinkt drastisch!",
+		"¡La Velocidad del @0 enemigo ha bajado muchísimo!"
+	],
+	"@0's accuracy severely fell!": [
+		"@0の めいちゅうりつが　がくーんと　さがった！",
+		"La Précision de @0 baisse énormément!",
+		"La precisione di @0 cala a picco!",
+		"Genauigkeit von @0 sinkt drastisch!",
+		"¡La Precisión de @0 ha bajado muchísimo!"
+	],
+	"The foe's @0's accuracy severely fell!": [
+		"あいての　@0の めいちゅうりつが　がくーんと　さがった！",
+		"La Précision du @0 ennemi baisse énormément!",
+		"La precisione di @0 nemico cala a picco!",
+		"Genauigkeit von @0 (Gegner) sinkt drastisch!",
+		"¡La Precisión del @0 enemigo ha bajado muchísimo!"
+	],
+	"@0's evasiveness severely fell!": [
+		"@0の かいひりつが　がくーんと　さがった！",
+		"L'Esquive de @0 baisse énormément!",
+		"L'elusione di @0 cala a picco!",
+		"Fluchtwert von @0 sinkt drastisch!",
+		"¡La Evasión de @0 ha bajado muchísimo!"
+	],
+	"The foe's @0's evasiveness severely fell!": [
+		"あいての　@0の かいひりつが　がくーんと　さがった！",
+		"L'Esquive du @0 ennemi baisse énormément!",
+		"L'elusione di @0 nemico cala a picco!",
+		"Fluchtwert von @0 (Gegner) sinkt drastisch!",
+		"¡La Evasión del @0 enemigo ha bajado muchísimo!"
+	],
+	"@0's Attack won't go any higher!": [
+		"@0の こうげきは　もう　あがらない！",
+		"L'Attaque de @0 ne peut plus augmenter!",
+		"L'Attacco di @0 non può aumentare di più!",
+		"Angriff von @0 kann nicht weiter erhöht werden!",
+		"¡El Ataque de @0 no puede subir más!"
+	],
+	"The foe's @0's Attack won't go any higher!": [
+		"あいての　@0の こうげきは　もう　あがらない！",
+		"L'Attaque du @0 ennemi ne peut plus augmenter!",
+		"L'Attacco di @0 nemico non può aumentare di più!",
+		"Angriff von @0 (Gegner) kann nicht weiter erhöht werden!",
+		"¡El Ataque del @0 enemigo no puede subir más!"
+	],
+	"@0's Defense won't go any higher!": [
+		"@0の ぼうぎょは　もう　あがらない！",
+		"La Défense de @0 ne peut plus augmenter!",
+		"La Difesa di @0 non può aumentare di più!",
+		"Verteidigung von @0 kann nicht weiter erhöht werden!",
+		"¡La Defensa de @0 no puede subir más!"
+	],
+	"The foe's @0's Defense won't go any higher!": [
+		"あいての　@0の ぼうぎょは　もう　あがらない！",
+		"La Défense du @0 ennemi ne peut plus augmenter!",
+		"La Difesa di @0 nemico non può aumentare di più!",
+		"Verteidigung von @0 (Gegner) kann nicht weiter erhöht werden!",
+		"¡La Defensa del @0 enemigo no puede subir más!"
+	],
+	"@0's Special Attack won't go any higher!": [
+		"@0の とくこうは　もう　あがらない！",
+		"L'Attaque Spéciale de @0 ne peut plus augmenter!",
+		"L'Attacco Speciale di @0 non può aumentare di più!",
+		"Spezial-Angriff von @0 kann nicht weiter erhöht werden!",
+		"¡El Ataque Especial de @0 no puede subir más!"
+	],
+	"The foe's @0's Special Attack won't go any higher!": [
+		"あいての　@0の とくこうは　もう　あがらない！",
+		"L'Attaque Spéciale du @0 ennemi ne peut plus augmenter!",
+		"L'Attacco Speciale di @0 nemico non può aumentare di più!",
+		"Spezial-Angriff von @0 (Gegner) kann nicht weiter erhöht werden!",
+		"¡El Ataque Especial del @0 enemigo no puede subir más!"
+	],
+	"@0's Special Defense won't go any higher!": [
+		"@0の とくぼうは　もう　あがらない！",
+		"La Défense Spéciale de @0 ne peut plus augmenter!",
+		"La Difesa Speciale di @0 non può aumentare di più!",
+		"Spezial-Verteidigung von @0 kann nicht weiter erhöht werden!",
+		"¡La Defensa Especial de @0 no puede subir más!"
+	],
+	"The foe's @0's Special Defense won't go any higher!": [
+		"あいての　@0の とくぼうは　もう　あがらない！",
+		"La Défense Spéciale du @0 ennemi ne peut plus augmenter!",
+		"La Difesa Speciale di @0 nemico non può aumentare di più!",
+		"Spezial-Verteidigung v. @0 (Gegner) kann nicht weiter erhöht werden!",
+		"¡La Defensa Especial del @0 enemigo no puede subir más!"
+	],
+	"@0's Speed won't go any higher!": [
+		"@0の すばやさは　もう　あがらない！",
+		"La Vitesse de @0 ne peut plus augmenter!",
+		"La Velocità di @0 non può aumentare di più!",
+		"Initiative von @0 kann nicht weiter erhöht werden!",
+		"¡La Velocidad de @0 no puede subir más!"
+	],
+	"The foe's @0's Speed won't go any higher!": [
+		"あいての　@0の すばやさは　もう　あがらない！",
+		"La Vitesse du @0 ennemi ne peut plus augmenter!",
+		"La Velocità di @0 nemico non può aumentare di più!",
+		"Initiative von @0 (Gegner) kann nicht weiter erhöht werden!",
+		"¡La Velocidad del @0 enemigo no puede subir más!"
+	],
+	"@0's accuracy won't go any higher!": [
+		"@0の めいちゅうりつは　もう　あがらない！",
+		"La Précision de @0 ne peut plus augmenter!",
+		"La precisione di @0 non può aumentare di più!",
+		"Genauigkeit von @0 kann nicht weiter erhöht werden!",
+		"¡La Precisión de @0 no puede subir más!"
+	],
+	"The foe's @0's accuracy won't go any higher!": [
+		"あいての　@0の めいちゅうりつは　もう　あがらない！",
+		"La Précision du @0 ennemi ne peut plus augmenter!",
+		"La precisione di @0 nemico non può aumentare di più!",
+		"Genauigkeit von @0 (Gegner) kann nicht weiter erhöht werden!",
+		"¡La Precisión del @0 enemigo no puede subir más!"
+	],
+	"@0's evasiveness won't go any higher!": [
+		"@0の かいひりつは　もう　あがらない！",
+		"L'Esquive de @0 ne peut plus augmenter!",
+		"L'elusione di @0 non può aumentare di più!",
+		"Fluchtwert von @0 kann nicht weiter erhöht werden!",
+		"¡La Evasión de @0 no puede subir más!"
+	],
+	"The foe's @0's evasiveness won't go any higher!": [
+		"あいての　@0の かいひりつは　もう　あがらない！",
+		"L'Esquive du @0 ennemi ne peut plus augmenter!",
+		"L'elusione di @0 nemico non può aumentare di più!",
+		"Fluchtwert von @0 (Gegner) kann nicht weiter erhöht werden!",
+		"¡La Evasión del @0 enemigo no puede subir más!"
+	],
+	"@0's Attack won't go any lower!": [
+		"@0の こうげきは　もう　さがらない！",
+		"L'Attaque de @0 ne peut plus baisser!",
+		"L'Attacco di @0 non può diminuire di più!",
+		"Angriff von @0 kann nicht weiter sinken!",
+		"¡El Ataque de @0 no puede bajar más!"
+	],
+	"The foe's @0's Attack won't go any lower!": [
+		"あいての　@0の こうげきは　もう　さがらない！",
+		"L'Attaque du @0 ennemi ne peut plus baisser!",
+		"L'Attacco di @0 nemico non può diminuire di più!",
+		"Angriff von @0 (Gegner) kann nicht weiter sinken!",
+		"¡El Ataque del @0 enemigo no puede bajar más!"
+	],
+	"@0's Defense won't go any lower!": [
+		"@0の ぼうぎょは　もう　さがらない！",
+		"La Défense de @0 ne peut plus baisser!",
+		"La Difesa di @0 non può diminuire di più!",
+		"Verteidigung von @0 kann nicht weiter sinken!",
+		"¡La Defensa de @0 no puede bajar más!"
+	],
+	"The foe's @0's Defense won't go any lower!": [
+		"あいての　@0の ぼうぎょは　もう　さがらない！",
+		"La Défense du @0 ennemi ne peut plus baisser!",
+		"La Difesa di @0 nemico non può diminuire di più!",
+		"Verteidigung von @0 (Gegner) kann nicht weiter sinken!",
+		"¡La Defensa del @0 enemigo no puede bajar más!"
+	],
+	"@0's Special Attack won't go any lower!": [
+		"@0の とくこうは　もう　さがらない！",
+		"L'Attaque Spéciale de @0 ne peut plus baisser!",
+		"L'Attacco Speciale di @0 non può diminuire di più!",
+		"Spezial-Angriff von @0 kann nicht weiter sinken!",
+		"¡El Ataque Especial de @0 no puede bajar más!"
+	],
+	"The foe's @0's Special Attack won't go any lower!": [
+		"あいての　@0の とくこうは　もう　さがらない！",
+		"L'Attaque Spéciale du @0 ennemi ne peut plus baisser!",
+		"L'Attacco Speciale di @0 nemico non può diminuire di più!",
+		"Spezial-Angriff von @0 (Gegner) kann nicht weiter sinken!",
+		"¡El Ataque Especial del @0 enemigo no puede bajar más!"
+	],
+	"@0's Special Defense won't go any lower!": [
+		"@0の とくぼうは　もう　さがらない！",
+		"La Défense Spéciale de @0 ne peut plus baisser!",
+		"La Difesa Speciale di @0 non può diminuire di più!",
+		"Spezial-Verteidigung von @0 kann nicht weiter sinken!",
+		"¡La Defensa Especial de @0 no puede bajar más!"
+	],
+	"The foe's @0's Special Defense won't go any lower!": [
+		"あいての　@0の とくぼうは　もう　さがらない！",
+		"La Défense Spéciale du @0 ennemi ne peut plus baisser!",
+		"La Difesa Speciale di @0 nemico non può diminuire di più!",
+		"Spezial-Verteidigung v. @0 (Gegner) kann nicht weiter sinken!",
+		"¡La Defensa Especial del @0 enemigo no puede bajar más!"
+	],
+	"@0's Speed won't go any lower!": [
+		"@0の すばやさは　もう　さがらない！",
+		"La Vitesse de @0 ne peut plus baisser!",
+		"La Velocità di @0 non può diminuire di più!",
+		"Initiative von @0 kann nicht weiter sinken!",
+		"¡La Velocidad de @0 no puede bajar más!"
+	],
+	"The foe's @0's Speed won't go any lower!": [
+		"あいての　@0の すばやさは　もう　さがらない！",
+		"La Vitesse du @0 ennemi ne peut plus baisser!",
+		"La Velocità di @0 nemico non può diminuire di più!",
+		"Initiative von @0 (Gegner) kann nicht weiter sinken!",
+		"¡La Velocidad del @0 enemigo no puede bajar más!"
+	],
+	"@0's accuracy won't go any lower!": [
+		"@0の めいちゅうりつは　もう　さがらない！",
+		"La Précision de @0 ne peut plus baisser!",
+		"La precisione di @0 non può diminuire di più!",
+		"Genauigkeit von @0 kann nicht weiter sinken!",
+		"¡La Precisión de @0 no puede bajar más!"
+	],
+	"The foe's @0's accuracy won't go any lower!": [
+		"あいての　@0の めいちゅうりつは　もう　さがらない！",
+		"La Précision du @0 ennemi ne peut plus baisser!",
+		"La precisione di @0 nemico non può diminuire di più!",
+		"Genauigkeit von @0 (Gegner) kann nicht weiter sinken!",
+		"¡La Precisión del @0 enemigo no puede bajar más!"
+	],
+	"@0's evasiveness won't go any lower!": [
+		"@0の かいひりつは　もう　さがらない！",
+		"L'Esquive de @0 ne peut plus baisser!",
+		"L'elusione di @0 non può diminuire di più!",
+		"Fluchtwert von @0 kann nicht weiter sinken!",
+		"¡La Evasión de @0 no puede bajar más!"
+	],
+	"The foe's @0's evasiveness won't go any lower!": [
+		"あいての　@0の かいひりつは　もう　さがらない！",
+		"L'Esquive du @0 ennemi ne peut plus baisser!",
+		"L'elusione di @0 nemico non può diminuire di più!",
+		"Fluchtwert von @0 (Gegner) kann nicht weiter sinken!",
+		"¡La Evasión del @0 enemigo no puede bajar más!"
+	],
+	"@0's stat changes were removed!": [
+		"@0の のうりょくへんかが　もとにもどった！",
+		"Les stats de @0 sont revenues à la normale!",
+		"Le statistiche di @0 tornano alla normalità!",
+		"Statusveränderungen von @0 wurden aufgehoben!",
+		"¡Las características de @0 han vuelto a sus valores originales!"
+	],
+	"The foe's @0's stat changes were removed!": [
+		"あいての　@0の のうりょくへんかが　もとにもどった！",
+		"Les stats du @0 ennemi sont revenues à la normale!",
+		"Le statistiche di @0 nemico tornano alla normalità!",
+		"Statusveränderungen von @0 (Gegner) wurden aufgehoben!",
+		"¡Las características del @0 enemigo han vuelto a sus valores originales!"
+	],
+	"@0's stats were not lowered!": [
+		"@0の のうりょくは　さがらない！",
+		"Les stats de @0 ne baissent pas!",
+		"La diminuzione delle statistiche di @0 è stata evitata!",
+		"Status von @0 sinkt nicht!",
+		"¡Las características de @0 no bajan!"
+	],
+	"The foe's @0's stats were not lowered!": [
+		"あいての　@0の のうりょくは　さがらない！",
+		"Les stats du @0 ennemi ne baissent pas!",
+		"La diminuzione delle statistiche di @0 nemico è stata evitata!",
+		"Status von @0 (Gegner) sinkt nicht!",
+		"¡Las características del @0 enemigo no bajan!"
+	],
+	"@0's Attack was not lowered!": [
+		"@0の こうげきは　さがらない！",
+		"L'Attaque de @0 ne baisse pas!",
+		"La diminuzione dell'Attacco di @0 è stata evitata!",
+		"Angriff von @0 sinkt nicht!",
+		"¡El Ataque de @0 no baja!"
+	],
+	"The foe's @0's Attack was not lowered!": [
+		"あいての　@0の こうげきは　さがらない！",
+		"L'Attaque du @0 ennemi ne baisse pas!",
+		"La diminuzione dell'Attacco di @0 nemico è stata evitata!",
+		"Angriff von @0 (Gegner) sinkt nicht!",
+		"¡El Ataque del @0 enemigo no baja!"
+	],
+	"@0's Defense was not lowered!": [
+		"@0の ぼうぎょは　さがらない！",
+		"La Défense de @0 ne baisse pas!",
+		"La diminuzione della Difesa di @0 è stata evitata!",
+		"Verteidigung von @0 sinkt nicht!",
+		"¡La Defensa de @0 no baja!"
+	],
+	"The foe's @0's Defense was not lowered!": [
+		"あいての　@0の ぼうぎょは　さがらない！",
+		"La Défense du @0 ennemi ne baisse pas!",
+		"La diminuzione della Difesa di @0 nemico è stata evitata!",
+		"Verteidigung von @0 (Gegner) sinkt nicht!",
+		"¡La Defensa del @0 enemigo no baja!"
+	],
+	"@0's accuracy was not lowered!": [
+		"@0の めいちゅうりつは　さがらない！",
+		"La Précision de @0 ne baisse pas!",
+		"La diminuzione della precisione di @0 è stata evitata!",
+		"Genauigkeit von @0 sinkt nicht!",
+		"¡La Precisión de @0 no baja!"
+	],
+	"The foe's @0's accuracy was not lowered!": [
+		"あいての　@0の めいちゅうりつは　さがらない！",
+		"La Précision du @0 ennemi ne baisse pas!",
+		"La diminuzione della precisione di @0 nemico è stata evitata!",
+		"Genauigkeit von @0 (Gegner) sinkt nicht!",
+		"¡La Precisión del @0 enemigo no baja!"
+	],
+	"It doesn't affect @0...": [
+		"@0には こうかが　ない　ようだ…",
+		"Ça n'affecte pas @0...",
+		"Non ha effetto su @0...",
+		"Es hat keine Wirkung auf @0...",
+		"No afecta a @0..."
+	],
+	"It doesn't affect the foe's @0...": [
+		"あいての　@0には こうかが　ない　ようだ…",
+		"Ça n'affecte pas le @0 ennemi...",
+		"Non ha effetto su @0 nemico...",
+		"Es hat keine Wirkung auf @0 (Gegner)...",
+		"No afecta al @0 enemigo..."
+	],
+	"@0 avoided the attack!": [
+		"@0には あたらなかった！",
+		"@0 évite l'attaque!",
+		"@0 evita l'attacco!",
+		"@0 wehrt die Attacke ab!",
+		"¡@0 ha evitado el ataque!"
+	],
+	"The foe's @0 avoided the attack!": [
+		"あいての　@0には あたらなかった！",
+		"Le @0 ennemi évite l'attaque!",
+		"@0 nemico evita l'attacco!",
+		"@0 (Gegner) wehrt die Attacke ab!",
+		"¡El @0 enemigo ha evitado el ataque!"
+	],
+	"@0 is unaffected!": [
+		"@0には ぜんぜん　きいてない！",
+		"@0 n'est pas affecté!",
+		"@0 è incolume!",
+		"@0 ist unversehrt!",
+		"¡No ha afectado a @0!"
+	],
+	"The foe's @0 is unaffected!": [
+		"あいての　@0には ぜんぜん　きいてない！",
+		"Le @0 ennemi n'est pas affecté!",
+		"@0 nemico è incolume!",
+		"@0 (Gegner) ist unversehrt!",
+		"¡No ha afectado al @0 enemigo!"
+	],
+	"The @1 weakened the damage to @0!": [
+		"@0への　ダメージを @1が　よわめた！",
+		"@1 réduit les dégâts infligés à @0!",
+		"@1 riduce i danni inflitti a @0!",
+		"@1 reduziert den Schaden gegen @0!",
+		"¡El daño a @0 ha sido atenuado por @1!"
+	],
+	"The @1 weakened the damage to the foe's @0!": [
+		"あいての　@0への　ダメージを @1が　よわめた！",
+		"@1 réduit les dégâts infligés au @0 ennemi!",
+		"@1 riduce i danni inflitti a @0 nemico!",
+		"@1 reduziert den Schaden gegen @0 (Gegner)!",
+		"¡El daño al @0 enemigo ha sido atenuado por @1!"
+	],
+	"@0 transformed!": [
+		"@0の すがたが　へんかした！",
+		"@0 se transforme!",
+		"@0 si è trasformato!",
+		"@0 verwandelt sich!",
+		"¡@0 se ha transformado!"
+	],
+	"The foe's @0 transformed!": [
+		"あいての　@0の すがたが　へんかした！",
+		"Le @0 ennemi se transforme!",
+		"@0 nemico si è trasformato!",
+		"@0 (Gegner) verwandelt sich!",
+		"¡El @0 enemigo se ha transformado!"
+	],
+	"@0 dropped its @1!": [
+		"@0は @1を　おとした！",
+		"@0 a laissé tomber ceci: @1!",
+		"@0 ha lasciato cadere @1!",
+		"@0 hat sein Item (@1) fallen lassen!",
+		"¡Se le ha caído @1 a @0!"
+	],
+	"The foe's @0 dropped its @1!": [
+		"あいての　@0は @1を　おとした！",
+		"Le @0 ennemi a laissé tomber ceci: @1!",
+		"@0 nemico ha lasciato cadere @1!",
+		"@0 (Gegner) hat sein Item (@1) fallen lassen!",
+		"¡Se le ha caído @1 al @0 enemigo!"
+	],
+	"@0's status was restored!": [
+		"@0の ステータスが　もとに　もどった！",
+		"Les changements de stats de @0 ont tous été annulés!",
+		"Eliminate tutte le modifiche alle statistiche di @0!",
+		"Die Statusveränderungen von @0 wurden aufgehoben!",
+		"¡Se han eliminado todos los cambios de estado de @0!"
+	],
+	"The foe's @0's status was restored!": [
+		"あいての　@0の ステータスが　もとに　もどった！",
+		"Les changements de stats du @0 ennemi ont tous été annulés!",
+		"Eliminate tutte le modifiche alle statistiche di @0 nemico!",
+		"Die Statusveränderungen von @0 (Gegner) wurden aufgehoben!",
+		"¡Se han eliminado todos los cambios de estado del @0 enemigo!"
+	],
+	"@0 moved to the center!": [
+		"@0は まんなかに　いどうした！",
+		"@0 s'est déplacé au milieu!",
+		"@0 passa in prima linea!",
+		"@0 ist in die Mitte gewechselt!",
+		"¡@0 se ha desplazado al centro!"
+	],
+	"The foe's @0 moved to the center!": [
+		"あいての　@0は まんなかに　いどうした！",
+		"Le @0 ennemi s'est déplacé au milieu!",
+		"@0 nemico passa in prima linea!",
+		"@0 (Gegner) ist in die Mitte gewechselt!",
+		"¡El @0 enemigo se ha desplazado al centro!"
+	],
+	"@0 was poisoned!": [
+		"@0は どくを　あびた！",
+		"@0 est empoisonné!",
+		"@0 è stato avvelenato!",
+		"@0 wurde vergiftet!",
+		"¡@0 ha sido envenenado!"
+	],
+	"The foe's @0 was poisoned!": [
+		"あいての　@0は どくを　あびた！",
+		"Le @0 ennemi est empoisonné!",
+		"@0 nemico è stato avvelenato!",
+		"@0 (Gegner) wurde vergiftet!",
+		"¡El @0 enemigo ha sido envenenado!"
+	],
+	"@0 was badly poisoned!": [
+		"@0は もうどくを　あびた！",
+		"@0 est gravement empoisonné!",
+		"@0 è stato iperavvelenato!",
+		"@0 wurde schwer vergiftet!",
+		"¡@0 ha sido gravemente envenenado!"
+	],
+	"The foe's @0 was badly poisoned!": [
+		"あいての　@0は もうどくを　あびた！",
+		"Le @0 ennemi est gravement empoisonné!",
+		"@0 nemico è stato iperavvelenato!",
+		"@0 (Gegner) wurde schwer vergiftet!",
+		"¡El @0 enemigo ha sido gravemente envenenado!"
+	],
+	"@0 was badly poisoned by the @1!": [
+		"@0は @1で もうどくを　あびた！",
+		"@0 est gravement empoisonné par l'objet @1!",
+		"@0 è stato iperavvelenato con @1!",
+		"@0 wurde durch das Item @1 schwer vergiftet!",
+		"¡@0 ha sido gravemente envenenado por @1!"
+	],
+	"The foe's @0 was badly poisoned by the @1!": [
+		"あいての　@0は @1で もうどくを　あびた！",
+		"Le @0 ennemi est gravement empoisonné par l'objet @1!",
+		"@0 nemico è stato iperavvelenato con @1!",
+		"@0 (Gegner) wurde durch das Item @1 schwer vergiftet!",
+		"¡El @0 enemigo ha sido gravemente envenenado por @1!"
+	],
+	"@0 was hurt by poison!": [
+		"@0は どくの　ダメージを　うけた！",
+		"@0 souffre du poison!",
+		"Il veleno ha effetto su @0!",
+		"@0 wird durch Gift verletzt!",
+		"¡El veneno resta PS a @0!"
+	],
+	"The foe's @0 was hurt by poison!": [
+		"あいての　@0は どくの　ダメージを　うけた！",
+		"Le @0 ennemi souffre du poison!",
+		"Il veleno ha effetto su @0 nemico!",
+		"@0 (Gegner) wird durch Gift verletzt!",
+		"¡El veneno resta PS al @0 enemigo!"
+	],
+	"@0 was cured of its poisoning.": [
+		"あいての　@0の　どくは きれいさっぱり　なくなった！",
+		"Le @0 ennemi n'est plus empoisonné!",
+		"@0 nemico è stato curato dal veleno.",
+		"Die Vergiftung von @0 (Gegner) wurde geheilt.",
+		"¡El @0 enemigo se ha curado del envenenamiento!"
+	],
+	"@0 is already poisoned.": [
+		"@0は　すでに どくを　あびている",
+		"@0 est déjà empoisonné.",
+		"@0 è già avvelenato.",
+		"@0 ist bereits vergiftet.",
+		"¡@0 ya está envenenado!"
+	],
+	"The foe's @0 is already poisoned.": [
+		"あいての　@0は　すでに どくを　あびている",
+		"Le @0 ennemi est déjà empoisonné.",
+		"@0 nemico è già avvelenato.",
+		"@0 (Gegner) ist bereits vergiftet.",
+		"¡El @0 enemigo ya está envenenado!"
+	],
+	"@0 cannot be poisoned!": [
+		"@0は どくに　ならない！",
+		"@0 ne peut pas être empoisonné!",
+		"@0 non può essere avvelenato!",
+		"Das Gift zeigt keine Wirkung bei @0!",
+		"¡El veneno no afecta a @0!"
+	],
+	"The foe's @0 cannot be poisoned!": [
+		"あいての　@0は どくに　ならない！",
+		"Le @0 ennemi ne peut pas être empoisonné!",
+		"@0 nemico non può essere avvelenato!",
+		"Das Gift zeigt keine Wirkung bei @0 (Gegner)!",
+		"¡El veneno no afecta al @0 enemigo!"
+	],
+	"@0 was burned!": [
+		"@0は やけどを　おった！",
+		"@0 est brûlé!",
+		"@0 è stato scottato!",
+		"@0 brennt!",
+		"¡@0 se ha quemado!"
+	],
+	"The foe's @0 was burned!": [
+		"あいての　@0は やけどを　おった！",
+		"Le @0 ennemi est brûlé!",
+		"@0 nemico è stato scottato!",
+		"@0 (Gegner) brennt!",
+		"¡El @0 enemigo se ha quemado!"
+	],
+	"@0 was burned by @1!": [
+		"@0は @1で　やけどを　おった！",
+		"@0 est brûlé par l'objet @1!",
+		"@0 è stato scottato con @1!",
+		"@0 erleidet Verbrennung durch @1!",
+		"¡@0 se ha quemado con @1!"
+	],
+	"The foe's @0 was burned by @1!": [
+		"あいての　@0は @1で　やけどを　おった！",
+		"Le @0 ennemi est brûlé par l'objet @1!",
+		"@0 nemico è stato scottato con @1!",
+		"@0 (Gegner) erleidet Verbrennung durch @1!",
+		"¡El @0 enemigo se ha quemado con @1!"
+	],
+	"@0 was hurt by its burn!": [
+		"@0は やけどの　ダメージを　うけた！",
+		"@0 souffre de sa brûlure!",
+		"@0 soffre per la scottatura!",
+		"Die Verbrennung schadet @0!",
+		"¡@0 se resiente de la quemadura!"
+	],
+	"The foe's @0 was hurt by its burn!": [
+		"あいての　@0は やけどの　ダメージを　うけた！",
+		"Le @0 ennemi souffre de sa brûlure!",
+		"@0 nemico soffre per la scottatura!",
+		"Die Verbrennung schadet @0 (Gegner)!",
+		"¡El @0 enemigo se resiente de la quemadura!"
+	],
+	"@0's burn was healed.": [
+		"@0の やけどが　なおった！",
+		"@0 n'est plus brûlé!",
+		"@0 guarisce dalla scottatura!",
+		"Verbrennung von @0 wurde geheilt.",
+		"¡@0 ya no tiene quemaduras!"
+	],
+	"The foe's @0 healed its burn!": [
+		"あいての　@0の やけどが　なおった！",
+		"Le @0 ennemi n'est plus brûlé!",
+		"@0 nemico guarisce dalla scottatura!",
+		"Verbrennung von @0 (Gegner) wurde geheilt.",
+		"¡El @0 enemigo ya no tiene quemaduras!"
+	],
+	"@0 already has a burn.": [
+		"@0は　すでに やけどを　おっている",
+		"@0 est déjà brûlé.",
+		"@0 è già scottato.",
+		"@0 brennt bereits.",
+		"¡@0 ya está quemado!"
+	],
+	"The foe's @0 already has a burn.": [
+		"あいての　@0は　すでに やけどを　おっている",
+		"Le @0 ennemi est déjà brûlé.",
+		"@0 nemico è già scottato.",
+		"@0 (Gegner) brennt bereits.",
+		"¡El @0 enemigo ya está quemado!"
+	],
+	"@0 cannot be burned!": [
+		"@0は やけどに　ならない！",
+		"@0 ne peut pas être brûlé!",
+		"@0 non può essere scottato!",
+		"@0 fängt nicht an zu brennen!",
+		"¡@0 no se quema!"
+	],
+	"The foe's @0 cannot be burned!": [
+		"あいての　@0は やけどに　ならない！",
+		"Le @0 ennemi ne peut pas être brûlé!",
+		"@0 nemico non può essere scottato!",
+		"@0 (Gegner) fängt nicht an zu brennen!",
+		"¡El @0 enemigo no se quema!"
+	],
+	"@0 is paralyzed! It may be unable to move!": [
+		"@0は　まひして わざが　でにくくなった！",
+		"@0 est paralysé! Il aura du mal à attaquer!",
+		"@0 è stato paralizzato! Forse non riuscirà ad agire!",
+		"@0 ist paralysiert! Es greift eventuell nicht an!",
+		"¡@0 sufre parálisis! ¡Quizás no se pueda mover!"
+	],
+	"The foe's @0 is paralyzed! It may be unable to move!": [
+		"あいての　@0は　まひして わざが　でにくくなった！",
+		"Le @0 ennemi est paralysé! Il aura du mal à attaquer!",
+		"@0 nemico è stato paralizzato! Forse non riuscirà ad agire!",
+		"@0 (Gegner) ist paralysiert! Es greift eventuell nicht an!",
+		"¡El @0 enemigo sufre parálisis! ¡Quizás no se pueda mover!"
+	],
+	"@0 is paralyzed! It can't move!": [
+		"@0は からだが　しびれて　うごけない！",
+		"@0 est paralysé! Il n'a pas pu attaquer!",
+		"@0 è paralizzato! Non può agire!",
+		"@0 ist paralysiert! Es kann nicht angreifen!",
+		"¡@0 está paralizado! ¡No se puede mover!"
+	],
+	"The foe's @0 is paralyzed! It can't move!": [
+		"あいての　@0は からだが　しびれて　うごけない！",
+		"Le @0 ennemi est paralysé! Il n'a pas pu attaquer!",
+		"@0 nemico è paralizzato! Non può agire!",
+		"@0 (Gegner) ist paralysiert! Es kann nicht angreifen!",
+		"¡El @0 enemigo está paralizado! ¡No se puede mover!"
+	],
+	"@0 was cured of paralysis.": [
+		"@0の しびれが　とれた！",
+		"@0 n'est plus paralysé!",
+		"@0 guarisce dalla paralisi!",
+		"Die Paralyse von @0 wurde aufgehoben.",
+		"¡@0 se ha curado de la parálisis!"
+	],
+	"The foe's @0 was cured of paralysis.": [
+		"あいての　@0の しびれが　とれた！",
+		"Le @0 ennemi n'est plus paralysé!",
+		"@0 nemico guarisce dalla paralisi!",
+		"Die Paralyse von @0 (Gegner) wurde aufgehoben.",
+		"¡El @0 enemigo se ha curado de la parálisis!"
+	],
+	"@0 is already paralyzed!": [
+		"@0は すでに　まひしている",
+		"@0 est déjà paralysé.",
+		"@0 è già paralizzato!",
+		"@0 ist bereits paralysiert!",
+		"¡@0 ya está paralizado!"
+	],
+	"The foe's @0 is already paralyzed!": [
+		"あいての　@0は すでに　まひしている",
+		"Le @0 ennemi est déjà paralysé.",
+		"@0 nemico è già paralizzato!",
+		"@0 (Gegner) ist bereits paralysiert!",
+		"¡El @0 enemigo ya está paralizado!"
+	],
+	"@0 cannot be paralyzed!": [
+		"@0は まひに　ならない！",
+		"@0 ne peut pas être paralysé!",
+		"@0 non può essere paralizzato!",
+		"@0 kann nicht paralysiert werden!",
+		"¡@0 no se queda paralizado!"
+	],
+	"The foe's @0 cannot be paralyzed!": [
+		"あいての　@0は まひに　ならない！",
+		"Le @0 ennemi ne peut pas être paralysé!",
+		"@0 nemico non può essere paralizzato!",
+		"@0 (Gegner) kann nicht paralysiert werden!",
+		"¡El @0 enemigo no se queda paralizado!"
+	],
+	"@0 was frozen solid!": [
+		"@0は こおりついた！",
+		"@0 est gelé!",
+		"@0 è stato congelato!",
+		"@0 erstarrt zu Eis!",
+		"¡@0 ha sido congelado!"
+	],
+	"The foe's @0 was frozen solid!": [
+		"あいての　@0は こおりついた！",
+		"Le @0 ennemi est gelé!",
+		"@0 nemico è stato congelato!",
+		"@0 (Gegner) erstarrt zu Eis!",
+		"¡El @0 enemigo ha sido congelado!"
+	],
+	"@0 is frozen solid!": [
+		"@0は こおってしまって　うごけない！",
+		"@0 est gelé! Il ne peut plus attaquer!",
+		"@0 è congelato! Non può agire!",
+		"@0 ist eingefroren!",
+		"¡@0 está congelado!"
+	],
+	"The foe's @0 is frozen solid!": [
+		"あいての　@0は こおってしまって　うごけない！",
+		"Le @0 ennemi est gelé! Il ne peut plus attaquer!",
+		"@0 nemico è congelato! Non può agire!",
+		"@0 (Gegner) ist eingefroren!",
+		"¡El @0 enemigo está congelado!"
+	],
+	"@0 thawed out!": [
+		"@0の こおりが　とけた！",
+		"@0 n'est plus gelé!",
+		"@0 non è più congelato!",
+		"@0 wurde aufgetaut!",
+		"¡@0 ya no está congelado!"
+	],
+	"The foe's @0 thawed out!": [
+		"あいての　@0の こおりが　とけた！",
+		"Le @0 ennemi n'est plus gelé!",
+		"@0 nemico non è più congelato!",
+		"@0 (Gegner) wurde aufgetaut!",
+		"¡El @0 enemigo ya no está congelado!"
+	],
+	"@0 is already frozen solid!": [
+		"@0は すでに　こおっている",
+		"@0 est déjà gelé.",
+		"@0 è già congelato.",
+		"@0 ist bereits eingefroren!",
+		"¡@0 ya está congelado!"
+	],
+	"The foe's @0 is already frozen solid!": [
+		"あいての　@0は すでに　こおっている",
+		"Le @0 ennemi est déjà gelé.",
+		"@0 nemico è già congelato.",
+		"@0 (Gegner) ist bereits eingefroren!",
+		"¡El @0 enemigo ya está congelado!"
+	],
+	"@0 cannot be frozen solid!": [
+		"@0は こおらない！",
+		"@0 ne peut pas être gelé!",
+		"@0 non può essere congelato!",
+		"@0 kann nicht eingefroren werden!",
+		"¡@0 no se congela!"
+	],
+	"The foe's @0 cannot be frozen solid!": [
+		"あいての　@0は こおらない！",
+		"Le @0 ennemi ne peut pas être gelé!",
+		"@0 nemico non può essere congelato!",
+		"@0 (Gegner) kann nicht eingefroren werden!",
+		"¡El @0 enemigo no se congela!"
+	],
+	"@0's @1 melted the ice!": [
+		"@0の @1で　こおりが　とけた！",
+		"La glace a fondu grâce à @1 de @0!",
+		"@1 di @0 scioglie il ghiaccio!",
+		"Das Eis wurde durch @1 von @0 aufgetaut!",
+		"¡@0 ha derretido el hielo con @1!"
+	],
+	"The foe's @0's @1 melted the ice!": [
+		"あいての　@0の @1で　こおりが　とけた！",
+		"La glace a fondu grâce à @1 du @0 ennemi!",
+		"@1 di @0 nemico scioglie il ghiaccio!",
+		"Das Eis wurde durch @1 von @0 (Gegner) aufgetaut!",
+		"¡El @0 enemigo ha derretido el hielo con @1!"
+	],
+	"@0 fell asleep!": [
+		"@0は ねむってしまった！",
+		"@0 s'est endormi!",
+		"@0 si è addormentato!",
+		"@0 ist eingeschlafen!",
+		"¡@0 se ha dormido!"
+	],
+	"The foe's @0 fell asleep!": [
+		"あいての　@0は ねむってしまった！",
+		"Le @0 ennemi s'est endormi!",
+		"@0 nemico si è addormentato!",
+		"@0 (Gegner) ist eingeschlafen!",
+		"¡El @0 enemigo se ha dormido!"
+	],
+	"@0 is fast asleep.": [
+		"@0は ぐうぐう　ねむっている",
+		"@0 dort profondément.",
+		"@0 dorme.",
+		"@0 schläft tief und fest.",
+		"@0 está dormido como un tronco."
+	],
+	"The foe's @0 is fast asleep.": [
+		"あいての　@0は ぐうぐう　ねむっている",
+		"Le @0 ennemi dort profondément.",
+		"@0 nemico dorme.",
+		"@0 (Gegner) schläft tief und fest.",
+		"El @0 enemigo está dormido como un tronco."
+	],
+	"@0 woke up!": [
+		"@0は めを　さました！",
+		"@0 se réveille!",
+		"@0 si è svegliato!",
+		"@0 ist aufgewacht!",
+		"¡@0 se ha despertado!"
+	],
+	"The foe's @0 woke up!": [
+		"あいての　@0は めを　さました！",
+		"Le @0 ennemi se réveille!",
+		"@0 nemico si è svegliato!",
+		"@0 (Gegner) ist aufgewacht!",
+		"¡El @0 enemigo se ha despertado!"
+	],
+	"@0 is already asleep!": [
+		"@0は すでに　ねむっている",
+		"@0 dort déjà.",
+		"@0 sta già dormendo!",
+		"@0 schläft bereits!",
+		"¡@0 ya está dormido!"
+	],
+	"The foe's @0 is already asleep!": [
+		"あいての　@0は すでに　ねむっている",
+		"Le @0 ennemi dort déjà.",
+		"@0 nemico sta già dormendo!",
+		"@0 (Gegner) schläft bereits!",
+		"¡El @0 enemigo ya está dormido!"
+	],
+	"@0 stays awake!": [
+		"@0は　ねむらない！",
+		"@0 ne s'endort pas!",
+		"@0 rimane sveglio!",
+		"@0 schläft nicht ein!",
+		"¡@0 se ha mantenido despierto!"
+	],
+	"The foe's @0 stays awake!": [
+		"あいての　@0は　ねむらない！",
+		"Le @0 ennemi ne s'endort pas!",
+		"@0 nemico rimane sveglio!",
+		"@0 (Gegner) schläft nicht ein!",
+		"¡El @0 enemigo se ha mantenido despierto!"
+	],
+	"@0 began having a nightmare!": [
+		"@0は あくむを　みはじめた！",
+		"@0 commence un cauchemar!",
+		"@0 ha un incubo!",
+		"Nachtmahr sucht @0 heim!",
+		"¡@0 ha caído en una pesadilla!"
+	],
+	"The foe's @0 began having a nightmare!": [
+		"あいての　@0は あくむを　みはじめた！",
+		"Le @0 ennemi commence un cauchemar!",
+		"@0 nemico ha un incubo!",
+		"Nachtmahr sucht @0 (Gegner) heim!",
+		"¡El @0 enemigo ha caído en una pesadilla!"
+	],
+	"@0 is locked in a nightmare!": [
+		"@0は あくむに　うなされている！",
+		"@0 est prisonnier d'un cauchemar!",
+		"@0 è intrappolato in un incubo!",
+		"Nachtmahr schadet @0!",
+		"¡@0 está inmerso en una pesadilla!"
+	],
+	"The foe's @0 is locked in a nightmare!": [
+		"あいての　@0は あくむに　うなされている！",
+		"Le @0 ennemi est prisonnier d'un cauchemar!",
+		"@0 nemico è intrappolato in un incubo!",
+		"Nachtmahr schadet @0 (Gegner)!",
+		"¡El @0 enemigo está inmerso en una pesadilla!"
+	],
+	"@0 fell in love!": [
+		"@0は メロメロに　なった！",
+		"@0 est amoureux!",
+		"@0 è innamorato!",
+		"@0 hat sich verliebt!",
+		"¡@0 se ha enamorado!"
+	],
+	"The foe's @0 fell in love!": [
+		"あいての　@0は メロメロに　なった！",
+		"Le @0 ennemi est amoureux!",
+		"@0 nemico è innamorato!",
+		"@0 (Gegner) hat sich verliebt!",
+		"¡El @0 enemigo se ha enamorado!"
+	],
+	"@0 fell in love from the @1!": [
+		"@0は　@1で メロメロに　なった！",
+		"@1 rend @0 amoureux!",
+		"@1 fa innamorare @0!",
+		"@1 hat bewirkt, dass @0 sich verliebt!",
+		"¡@0 se ha enamorado con @1!"
+	],
+	"The foe's @0 fell in love from the @1!": [
+		"あいての　@0は　@1で メロメロに　なった！",
+		"@1 rend le @0 ennemi amoureux!",
+		"@1 fa innamorare @0 nemico!",
+		"@1 hat bewirkt, dass @0 (Gegner) sich verliebt!",
+		"¡El @0 enemigo se ha enamorado con @1!"
+	],
+	"@0 is in love with @1!": [
+		"@0は @1に　メロメロだ！",
+		"@0 est amoureux de @1!",
+		"@0 è innamorato di @1!",
+		"@0 hat sich in @1 verliebt!",
+		"¡@0 está enamorado de @1!"
+	],
+	"The foe's @0 is in love with @1!": [
+		"あいての　@0は @1に　メロメロだ！",
+		"Le @0 ennemi est amoureux de @1!",
+		"@0 nemico è innamorato di @1!",
+		"@0 (Gegner) hat sich in @1 verliebt!",
+		"¡El @0 enemigo está enamorado de @1!"
+	],
+	"@0 is immobilized by love!": [
+		"@0は メロメロで　わざが　だせなかった！",
+		"L'amour empêche @0 d'agir!",
+		"L'innamoramento impedisce a @0 di agire!",
+		"@0 ist starr vor Liebe!",
+		"¡El amor impide que @0 reaccione!"
+	],
+	"The foe's @0 is immobilized by love!": [
+		"あいての　@0は メロメロで　わざが　だせなかった！",
+		"L'amour empêche le @0 ennemi d'agir!",
+		"L'innamoramento impedisce a @0 nemico di agire!",
+		"@0 (Gegner) ist starr vor Liebe!",
+		"¡El amor impide que el @0 enemigo reaccione!"
+	],
+	"@0 got over its infatuation.": [
+		"@0は メロメロじょうたいが　なおった！",
+		"@0 n'est plus amoureux!",
+		"@0 non è più innamorato!",
+		"@0 ist nicht mehr verliebt!",
+		"¡@0 ya no está enamorado!"
+	],
+	"The foe's @0 got over its infatuation.": [
+		"あいての　@0は メロメロじょうたいが　なおった！",
+		"Le @0 ennemi n'est plus amoureux!",
+		"@0 nemico non è più innamorato!",
+		"@0 (Gegner) ist nicht mehr verliebt!",
+		"¡El @0 enemigo ya no está enamorado!"
+	],
+	"@0's status is returned to normal!": [
+		"@0は じょうたいが　もとに　もどった！",
+		"@0 est redevenu normal!",
+		"Lo stato di @0 torna normale.",
+		"Der Zustand von @0 hat sich wieder normalisiert!",
+		"¡El estado de @0 ha vuelto a la normalidad!"
+	],
+	"The foe's @0's status is returned to normal!": [
+		"あいての　@0は じょうたいが　もとに　もどった！",
+		"Le @0 ennemi est redevenu normal!",
+		"Lo stato di @0 nemico torna normale.",
+		"Der Zustand von @0 (Gegner) hat sich wieder normalisiert!",
+		"¡El estado del @0 enemigo ha vuelto a la normalidad!"
+	],
+	"@0 became confused!": [
+		"@0は こんらん　した！",
+		"Cela rend @0 confus!",
+		"@0 è stato confuso!",
+		"@0 wurde verwirrt!",
+		"¡@0 se encuentra confuso!"
+	],
+	"The foe's @0 became confused!": [
+		"あいての　@0は こんらん　した！",
+		"Cela rend le @0 ennemi confus!",
+		"@0 nemico è stato confuso!",
+		"@0 (Gegner) wurde verwirrt!",
+		"¡El @0 enemigo se encuentra confuso!"
+	],
+	"@0 is confused!": [
+		"@0は こんらん　している！",
+		"@0 est confus!",
+		"@0 è confuso!",
+		"@0 ist verwirrt!",
+		"¡@0 está confuso!"
+	],
+	"The foe's @0 is confused!": [
+		"あいての　@0は こんらん　している！",
+		"Le @0 ennemi est confus!",
+		"@0 nemico è confuso!",
+		"@0 (Gegner) ist verwirrt!",
+		"¡El @0 enemigo está confuso!"
+	],
+	"@0 snapped out of its confusion.": [
+		"@0の こんらんが　とけた！",
+		"@0 n'est plus confus!",
+		"@0 non è più confuso!",
+		"@0 ist nicht mehr verwirrt!",
+		"¡@0 ya no está confuso!"
+	],
+	"The foe's @0 snapped out of confusion!": [
+		"あいての　@0の こんらんが　とけた！",
+		"Le @0 ennemi n'est plus confus!",
+		"@0 nemico non è più confuso!",
+		"@0 (Gegner) ist nicht mehr verwirrt!",
+		"¡El @0 enemigo ya no está confuso!"
+	],
+	"@0 is already confused!": [
+		"@0は　すでに こんらん　している",
+		"@0 est déjà confus!",
+		"@0 è già confuso!",
+		"@0 ist bereits verwirrt!",
+		"¡@0 ya está confuso!"
+	],
+	"The foe's @0 is already confused!": [
+		"あいての　@0は　すでに こんらん　している",
+		"Le @0 ennemi est déjà confus!",
+		"@0 nemico è già confuso!",
+		"@0 (Gegner) ist bereits verwirrt!",
+		"¡El @0 enemigo ya está confuso!"
+	],
+	"@0 doesn't become confused!": [
+		"@0は こんらん　しない！",
+		"@0 ne peut pas être rendu confus!",
+		"@0 non è stato confuso!",
+		"@0 lässt sich nicht verwirren!",
+		"¡A @0 no le afecta la confusión!"
+	],
+	"The foe's @0 doesn't become confused!": [
+		"あいての　@0は こんらん　しない！",
+		"Le @0 ennemi ne peut pas être rendu confus!",
+		"@0 nemico non è stato confuso!",
+		"@0 (Gegner) lässt sich nicht verwirren!",
+		"¡Al @0 enemigo no le afecta la confusión!"
+	],
+	"@0 became confused due to fatigue!": [
+		"@0は つかれはてて　こんらん　した！",
+		"La fatigue rend @0 confus!",
+		"@0 è confuso per la fatica!",
+		"@0 ist vor Erschöpfung verwirrt!",
+		"¡El cansancio ha terminado confundiendo a @0!"
+	],
+	"The foe's @0 became confused due to fatigue!": [
+		"あいての　@0は つかれはてて　こんらん　した！",
+		"La fatigue rend le @0 ennemi confus!",
+		"@0 nemico è confuso per la fatica!",
+		"@0 (Gegner) ist vor Erschöpfung verwirrt!",
+		"¡El cansancio ha terminado confundiendo al @0 enemigo!"
+	],
+	"@0 flinched and couldn't move!": [
+		"@0は ひるんで　わざが　だせない！",
+		"@0 a la trouille! Il ne peut plus attaquer!",
+		"@0 tentenna! Non può agire!",
+		"@0 ist zurückgeschreckt und kann nicht angreifen!",
+		"¡@0 ha retrocedido y no puede lanzar ningún ataque!"
+	],
+	"The foe's @0 flinched and couldn't move!": [
+		"あいての　@0は ひるんで　わざが　だせない！",
+		"Le @0 ennemi a la trouille! Il ne peut plus attaquer!",
+		"@0 nemico tentenna! Non può agire!",
+		"@0 (Gegner) ist zurückgeschreckt und kann nicht angreifen!",
+		"¡El @0 enemigo ha retrocedido y no puede lanzar ningún ataque!"
+	],
+	"@0 lost its focus and couldn't move!": [
+		"@0は　しゅうちゅうが とぎれて　わざが　だせない！",
+		"@0 n'est plus concentré. Il ne peut plus attaquer!",
+		"@0 perde la concentrazione e non può agire!",
+		"@0 mangelt es an Konzentration. Es kann nicht angreifen!",
+		"¡@0 ha perdido la concentración y no puede atacar!"
+	],
+	"The foe's @0 lost its focus and couldn't move!": [
+		"あいての　@0は　しゅうちゅうが とぎれて　わざが　だせない！",
+		"Le @0 ennemi n'est plus concentré. Il ne peut plus attaquer!",
+		"@0 nemico perde la concentrazione e non può agire!",
+		"@0 (Gegner) mangelt es an Konzentration. Es kann nicht angreifen!",
+		"¡El @0 enemigo ha perdido la concentración y no puede atacar!"
+	],
+	"@0 was identified!": [
+		"@0の しょうたいを　みやぶった！",
+		"@0 est identifié!",
+		"@0 è stato identificato!",
+		"@0 wurde erkannt!",
+		"¡@0 identificado!"
+	],
+	"The foe's @0 was identified!": [
+		"あいての　@0の しょうたいを　みやぶった！",
+		"Le @0 ennemi est identifié!",
+		"@0 nemico è stato identificato!",
+		"@0 (Gegner) wurde erkannt!",
+		"¡@0 enemigo identificado!"
+	],
+	"@0 is hurt by @1!": [
+		"@0は　@1の ダメージを　うけている",
+		"@0 est blessé par @1!",
+		"@0 subisce i danni della mossa @1!",
+		"@0 wurde durch @1 verletzt!",
+		"¡@1 ha herido a @0!"
+	],
+	"The foe's @0 is hurt by @1!": [
+		"あいての　@0は　@1の ダメージを　うけている",
+		"Le @0 ennemi est blessé par @1!",
+		"@0 nemico subisce i danni della mossa @1!",
+		"@0 (Gegner) wurde durch @1 verletzt!",
+		"¡@1 ha herido al @0 enemigo!"
+	],
+	"@0 was freed from @1!": [
+		"@0は @1から　かいほうされた！",
+		"@0 est libéré de @1!",
+		"@0 si è liberato da @1!",
+		"@0 wurde von @1 befreit!",
+		"¡@0 se ha liberado de @1!"
+	],
+	"The foe's @0 was freed from @1!": [
+		"あいての　@0は @1から　かいほうされた！",
+		"Le @0 ennemi est libéré de @1!",
+		"@0 nemico si è liberato da @1!",
+		"@0 (Gegner) wurde von @1 befreit!",
+		"¡El @0 enemigo se ha liberado de @1!"
+	],
+	"@0 is damaged by recoil!": [
+		"@0は はんどうによる　ダメージを　うけた！",
+		"@0 est blessé par le contrecoup!",
+		"@0 ha subito il contraccolpo!",
+		"@0 erleidet Schaden durch Rückstoß!",
+		"¡@0 también se ha hecho daño!"
+	],
+	"The foe's @0 is damaged by recoil!": [
+		"あいての　@0は はんどうによる　ダメージを　うけた！",
+		"Le @0 ennemi est blessé par le contrecoup!",
+		"@0 nemico ha subito il contraccolpo!",
+		"@0 (Gegner) erleidet Schaden durch Rückstoß!",
+		"¡El @0 enemigo también se ha hecho daño!"
+	],
+	"It traced @0's @1!": [
+		"@0の @1　を　トレースした！",
+		"La capacité spéciale @1 de @0 a été calquée!",
+		"@1 di @0 viene copiata con Traccia!",
+		"@1 von @0 wurde per Fährte erkannt!",
+		"¡Se ha copiado la habilidad @1 de @0!"
+	],
+	"It traced the foe's @0's @1!": [
+		"あいての　@0の @1　を　トレースした！",
+		"La capacité spéciale @1 du @0 ennemi a été calquée!",
+		"@1 di @0 nemico viene copiata con Traccia!",
+		"@1 von @0 (Gegner) wurde per Fährte erkannt!",
+		"¡Se ha copiado la habilidad @1 del @0 enemigo!"
+	],
+	"A critical hit on @0!": [
+		"@0の きゅうしょに　あたった！",
+		"Coup critique infligé à @0!",
+		"Brutto colpo su @0!",
+		"Gegen @0 wurde ein Volltreffer gelandet!",
+		"¡@0 ha recibido un golpe crítico!"
+	],
+	"A critical hit on the foe's @0!": [
+		"あいての　@0の きゅうしょに　あたった！",
+		"Coup critique infligé au @0 ennemi!",
+		"Brutto colpo su @0 nemico!",
+		"Gegen @0 (Gegner) wurde ein Volltreffer gelandet!",
+		"¡El @0 enemigo ha recibido un golpe crítico!"
+	],
+	"@0's HP was restored.": [
+		"@0の たいりょくが　かいふくした！",
+		"@0 récupère des PV!",
+		"@0 ha recuperato dei Punti Salute!",
+		"KP von @0 wurden aufgefrischt!",
+		"¡@0 ha recuperado PS!"
+	],
+	"The foe's @0 had its HP restored.": [
+		"あいての　@0の たいりょくが　かいふくした！",
+		"Le @0 ennemi récupère des PV!",
+		"@0 nemico ha recuperato dei Punti Salute!",
+		"KP von @0 (Gegner) wurden aufgefrischt!",
+		"¡El @0 enemigo ha recuperado PS!"
+	],
+	"@0 restored @1's PP!": [
+		"@0は @1の　ＰＰを　かいふくした！",
+		"@0 récupère les PP de @1!",
+		"@0 recupera i Punti Potenza di @1!",
+		"@0 hat die AP seiner Attacke @1 aufgefrischt!",
+		"¡@0 ha restaurado los PP de @1!"
+	],
+	"The foe's @0 restored @1's PP!": [
+		"あいての　@0は @1の　ＰＰを　かいふくした！",
+		"Le @0 ennemi récupère les PP de @1!",
+		"@0 nemico recupera i Punti Potenza di @1!",
+		"@0 (Gegner) hat die AP seiner Attacke @1 aufgefrischt!",
+		"¡El @0 enemigo ha restaurado los PP de @1!"
+	],
+	"@0 restored all its moves' PP!": [
+		"@0は すべての　わざの　ＰＰを　かいふくした！",
+		"@0 récupère des PP!",
+		"@0 recupera i Punti Potenza di tutte le mosse!",
+		"AP aller Attacken von @0 wurden aufgefüllt!",
+		"¡@0 ha restaurado los PP de todos los movimientos!"
+	],
+	"The foe's @0 restored all its moves' PP!": [
+		"あいての　@0は すべての　わざの　ＰＰを　かいふくした！",
+		"Le @0 ennemi récupère des PP!",
+		"@0 nemico recupera i Punti Potenza di tutte le mosse!",
+		"AP aller Attacken von @0 (Gegner) wurden aufgefüllt!",
+		"¡El @0 enemigo ha restaurado los PP de todos los movimientos!"
+	],
+	"@0 is buffeted by the sandstorm!": [
+		"すなあらしが @0を　おそう！",
+		"La tempête de sable inflige des dégâts à @0!",
+		"La tempesta di sabbia infligge danni a @0!",
+		"Der Sandsturm fügt @0 Schaden zu!",
+		"¡La tormenta de arena zarandea a @0!"
+	],
+	"The foe's @0 is buffeted by the sandstorm!": [
+		"すなあらしが あいての　@0を　おそう！",
+		"La tempête de sable inflige des dégâts au @0 ennemi!",
+		"La tempesta di sabbia infligge danni a @0 nemico!",
+		"Der Sandsturm fügt @0 (Gegner) Schaden zu!",
+		"¡La tormenta de arena zarandea al @0 enemigo!"
+	],
+	"@0 is buffeted by the hail!": [
+		"あられが @0を　おそう！",
+		"La tempête de grêle inflige des dégâts à @0!",
+		"La Grandine infligge danni a @0!",
+		"@0 wird von Hagelkörnern getroffen!",
+		"¡Granizo zarandea a @0!"
+	],
+	"The foe's @0 is buffeted by the hail!": [
+		"あられが あいての　@0を　おそう！",
+		"La tempête de grêle inflige des dégâts au @0 ennemi!",
+		"La Grandine infligge danni a @0 nemico!",
+		"@0 (Gegner) wird von Hagelkörnern getroffen!",
+		"¡Granizo zarandea al @0 enemigo!"
+	],
+	"@0 is hurt!": [
+		"@0は ダメージを　うけた！",
+		"@0 est blessé!",
+		"@0 è ferito!",
+		"@0 wurde Schaden zugefügt!",
+		"¡@0 ha sido herido!"
+	],
+	"The foe's @0 is hurt!": [
+		"あいての　@0は ダメージを　うけた！",
+		"Le @0 ennemi est blessé!",
+		"@0 nemico è ferito!",
+		"@0 (Gegner) wurde Schaden zugefügt!",
+		"¡El @0 enemigo ha sido herido!"
+	],
+	"@0 acquired @1!": [
+		"@0は @1に　なった！",
+		"@0 prend la capacité spéciale @1!",
+		"L'abilità di @0 è ora @1!",
+		"@0 nimmt die Fähigkeit @1 an!",
+		"¡La habilidad de @0 ha cambiado a @1!"
+	],
+	"The foe's @0 acquired @1!": [
+		"あいての　@0は @1に　なった！",
+		"Le @0 ennemi prend la capacité spéciale @1!",
+		"L'abilità di @0 nemico è ora @1!",
+		"@0 (Gegner) nimmt die Fähigkeit @1 an!",
+		"¡La habilidad del @0 enemigo ha cambiado a @1!"
+	],
+	"@0 floats in the air with its Air Balloon!": [
+		"@0は ふうせんで　ういている！",
+		"@0 flotte grâce à son Ballon!",
+		"@0 galleggia in aria grazie a un Palloncino!",
+		"@0 gerät durch den Luftballon in die Schwebe!",
+		"¡@0 está flotando con un Globo Helio!"
+	],
+	"The foe's @0 floats in the air with its Air Balloon!": [
+		"あいての　@0は ふうせんで　ういている！",
+		"Le @0 ennemi flotte grâce à son Ballon!",
+		"@0 nemico galleggia in aria grazie a un Palloncino!",
+		"@0 (Gegner) gerät durch den Luftballon in die Schwebe!",
+		"¡El @0 enemigo está flotando con un Globo Helio!"
+	],
+	"@0's Air Balloon popped!": [
+		"@0の ふうせんが　われた！",
+		"Le Ballon de @0 a éclaté!",
+		"Il Palloncino di @0 è scoppiato!",
+		"Der Luftballon von @0 ist geplatzt!",
+		"¡Ha explotado el Globo Helio de @0!"
+	],
+	"The foe's @0's Air Balloon popped!": [
+		"あいての　@0の ふうせんが　われた！",
+		"Le Ballon du @0 ennemi a éclaté!",
+		"Il Palloncino di @0 nemico è scoppiato!",
+		"Der Luftballon von @0 (Gegner) ist geplatzt!",
+		"¡Ha explotado el Globo Helio del @0 enemigo!"
+	],
+	"@0 is switched out with the Eject Button!": [
+		"@0は だっしゅつボタンで　もどっていく！",
+		"@0 se retire grâce au Bouton Fuite!",
+		"@0 è sostituito grazie a Pulsantefuga!",
+		"@0 kommt dank des Fluchtknopfes zurück!",
+		"¡@0 regresa gracias al Botón Escape!"
+	],
+	"The foe's @0 is switched out with the Eject Button!": [
+		"あいての　@0は だっしゅつボタンで　もどっていく！",
+		"Le @0 ennemi se retire grâce au Bouton Fuite!",
+		"@0 nemico è sostituito grazie a Pulsantefuga!",
+		"@0 (Gegner) kommt dank des Fluchtknopfes zurück!",
+		"¡El @0 enemigo regresa gracias al Botón Escape!"
+	],
+	"@0 held up its Red Card against @1!": [
+		"@0は　レッドカードを @1に　たたきつけた！",
+		"@0 a mis un Carton Rouge à @1!",
+		"@0 dà un Cartelrosso a @1!",
+		"@0 hält @1 die Rote Karte vor die Nase!",
+		"¡@0 le ha sacado una Tarjeta Roja a @1!"
+	],
+	"@0 held up its Red Card against the foe's @1!": [
+		"@0は　レッドカードを あいての　@1に　たたきつけた！",
+		"@0 a mis un Carton Rouge au @1 ennemi!",
+		"@0 dà un Cartelrosso a @1 nemico!",
+		"@0 hält @1 (Gegner) die Rote Karte vor die Nase!",
+		"¡@0 le ha sacado una Tarjeta Roja al @1 enemigo!"
+	],
+	"The foe's @0 held up its Red Card against @1!": [
+		"あいての　@0は　レッドカードを @1に　たたきつけた！",
+		"Le @0 ennemi a mis un Carton Rouge au @1!",
+		"@0 nemico dà un Cartelrosso a @1!",
+		"@0 (Gegner) hält @1 die Rote Karte vor die Nase!",
+		"¡El @0 enemigo le ha sacado una Tarjeta Roja a @1!"
+	],
+	"The foe's @0 held up its Red Card against the foe's @1!": [
+		"あいての　@0は　レッドカードを あいての　@1に　たたきつけた！",
+		"Le @0 ennemi a mis un Carton Rouge au @1 ennemi!",
+		"@0 nemico dà un Cartelrosso a @1 nemico!",
+		"@0 (Gegner) hält @1 (Gegner) die Rote Karte vor die Nase!",
+		"¡El @0 enemigo le ha sacado una Tarjeta Roja al @1 enemigo!"
+	],
+	"@0 was hurt by the Rocky Helmet!": [
+		"@0は ゴツゴツメットで　ダメージを　うけた！",
+		"@0 est blessé par le Casque Brut!",
+		"@0 è ferito da Bitorzolelmo!",
+		"@0 erleidet durch den Beulenhelm Schaden!",
+		"¡Casco Dentado ha dañado a @0!"
+	],
+	"The foe's @0 was hurt by the Rocky Helmet!": [
+		"あいての　@0は ゴツゴツメットで　ダメージを　うけた！",
+		"Le @0 ennemi est blessé par le Casque Brut!",
+		"@0 nemico è ferito da Bitorzolelmo!",
+		"@0 (Gegner) erleidet durch den Beulenhelm Schaden!",
+		"¡Casco Dentado ha dañado al @0 enemigo!"
+	],
+	"The power of @0's Fire-type moves rose!": [
+		"@0は ほのおの　いりょくが　あがった！",
+		"@0 augmente sa puissance de feu!",
+		"La potenza delle mosse di tipo Fuoco di @0 aumenta!",
+		"Die Stärke der Feuer-Attacken von @0 wurde erhöht!",
+		"¡@0 ha aumentado la potencia de sus movimientos de tipo Fuego!"
+	],
+	"The power of the foe's @0's Fire-type moves rose!": [
+		"あいての　@0は ほのおの　いりょくが　あがった！",
+		"Le @0 ennemi augmente sa puissance de feu!",
+		"La potenza delle mosse di tipo Fuoco di @0 nemico aumenta!",
+		"Die Stärke der Feuer-Attacken von @0 (Gegner) wurde erhöht!",
+		"¡El @0 enemigo ha aumentado la potencia de sus movimientos de tipo Fuego!"
+	],
+	"@0 was hurt!": [
+		"@0は きずついた！",
+		"@0 s'est blessé en attaquant!",
+		"@0 si è fatto male!",
+		"@0 wurde verletzt!",
+		"¡@0 se ha herido!"
+	],
+	"The foe's @0 was hurt!": [
+		"あいての　@0は きずついた！",
+		"Le @0 ennemi s'est blessé en attaquant!",
+		"@0 nemico si è fatto male!",
+		"@0 (Gegner) wurde verletzt!",
+		"¡El @0 enemigo se ha herido!"
+	],
+	"It was alerted to @0's @1!": [
+		"@0の @1　を　よみとった！",
+		"La capacité @1 de @0 a été détectée!",
+		"La mossa @1 di @0 è stata scoperta!",
+		"@1 von @0 wurde durchschaut!",
+		"¡Detectado el movimiento @1 de @0!"
+	],
+	"It was alerted to the foe's @0's @1!": [
+		"あいての　@0の @1　を　よみとった！",
+		"La capacité @1 du @0 ennemi a été détectée!",
+		"La mossa @1 di @0 nemico è stata scoperta!",
+		"@1 von @0 (Gegner) wurde durchschaut!",
+		"¡Detectado el movimiento @1 del @0 enemigo!"
+	],
+	"@0 shuddered!": [
+		"@0は みぶるいした！",
+		"@0 est tout tremblant!",
+		"@0 rabbrividisce!",
+		"@0 erschaudert!",
+		"¡@0 se ha estremecido!"
+	],
+	"The foe's @0 shuddered!": [
+		"あいての　@0は みぶるいした！",
+		"Le @0 ennemi est tout tremblant!",
+		"@0 nemico rabbrividisce!",
+		"@0 (Gegner) erschaudert!",
+		"¡El @0 enemigo se ha estremecido!"
+	],
+	"@0 frisked its target and found one @1!": [
+		"@0は @1　を　おみとおしだ！",
+		"@0 a décelé l'objet: @1!",
+		"@0 perquisisce l'avversario e trova @1!",
+		"@0 hat @1 erschnüffelt!",
+		"¡@0 ha cacheado a su rival y ha encontrado @1!"
+	],
+	"The foe's @0 frisked its target and found one @1!": [
+		"あいての　@0は @1　を　おみとおしだ！",
+		"Le @0 ennemi a décelé l'objet: @1!",
+		"@0 nemico perquisisce l'avversario e trova @1!",
+		"@0 (Gegner) hat @1 erschnüffelt!",
+		"¡El @0 enemigo ha cacheado a su rival y ha encontrado @1!"
+	],
+	"@0 breaks the mold!": [
+		"@0は かたやぶりだ！",
+		"@0 brise le moule!",
+		"@0 ha Rompiforma!",
+		"@0 gelingt es, gegnerische Fähigkeiten zu überbrücken!",
+		"¡@0 ha usado Rompemoldes!"
+	],
+	"The foe's @0 breaks the mold!": [
+		"あいての　@0は かたやぶりだ！",
+		"Le @0 ennemi brise le moule!",
+		"@0 nemico ha Rompiforma!",
+		"@0 (Gegner) gelingt es, gegnerische Fähigkeiten zu überbrücken!",
+		"¡El @0 enemigo ha usado Rompemoldes!"
+	],
+	"The foe's @0 is loafing around!": [
+		"あいての　@0は なまけている",
+		"Le @0 ennemi paresse!",
+		"@0 nemico sta ciondolando!",
+		"@0 (Gegner) faulenzt!",
+		"¡El @0 enemigo está holgazaneando!"
+	],
+	"@0 took the attack!": [
+		"@0は こうげきを　ひきよせた！",
+		"@0 attire les coups sur lui!",
+		"@0 attira l'attacco su di sé!",
+		"@0 zieht den Angriff auf sich!",
+		"¡@0 ha atraído el ataque!"
+	],
+	"The foe's @0 took the attack!": [
+		"あいての　@0は こうげきを　ひきよせた！",
+		"Le @0 ennemi attire les coups sur lui!",
+		"@0 nemico attira l'attacco su di sé!",
+		"@0 (Gegner) zieht den Angriff auf sich!",
+		"¡El @0 enemigo ha atraído el ataque!"
+	],
+	"@0 anchors itself!": [
+		"@0は きゅうばんで　はりついている！",
+		"@0 s'accroche avec sa Ventouse!",
+		"@0 è ancorato al suolo grazie alle Ventose!",
+		"@0 verankert sich mithilfe von Saugnapf!",
+		"¡@0 se aferra al suelo con Ventosas!"
+	],
+	"The foe's @0 anchors itself!": [
+		"あいての　@0は きゅうばんで　はりついている！",
+		"Le @0 ennemi s'accroche avec sa Ventouse!",
+		"@0 nemico è ancorato al suolo grazie alle Ventose!",
+		"@0 (Gegner) verankert sich mithilfe von Saugnapf!",
+		"¡El @0 enemigo se aferra al suelo con Ventosas!"
+	],
+	"@0 sucked up the liquid ooze!": [
+		"@0は ヘドロえきを　すいとった！",
+		"@0 aspire le Suintement!",
+		"@0 ha assorbito la melma!",
+		"@0 saugt Kloakensoße auf!",
+		"¡@0 ha absorbido el lodo líquido!"
+	],
+	"The foe's @0 sucked up the liquid ooze!": [
+		"あいての　@0は ヘドロえきを　すいとった！",
+		"Le @0 ennemi aspire le Suintement!",
+		"@0 nemico ha assorbito la melma!",
+		"@0 (Gegner) saugt Kloakensoße auf!",
+		"¡El @0 enemigo ha absorbido el lodo líquido!"
+	],
+	"It stole @0's @1!": [
+		"@0の @1を　うばった！",
+		"@0 s'est fait voler l'objet: @1!",
+		"Ruba @1 a @0!",
+		"@0 hat sich @1 wegnehmen lassen!",
+		"¡El objeto @1 de @0 ha sido robado!"
+	],
+	"It stole the foe's @0's @1!": [
+		"あいての　@0の @1を　うばった！",
+		"Le @0 ennemi s'est fait voler l'objet: @1!",
+		"Ruba @1 a @0 nemico!",
+		"@0 (Gegner) hat sich @1 wegnehmen lassen!",
+		"¡El objeto @1 del @0 enemigo ha sido robado!"
+	],
+	"@0's Ability became Mummy!": [
+		"@0は とくせいが　ミイラになっちゃった！",
+		"La capacité spéciale de @0 est changée en Momie!",
+		"L'abilità di @0 è diventata Mummia!",
+		"@0 hat die Fähigkeit Mumie angenommen!",
+		"¡La habilidad de @0 es ahora Momia!"
+	],
+	"The foe's @0's Ability became Mummy!": [
+		"あいての　@0は とくせいが　ミイラになっちゃった！",
+		"La capacité spéciale du @0 ennemi est changée en Momie!",
+		"L'abilità di @0 nemico è diventata Mummia!",
+		"@0 (Gegner) hat die Fähigkeit Mumie angenommen!",
+		"¡La habilidad del @0 enemigo es ahora Momia!"
+	],
+	"It bounced back @0's @1!": [
+		"@0の @1を　はねかえした！",
+		"@0 a renvoyé @1!",
+		"La mossa @1 di @0 è stata riflessa!",
+		"@1 von @0 wurde zurückgelenkt!",
+		"¡El movimiento @1 de @0 ha sido devuelto!"
+	],
+	"It bounced back the foe's @0's @1!": [
+		"あいての　@0の @1を　はねかえした！",
+		"Le @0 ennemi a renvoyé @1!",
+		"La mossa @1 di @0 nemico è stata riflessa!",
+		"@1 von @0 (Gegner) wurde zurückgelenkt!",
+		"¡El movimiento @1 del @0 enemigo ha sido devuelto!"
+	],
+	"@0 avoids attacks by its ally Pokémon!": [
+		"@0は みかたからの　こうげきを　うけない！",
+		"@0 ne peut pas être attaqué par ses alliés!",
+		"@0 non può essere attaccato da un alleato!",
+		"@0 nimmt keinen Schaden durch Attacken von Partnern!",
+		"¡@0 no ha sufrido el ataque de su aliado!"
+	],
+	"The foe's @0 avoids attacks by its ally Pokémon!": [
+		"あいての　@0は みかたからの　こうげきを　うけない！",
+		"Le @0 ennemi ne peut pas être attaqué par ses alliés!",
+		"@0 nemico non può essere attaccato da un alleato!",
+		"@0 (Gegner) nimmt keinen Schaden durch Attacken von Partnern!",
+		"¡El @0 enemigo no ha sufrido el ataque de su aliado!"
+	],
+	"It poisoned @0!": [
+		"@0に どくを　あびせた！",
+		"@0 est aspergé de poison!",
+		"@0 viene cosparso di veleno!",
+		"@0 wurde vergiftet!",
+		"¡@0 ha sido envenenado!"
+	],
+	"It poisoned the foe's @0!": [
+		"あいての　@0に どくを　あびせた！",
+		"Le @0 ennemi est aspergé de poison!",
+		"@0 nemico viene cosparso di veleno!",
+		"@0 (Gegner) wurde vergiftet!",
+		"¡El @0 enemigo ha sido envenenado!"
+	],
+	"@0 harvested one @1!": [
+		"@0は @1を　しゅうかくした！",
+		"@0 a récolté l'objet: @1!",
+		"@0 raccoglie @1!",
+		"@0 hat @1 geerntet!",
+		"¡@0 ha recogido @1!"
+	],
+	"The foe's @0 harvested one @1!": [
+		"あいての　@0は @1を　しゅうかくした！",
+		"Le @0 ennemi a récolté l'objet: @1!",
+		"@0 nemico raccoglie @1!",
+		"@0 (Gegner) hat @1 geerntet!",
+		"¡El @0 enemigo ha recogido @1!"
+	],
+	"@0's illusion wore off!": [
+		"@0の イリュージョンが　とけた！",
+		"L'Illusion de @0 se brise!",
+		"L'illusione di @0 viene sfatata!",
+		"Das Trugbild von @0 verschwindet!",
+		"¡La ilusión de @0 se ha desvanecido!"
+	],
+	"The foe's @0's illusion wore off!": [
+		"あいての　@0の イリュージョンが　とけた！",
+		"L'Illusion du @0 ennemi se brise!",
+		"L'illusione di @0 nemico viene sfatata!",
+		"Das Trugbild von @0 (Gegner) verschwindet!",
+		"¡La ilusión del @0 enemigo se ha desvanecido!"
+	],
+	"@0 maxed its Attack!": [
+		"@0は こうげきが　さいだいまで　あがった！",
+		"@0 monte son Attaque au maximum!",
+		"@0 aumenta al massimo il suo Attacco!",
+		"Der Angriffs-Wert von @0 erreicht das maximale Niveau!",
+		"¡@0 ha subido su Ataque al máximo!"
+	],
+	"The foe's @0 maxed its Attack!": [
+		"あいての　@0は こうげきが　さいだいまで　あがった！",
+		"Le @0 ennemi monte son Attaque au maximum!",
+		"@0 nemico aumenta al massimo il suo Attacco!",
+		"Der Angriffs-Wert von @0 (Gegner) erreicht das maximale Niveau!",
+		"¡El @0 enemigo ha subido su Ataque al máximo!"
+	],
+	"@0 is tormented!": [
+		"@0は うなされている！",
+		"@0 a le sommeil agité!",
+		"@0 ha il sonno inquieto!",
+		"@0 ist in einem Alptraum gefangen!",
+		"¡@0 está inmerso en una pesadilla!"
+	],
+	"The foe's @0 is tormented!": [
+		"あいての　@0は うなされている！",
+		"Le @0 ennemi a le sommeil agité!",
+		"@0 nemico ha il sonno inquieto!",
+		"@0 (Gegner) ist in einem Alptraum gefangen!",
+		"¡El @0 enemigo está inmerso en una pesadilla!"
+	],
+	"@0 is exerting its pressure!": [
+		"@0は プレッシャーを　はなっている！",
+		"@0 augmente la pression!",
+		"@0 esercita pressione!",
+		"@0 setzt Gegner mit Erzwinger unter Druck!",
+		"¡@0 ejerce presión!"
+	],
+	"The foe's @0 is exerting its pressure!": [
+		"あいての　@0は プレッシャーを　はなっている！",
+		"Le @0 ennemi augmente la pression!",
+		"@0 nemico esercita pressione!",
+		"@0 (Gegner) setzt Gegner mit Erzwinger unter Druck!",
+		"¡El @0 enemigo ejerce presión!"
+	],
+	"@0 found one @1!": [
+		"@0は @1を　ひろってきた！",
+		"@0 ramasse l'objet: @1!",
+		"@0 ricicla @1!",
+		"@0 hat das Item @1 recycelt!",
+		"¡@0 ha reciclado @1!"
+	],
+	"The foe's @0 found one @1!": [
+		"あいての　@0は @1を　ひろってきた！",
+		"Le @0 ennemi ramasse l'objet: @1!",
+		"@0 nemico ricicla @1!",
+		"@0 (Gegner) hat das Item @1 recycelt!",
+		"¡El @0 enemigo ha reciclado @1!"
+	],
+	"@0's item cannot be stolen!": [
+		"@0の どうぐを　うばえない！",
+		"L'objet de @0 ne peut pas être volé!",
+		"Lo strumento di @0 non può essere rubato!",
+		"@0 konnte kein Item abgenommen werden!",
+		"¡Es imposible robarle objetos a @0!"
+	],
+	"The foe's @0's item cannot be stolen!": [
+		"あいての　@0の どうぐを　うばえない！",
+		"L'objet du @0 ennemi ne peut pas être volé!",
+		"Lo strumento di @0 nemico non può essere rubato!",
+		"@0 (Gegner) konnte kein Item abgenommen werden!",
+		"¡Es imposible robarle objetos al @0 enemigo!"
+	],
+	"@0 can't get it going!": [
+		"@0は ちょうしが　あがらない！",
+		"@0 n'arrive pas à se motiver!",
+		"@0 non ingrana!",
+		"@0 kommt nicht in Fahrt.",
+		"¡@0 no está rindiendo todo lo que podría!"
+	],
+	"The foe's @0 can't get it going!": [
+		"あいての　@0は ちょうしが　あがらない！",
+		"Le @0 ennemi n'arrive pas à se motiver!",
+		"@0 nemico non ingrana!",
+		"@0 (Gegner) kommt nicht in Fahrt.",
+		"¡El @0 enemigo no está rindiendo todo lo que podría!"
+	],
+	"@0 finally got its act together!": [
+		"@0は ちょうしを　とりもどした！",
+		"@0 arrive enfin à s'y mettre sérieusement!",
+		"@0 riordina le idee!",
+		"@0 kriegt schließlich doch noch die Kurve!",
+		"¡@0 vuelve a ir a por todas!"
+	],
+	"The foe's @0 finally got its act together!": [
+		"あいての　@0は ちょうしを　とりもどした！",
+		"Le @0 ennemi arrive enfin à s'y mettre sérieusement!",
+		"@0 nemico riordina le idee!",
+		"@0 (Gegner) kriegt schließlich doch noch die Kurve!",
+		"¡El @0 enemigo vuelve a ir a por todas!"
+	],
+	"@0 is radiating a bursting aura!": [
+		"@0は はじける　オーラを　はなっている！",
+		"@0 dégage une aura électrique instable!",
+		"@0 emana un'aura repulsiva!",
+		"@0 strahlt eine knisternde Aura aus!",
+		"¡@0 desprende un aura chisporroteante!"
+	],
+	"The foe's @0 is radiating a bursting aura!": [
+		"あいての　@0は はじける　オーラを　はなっている！",
+		"Le @0 ennemi dégage une aura électrique instable!",
+		"@0 nemico emana un'aura repulsiva!",
+		"@0 (Gegner) strahlt eine knisternde Aura aus!",
+		"¡El @0 enemigo desprende un aura chisporroteante!"
+	],
+	"@0 is radiating a blazing aura!": [
+		"@0は もえさかる　オーラを　はなっている！",
+		"@0 dégage une aura de flammes incandescentes!",
+		"@0 emana un'aura infuocata!",
+		"@0 strahlt eine lodernde Aura aus!",
+		"¡@0 desprende un aura llameante!"
+	],
+	"The foe's @0 is radiating a blazing aura!": [
+		"あいての　@0は もえさかる　オーラを　はなっている！",
+		"Le @0 ennemi dégage une aura de flammes incandescentes!",
+		"@0 nemico emana un'aura infuocata!",
+		"@0 (Gegner) strahlt eine lodernde Aura aus!",
+		"¡El @0 enemigo desprende un aura llameante!"
+	],
+	"@0 swapped Abilities with its target!": [
+		"@0は おたがいの　とくせいを　いれかえた！",
+		"@0 et sa cible échangent leurs capacités spéciales!",
+		"@0 scambia la sua abilità con l'avversario!",
+		"@0 tauscht Fähigkeiten mit dem Ziel!",
+		"¡@0 ha intercambiado su habilidad con la de su objetivo!"
+	],
+	"The foe's @0 swapped Abilities with its target!": [
+		"あいての　@0は おたがいの　とくせいを　いれかえた！",
+		"Le @0 ennemi et sa cible échangent leurs capacités spéciales!",
+		"@0 nemico scambia la sua abilità con l'avversario!",
+		"@0 (Gegner) tauscht Fähigkeiten mit dem Ziel!",
+		"¡El @0 enemigo ha intercambiado su habilidad con la de su objetivo!"
+	],
+	"@0 braced itself!": [
+		"@0は こらえる　たいせいに　はいった！",
+		"@0 se prépare à encaisser les coups!",
+		"@0 si rinvigorisce!",
+		"@0 macht sich bereit!",
+		"¡@0 se ha fortalecido!"
+	],
+	"The foe's @0 braced itself!": [
+		"あいての　@0は こらえる　たいせいに　はいった！",
+		"Le @0 ennemi se prépare à encaisser les coups!",
+		"@0 nemico si rinvigorisce!",
+		"@0 (Gegner) macht sich bereit!",
+		"¡El @0 enemigo se ha fortalecido!"
+	],
+	"@0 endured the hit!": [
+		"@0は こうげきを　こらえた！",
+		"@0 encaisse les coups!",
+		"@0 sopporta il colpo!",
+		"@0 übersteht die Attacke!",
+		"¡@0 ha aguantado el golpe!"
+	],
+	"The foe's @0 endured the hit!": [
+		"あいての　@0は こうげきを　こらえた！",
+		"Le @0 ennemi encaisse les coups!",
+		"@0 nemico sopporta il colpo!",
+		"@0 (Gegner) übersteht die Attacke!",
+		"¡El @0 enemigo ha aguantado el golpe!"
+	],
+	"@0 protected itself!": [
+		"@0は こうげきから　みを　まもった！",
+		"@0 se protège!",
+		"@0 si protegge!",
+		"@0 schützt sich selbst!",
+		"¡@0 se ha protegido!"
+	],
+	"The foe's @0 protected itself!": [
+		"あいての　@0は こうげきから　みを　まもった！",
+		"Le @0 ennemi se protège!",
+		"@0 nemico si protegge!",
+		"@0 (Gegner) schützt sich selbst!",
+		"¡El @0 enemigo se ha protegido!"
+	],
+	"It broke through @0's protection!": [
+		"@0の まもりを　うちやぶった！",
+		"Ça transperce la protection de @0!",
+		"La protezione di @0 è stata infranta!",
+		"Es durchbrach den Schutz von @0!",
+		"¡Ha eliminado la protección de @0!"
+	],
+	"It broke through the foe's @0's protection!": [
+		"あいての　@0の まもりを　うちやぶった！",
+		"Ça transperce la protection du @0 ennemi!",
+		"La protezione di @0 nemico è stata infranta!",
+		"Es durchbrach den Schutz von @0 (Gegner)!",
+		"¡Ha eliminado la protección del @0 enemigo!"
+	],
+	"@0 fell for the feint!": [
+		"@0は フェイントに　ひっかかった！",
+		"@0 succombe à la Ruse!",
+		"Fintoattacco inganna @0!",
+		"@0 ist auf die Offenlegung hereingefallen!",
+		"¡@0 se ha dejado engañar por Amago!"
+	],
+	"The foe's @0 fell for the feint!": [
+		"あいての　@0は フェイントに　ひっかかった！",
+		"Le @0 ennemi succombe à la Ruse!",
+		"Fintoattacco inganna @0 nemico!",
+		"@0 (Gegner) ist auf die Offenlegung hereingefallen!",
+		"¡El @0 enemigo se ha dejado engañar por Amago!"
+	],
+	"@0 flew up high!": [
+		"@0は そらたかく　とびあがった！",
+		"@0 s'envole!",
+		"@0 vola in alto!",
+		"@0 fliegt hoch empor!",
+		"¡@0 ha volado muy alto!"
+	],
+	"The foe's @0 flew up high!": [
+		"あいての　@0は そらたかく　とびあがった！",
+		"Le @0 ennemi s'envole!",
+		"@0 nemico vola in alto!",
+		"@0 (Gegner) fliegt hoch empor!",
+		"¡El @0 enemigo ha volado muy alto!"
+	],
+	"@0's rage is building!": [
+		"@0の いかりのボルテージが　あがっていく！",
+		"La Frénésie de @0 augmente!",
+		"Cresce l'ira di @0!",
+		"@0 verfällt in Raserei!",
+		"¡La furia de @0 está aumentando!"
+	],
+	"The foe's @0's rage is building!": [
+		"あいての　@0の いかりのボルテージが　あがっていく！",
+		"La Frénésie du @0 ennemi augmente!",
+		"Cresce l'ira di @0 nemico!",
+		"@0 (Gegner) verfällt in Raserei!",
+		"¡La furia del @0 enemigo está aumentando!"
+	],
+	"@0 hid underwater!": [
+		"@0は すいちゅうに　みをひそめた！",
+		"@0 se cache sous l'eau!",
+		"@0 sparisce sott'acqua!",
+		"@0 taucht unter!",
+		"¡@0 se ha ocultado bajo el agua!"
+	],
+	"The foe's @0 hid underwater!": [
+		"あいての　@0は すいちゅうに　みをひそめた！",
+		"Le @0 ennemi se cache sous l'eau!",
+		"@0 nemico sparisce sott'acqua!",
+		"@0 (Gegner) taucht unter!",
+		"¡El @0 enemigo se ha ocultado bajo el agua!"
+	],
+	"@0 burrowed its way under the ground!": [
+		"@0は じめんに　もぐった！",
+		"@0 se cache dans le sol!",
+		"@0 si nasconde sottoterra!",
+		"@0 vergräbt sich in der Erde!",
+		"¡@0 se ha ocultado bajo tierra!"
+	],
+	"The foe's @0 burrowed its way under the ground!": [
+		"あいての　@0は じめんに　もぐった！",
+		"Le @0 ennemi se cache dans le sol!",
+		"@0 nemico si nasconde sottoterra!",
+		"@0 (Gegner) vergräbt sich in der Erde!",
+		"¡El @0 enemigo se ha ocultado bajo tierra!"
+	],
+	"@0 vanished instantly!": [
+		"@0のすがたが いっしゅんにして　きえた！",
+		"@0 a disparu instantanément!",
+		"@0 sparisce all'istante!",
+		"@0 verschwand augenblicklich!",
+		"¡@0 ha desaparecido en un abrir y cerrar de ojos!"
+	],
+	"The foe's @0 vanished instantly!": [
+		"あいての　@0のすがたが いっしゅんにして　きえた！",
+		"Le @0 ennemi a disparu instantanément!",
+		"@0 nemico sparisce all'istante!",
+		"@0 (Gegner) verschwand augenblicklich!",
+		"¡El @0 enemigo ha desaparecido en un abrir y cerrar de ojos!"
+	],
+	"@0 sprang up!": [
+		"@0は たかく　とびはねた！",
+		"@0 se propulse dans les airs!",
+		"@0 salta in alto!",
+		"@0 springt hoch in die Luft!",
+		"¡@0 ha saltado muy alto!"
+	],
+	"The foe's @0 sprang up!": [
+		"あいての　@0は たかく　とびはねた！",
+		"Le @0 ennemi se propulse dans les airs!",
+		"@0 nemico salta in alto!",
+		"@0 (Gegner) springt hoch in die Luft!",
+		"¡El @0 enemigo ha saltado muy alto!"
+	],
+	"@0 whipped up a whirlwind!": [
+		"@0の　まわりで くうきが　うずをまく！",
+		"@0 déclenche un cyclone!",
+		"@0 genera un turbine!",
+		"@0 entfacht einen Wirbelwind!",
+		"¡@0 ha provocado un remolino!"
+	],
+	"The foe's @0 whipped up a whirlwind!": [
+		"あいての　@0の　まわりで くうきが　うずをまく！",
+		"Le @0 ennemi déclenche un cyclone!",
+		"@0 nemico genera un turbine!",
+		"@0 (Gegner) entfacht einen Wirbelwind!",
+		"¡El @0 enemigo ha provocado un remolino!"
+	],
+	"@0 became cloaked in a harsh light!": [
+		"@0を はげしい　ひかりが　つつむ！",
+		"@0 est entouré d'une lumière intense!",
+		"@0 è avvolto da una luce intensa!",
+		"@0 leuchtet grell!",
+		"¡@0 está rodeado de una luz brillante!"
+	],
+	"The foe's @0 became cloaked in a harsh light!": [
+		"あいての　@0を はげしい　ひかりが　つつむ！",
+		"Le @0 ennemi est entouré d'une lumière intense!",
+		"@0 nemico è avvolto da una luce intensa!",
+		"@0 (Gegner) leuchtet grell!",
+		"¡El @0 enemigo está rodeado de una luz brillante!"
+	],
+	"@0 absorbed light!": [
+		"@0は ひかりを　きゅうしゅうした！",
+		"@0 absorbe la lumière!",
+		"@0 assorbe la luce!",
+		"@0 absorbiert Sonnenlicht!",
+		"¡@0 ha absorbido luz solar!"
+	],
+	"The foe's @0 absorbed light!": [
+		"あいての　@0は ひかりを　きゅうしゅうした！",
+		"Le @0 ennemi absorbe la lumière!",
+		"@0 nemico assorbe la luce!",
+		"@0 (Gegner) absorbiert Sonnenlicht!",
+		"¡El @0 enemigo ha absorbido luz solar!"
+	],
+	"@0 tucked in its head!": [
+		"@0は くびを　ひっこめた！",
+		"@0 baisse la tête!",
+		"@0 abbassa la testa!",
+		"@0 zieht seinen Kopf ein!",
+		"¡@0 ha agachado la cabeza!"
+	],
+	"The foe's @0 tucked in its head!": [
+		"あいての　@0は くびを　ひっこめた！",
+		"Le @0 ennemi baisse la tête!",
+		"@0 nemico abbassa la testa!",
+		"@0 (Gegner) zieht seinen Kopf ein!",
+		"¡El @0 enemigo ha agachado la cabeza!"
+	],
+	"@0 received an encore!": [
+		"@0は アンコールをうけた！",
+		"@0! Encore une fois!",
+		"@0 è colpito da Ripeti!",
+		"@0 gibt eine Zugabe!",
+		"¡@0 ha sufrido los efectos de Otra Vez!"
+	],
+	"The foe's @0 received an encore!": [
+		"あいての　@0は アンコールをうけた！",
+		"@0 ennemi! Encore une fois!",
+		"@0 nemico è colpito da Ripeti!",
+		"@0 (Gegner) gibt eine Zugabe!",
+		"¡El @0 enemigo ha sufrido los efectos de Otra Vez!"
+	],
+	"@0's encore ended!": [
+		"@0の アンコールじょうたいが　とけた！",
+		"@0 n'a plus à répéter la même capacité!",
+		"Termina l'effetto di Ripeti su @0!",
+		"Zugabe von @0 ist beendet!",
+		"¡Otra Vez ya no surte efecto en @0!"
+	],
+	"The foe's @0's encore ended!": [
+		"あいての　@0の アンコールじょうたいが　とけた！",
+		"Le @0 ennemi n'a plus à répéter la même capacité!",
+		"Termina l'effetto di Ripeti su @0 nemico!",
+		"Zugabe von @0 (Gegner) ist beendet!",
+		"¡Otra Vez ya no surte efecto en el @0 enemigo!"
+	],
+	"@0's Ability was suppressed!": [
+		"@0の とくせいが　きかなくなった！",
+		"La capacité spéciale de @0 ne fait plus effet!",
+		"L'abilità di @0 perde ogni efficacia!",
+		"Die Fähigkeit von @0 wurde unterdrückt!",
+		"¡Se ha suprimido la habilidad de @0!"
+	],
+	"The foe's @0's Ability was suppressed!": [
+		"あいての　@0の とくせいが　きかなくなった！",
+		"La capacité spéciale du @0 ennemi ne fait plus effet!",
+		"L'abilità di @0 nemico perde ogni efficacia!",
+		"Die Fähigkeit von @0 (Gegner) wurde unterdrückt!",
+		"¡Se ha suprimido la habilidad del @0 enemigo!"
+	],
+	"@0 fell for the taunt!": [
+		"@0は ちょうはつに　のってしまった！",
+		"@0 répond à la Provoc!",
+		"@0 è in balia di Provocazione!",
+		"@0 fällt auf Verhöhner herein!",
+		"¡@0 se ha dejado engañar por una mofa!"
+	],
+	"The foe's @0 fell for the taunt!": [
+		"あいての　@0は ちょうはつに　のってしまった！",
+		"Le @0 ennemi répond à la Provoc!",
+		"@0 nemico è in balia di Provocazione!",
+		"@0 (Gegner) fällt auf Verhöhner herein!",
+		"¡El @0 enemigo se ha dejado engañar por una mofa!"
+	],
+	"@0 can't use @1 after the taunt!": [
+		"@0は　ちょうはつ されて　@1が　だせない！",
+		"@0 ne peut pas utiliser @1 après Provoc!",
+		"A causa di Provocazione @0 non può usare @1!",
+		"@0 kann @1 nach Verhöhner nicht einsetzen!",
+		"¡@0 no puede usar @1 debido a la mofa!"
+	],
+	"The foe's @0 can't use @1 after the taunt!": [
+		"あいての　@0は　ちょうはつ されて　@1が　だせない！",
+		"Le @0 ennemi ne peut pas utiliser @1 après Provoc!",
+		"A causa di Provocazione @0 nemico non può usare @1!",
+		"@0 (Gegner) kann @1 nach Verhöhner nicht einsetzen!",
+		"¡El @0 enemigo no puede usar @1 debido a la mofa!"
+	],
+	"@0's taunt wore off!": [
+		"@0は ちょうはつの　こうかが　とけた！",
+		"@0 a oublié la Provoc!",
+		"Provocazione non ha più effetto su @0!",
+		"Verhöhner von @0 lässt nach!",
+		"¡Se ha pasado el efecto de Mofa en @0!"
+	],
+	"The foe's @0's taunt wore off!": [
+		"あいての　@0は ちょうはつの　こうかが　とけた！",
+		"Le @0 ennemi a oublié la Provoc!",
+		"Provocazione non ha più effetto su @0 nemico!",
+		"Verhöhner von @0 (Gegner) lässt nach!",
+		"¡Se ha pasado el efecto de Mofa en el @0 enemigo!"
+	],
+	"@0 was subjected to torment!": [
+		"@0は いちゃもんを　つけられた！",
+		"@0 est tourmenté!",
+		"@0 subisce Attaccalite!",
+		"@0 wird von Folterknecht unterworfen!",
+		"¡@0 es víctima de Tormento!"
+	],
+	"The foe's @0 was subjected to torment!": [
+		"あいての　@0は いちゃもんを　つけられた！",
+		"Le @0 ennemi est tourmenté!",
+		"@0 nemico subisce Attaccalite!",
+		"@0 (Gegner) wird von Folterknecht unterworfen!",
+		"¡El @0 enemigo es víctima de Tormento!"
+	],
+	"@0 can't use the same move twice in a row due to the torment!": [
+		"@0は いちゃもんを　つけられたので つづけて　おなじ　わざが　だせない！",
+		"Tourmenté, @0 ne peut pas utiliser une capacité deux fois de suite!",
+		"Attaccalite impedisce a @0 di sferrare la stessa mossa più volte di fila!",
+		"@0 kann aufgrund von Folterknecht die Attacke nicht 2-mal hintereinander einsetzen!",
+		"¡@0 no puede usar el mismo movimiento dos veces seguidas debido a Tormento!"
+	],
+	"The foe's @0 can't use the same move twice in a row due to the torment!": [
+		"あいての　@0は いちゃもんを　つけられたので つづけて　おなじ　わざが　だせない！",
+		"Tourmenté, le @0 ennemi ne peut pas utiliser une capacité deux fois de suite!",
+		"Attaccalite impedisce a @0 nemico di sferrare la stessa mossa più volte di fila!",
+		"@0 (Gegner) kann aufgrund von Folterknecht die Attacke nicht 2-mal hintereinander einsetzen!",
+		"¡El @0 enemigo no puede usar el mismo movimiento dos veces seguidas debido a Tormento!"
+	],
+	"@0's torment wore off!": [
+		"@0の いちゃもんの　こうかが　きれた！",
+		"Les tourments de @0 sont apaisés!",
+		"L'effetto di Attaccalite è terminato per @0!",
+		"Folterknecht von @0 hört auf zu wirken!",
+		"¡Se ha disipado el efecto de Tormento en @0!"
+	],
+	"The foe's @0's torment wore off!": [
+		"あいての　@0の いちゃもんの　こうかが　きれた！",
+		"Les tourments du @0 ennemi sont apaisés!",
+		"L'effetto di Attaccalite è terminato per @0 nemico!",
+		"Folterknecht von @0 (Gegner) hört auf zu wirken!",
+		"¡Se ha disipado el efecto de Tormento en el @0 enemigo!"
+	],
+	"@0 sealed the opponent's move(s)!": [
+		"@0は あいての　わざを　ふういんした！",
+		"@0 bloque les capacités en commun avec l'adversaire!",
+		"@0 blocca una o più mosse dell'avversario!",
+		"@0 versiegelt die Attacke(n) des gegnerischen Teams!",
+		"¡@0 ha sellado movimientos del oponente!"
+	],
+	"The foe's @0 sealed the opponent's move(s)!": [
+		"あいての　@0は あいての　わざを　ふういんした！",
+		"Le @0 ennemi bloque les capacités en commun avec l'adversaire!",
+		"@0 nemico blocca una o più mosse dell'avversario!",
+		"@0 (Gegner) versiegelt die Attacke(n) des gegnerischen Teams!",
+		"¡El @0 enemigo ha sellado movimientos del oponente!"
+	],
+	"@0 can't use the sealed @1!": [
+		"@0は ふういんで @1が　だせない！",
+		"@0 ne peut pas utiliser la capacité bloquée @1!",
+		"@0 non può usare la mossa @1: è bloccata!",
+		"@0 kann die versiegelte Attacke @1 nicht einsetzen!",
+		"¡@0 no puede usar @1 porque está sellado!"
+	],
+	"The foe's @0 can't use the sealed @1!": [
+		"あいての　@0は ふういんで @1が　だせない！",
+		"Le @0 ennemi ne peut pas utiliser la capacité bloquée @1!",
+		"@0 nemico non può usare la mossa @1: è bloccata!",
+		"@0 (Gegner) kann die versiegelte Attacke @1 nicht einsetzen!",
+		"¡El @0 enemigo no puede usar @1 porque está sellado!"
+	],
+	"@0's @1 was disabled!": [
+		"@0の @1を　ふうじこめた！",
+		"La capacité @1 de @0 est mise sous Entrave!",
+		"Inibitore ha messo fuori uso @1 di @0!",
+		"@1 von @0 wurde blockiert!",
+		"¡El movimiento @1 de @0 ha sido desactivado!"
+	],
+	"The foe's @0's @1 was disabled!": [
+		"あいての　@0の @1を　ふうじこめた！",
+		"La capacité @1 du @0 ennemi est mise sous Entrave!",
+		"Inibitore ha messo fuori uso @1 di @0 nemico!",
+		"@1 von @0 (Gegner) wurde blockiert!",
+		"¡El movimiento @1 del @0 enemigo ha sido desactivado!"
+	],
+	"@0's @1 is disabled!": [
+		"@0は　かなしばりで @1が　だせない！",
+		"Il y a une Entrave sur @1 de @0!",
+		"A causa di Inibitore, @1 di @0 è fuori uso!",
+		"@1 von @0 ist blockiert!",
+		"¡@0 no puede usar @1 porque ha sido anulado!"
+	],
+	"The foe's @0's @1 is disabled!": [
+		"あいての　@0は　かなしばりで @1が　だせない！",
+		"Il y a une Entrave sur @1 du @0 ennemi!",
+		"A causa di Inibitore, @1 di @0 nemico è fuori uso!",
+		"@1 von @0 (Gegner) ist blockiert!",
+		"¡El @0 enemigo no puede usar @1 porque ha sido anulado!"
+	],
+	"@0 is no longer disabled!": [
+		"@0の かなしばりが　とけた！",
+		"@0 n'est plus sous Entrave!",
+		"Termina l'effetto di Inibitore su @0!",
+		"@0 ist nicht mehr blockiert!",
+		"¡@0 se ha liberado de Anulación!"
+	],
+	"The foe's @0 is no longer disabled!": [
+		"あいての　@0の かなしばりが　とけた！",
+		"Le @0 ennemi n'est plus sous Entrave!",
+		"Termina l'effetto di Inibitore su @0 nemico!",
+		"@0 (Gegner) ist nicht mehr blockiert!",
+		"¡El @0 enemigo se ha liberado de Anulación!"
+	],
+	"@0 surrounded itself with a veil of water!": [
+		"@0は みずのリングを　まとった！",
+		"@0 s'entoure d'un voile d'eau!",
+		"Un velo d'acqua avvolge @0!",
+		"@0 umgibt sich mit einem Wasserring!",
+		"¡@0 se ha rodeado de un manto de agua!"
+	],
+	"The foe's @0 surrounded itself with a veil of water!": [
+		"あいての　@0は みずのリングを　まとった！",
+		"Le @0 ennemi s'entoure d'un voile d'eau!",
+		"Un velo d'acqua avvolge @0 nemico!",
+		"@0 (Gegner) umgibt sich mit einem Wasserring!",
+		"¡El @0 enemigo se ha rodeado de un manto de agua!"
+	],
+	"Aqua Ring restored @0's HP!": [
+		"@0は みずのリングで　たいりょくを　かいふく！",
+		"Le voile d'eau restaure les PV de @0!",
+		"Un velo d'acqua fa recuperare Punti Salute a @0!",
+		"Der Wasserring stellt KP von @0 wieder her!",
+		"¡Un manto de agua ha restaurado PS de @0!"
+	],
+	"Aqua Ring restored the foe's @0's HP!": [
+		"あいての　@0は みずのリングで　たいりょくを　かいふく！",
+		"Le voile d'eau restaure les PV du @0 ennemi!",
+		"Un velo d'acqua fa recuperare Punti Salute a @0 nemico!",
+		"Der Wasserring stellt KP von @0 (Gegner) wieder her!",
+		"¡Un manto de agua ha restaurado PS del @0 enemigo!"
+	],
+	"@0 was seeded!": [
+		"@0に たねを　うえつけた！",
+		"@0 est infecté!",
+		"@0 è pieno di semi!",
+		"@0 wurde bepflanzt!",
+		"¡@0 ha sido infectado!"
+	],
+	"The foe's @0 was seeded!": [
+		"あいての　@0に たねを　うえつけた！",
+		"Le @0 ennemi est infecté!",
+		"@0 nemico è pieno di semi!",
+		"@0 (Gegner) wurde bepflanzt!",
+		"¡El @0 enemigo ha sido infectado!"
+	],
+	"@0's health is sapped by Leech Seed!": [
+		"やどりぎが　@0の たいりょくを　うばう！",
+		"Vampigraine draine l'énergie de @0!",
+		"Parassiseme sottrae energia a @0!",
+		"Egelsamen schadet @0!",
+		"¡El movimiento Drenadoras ha restado salud a @0!"
+	],
+	"The foe's @0's health is sapped by Leech Seed!": [
+		"やどりぎが　あいての　@0の たいりょくを　うばう！",
+		"Vampigraine draine l'énergie du @0 ennemi!",
+		"Parassiseme sottrae energia a @0 nemico!",
+		"Egelsamen schadet @0 (Gegner)!",
+		"¡El movimiento Drenadoras ha restado salud al @0 enemigo!"
+	],
+	"@0 cut its own HP and maximized its Attack!": [
+		"@0は たいりょくを　けずって　パワーぜんかい！",
+		"@0 sacrifie ses PV et monte son Attaque au maximum!",
+		"@0 riduce i suoi Punti Salute e aumenta al massimo il suo Attacco!",
+		"@0 nutzt seine KP und hebt den Angriffs-Wert!",
+		"¡@0 ha reducido sus PS y ha mejorado su Ataque!"
+	],
+	"The foe's @0 cut its own HP and maximized its Attack!": [
+		"あいての　@0は たいりょくを　けずって　パワーぜんかい！",
+		"Le @0 ennemi sacrifie ses PV et monte son Attaque au maximum!",
+		"@0 nemico riduce i suoi Punti Salute e aumenta al massimo il suo Attacco!",
+		"@0 (Gegner) nutzt seine KP und hebt den Angriffs-Wert!",
+		"¡El @0 enemigo ha reducido sus PS y ha mejorado su Ataque!"
+	],
+	"@0 is tightening its focus!": [
+		"@0は しゅうちゅうりょくを　たかめている！",
+		"@0 se concentre davantage!",
+		"@0 si concentra al massimo!",
+		"@0 verstärkt seinen Fokus!",
+		"¡@0 está reforzando su concentración!"
+	],
+	"The foe's @0 is tightening its focus!": [
+		"あいての　@0は しゅうちゅうりょくを　たかめている！",
+		"Le @0 ennemi se concentre davantage!",
+		"@0 nemico si concentra al massimo!",
+		"@0 (Gegner) verstärkt seinen Fokus!",
+		"¡El @0 enemigo está reforzando su concentración!"
+	],
+	"@0 copied @1's @2!": [
+		"@0は　@1の @2を　コピーした！",
+		"@0 copie @2 de @1!",
+		"@0 copia @2 di @1!",
+		"@0 kopiert @2 von @1!",
+		"¡@0 ha copiado @2 de @1!"
+	],
+	"@0 copied the foe's @1's @2!": [
+		"@0は　あいての　@1の @2を　コピーした！",
+		"@0 copie @2 du @1 ennemi!",
+		"@0 copia @2 di @1 nemico!",
+		"@0 kopiert @2 von @1 (Gegner)!",
+		"¡@0 ha copiado @2 del @1 enemigo!"
+	],
+	"The foe's @0 copied @1's @2!": [
+		"あいての　@0は　@1の @2を　コピーした！",
+		"Le @0 ennemi copie @2 de @1!",
+		"@0 nemico copia @2 di @1!",
+		"@0 (Gegner) kopiert @2 von @1!",
+		"¡El @0 enemigo ha copiado @2 de @1!"
+	],
+	"The foe's @0 copied the foe's @1's @2!": [
+		"あいての　@0は あいての　@1の @2を　コピーした！",
+		"Le @0 ennemi copie @2 du @1 ennemi!",
+		"@0 nemico copia @2 di @1 nemico!",
+		"@0 (Gegner) kopiert @2 von @1 (Gegner)!",
+		"¡El @0 enemigo ha copiado @2 del @1 enemigo!"
+	],
+	"@0 is trying to take its foe down with it!": [
+		"@0は　あいてを みちづれに　しようとしている！",
+		"@0 veut emmener son ennemi au tapis!",
+		"@0 tenta di trascinare con sé l'avversario!",
+		"@0 versucht, den Gegner mit sich zu nehmen!",
+		"¡@0 intenta llevarse a su rival!"
+	],
+	"The foe's @0 is trying to take its foe down with it!": [
+		"あいての　@0は　あいてを みちづれに　しようとしている！",
+		"Le @0 ennemi veut emmener son ennemi au tapis!",
+		"@0 nemico tenta di trascinare con sé l'avversario!",
+		"@0 (Gegner) versucht, den Gegner mit sich zu nehmen!",
+		"¡El @0 enemigo intenta llevarse a su rival!"
+	],
+	"@0 took its attacker down with it!": [
+		"@0は　あいてを みちづれに　した！",
+		"@0 emmène son adversaire au tapis!",
+		"@0 trascina con sé l'avversario.",
+		"@0 nimmt den Gegner mit sich!",
+		"¡@0 se ha llevado a su rival!"
+	],
+	"The foe's @0 took its attacker down with it!": [
+		"あいての　@0は　あいてを みちづれに　した！",
+		"Le @0 ennemi emmène son adversaire au tapis!",
+		"@0 nemico trascina con sé l'avversario.",
+		"@0 (Gegner) nimmt den Gegner mit sich!",
+		"¡El @0 enemigo se ha llevado a su rival!"
+	],
+	"@0 wants its target to bear a grudge!": [
+		"@0は　あいてに おんねんを　かけようとしている！",
+		"@0 veut que son adversaire subisse sa Rancune!",
+		"@0 serba rancore all'avversario!",
+		"@0 möchte, dass der Gegner ein Nachspiel erträgt!",
+		"¡@0 quiere que el rival sufra su rabia!"
+	],
+	"The foe's @0 wants its target to bear a grudge!": [
+		"あいての　@0は　あいてに おんねんを　かけようとしている！",
+		"Le @0 ennemi veut que son adversaire subisse sa Rancune!",
+		"@0 nemico serba rancore all'avversario!",
+		"@0 (Gegner) möchte, dass der Gegner ein Nachspiel erträgt!",
+		"¡El @0 enemigo quiere que el rival sufra su rabia!"
+	],
+	"@0's @1 lost all its PP due to the grudge!": [
+		"@0の @1は おんねんで　ＰＰが０になった！",
+		"@1 de @0 perd ses PP à cause de la Rancune!",
+		"@1 di @0 perde tutti i Punti Potenza a causa di Rancore!",
+		"@1 von @0 hat aufgrund von Nachspiel alle AP verloren!",
+		"¡Rabia ha hecho que el movimiento @1 de @0 se quede sin PP!"
+	],
+	"The foe's @0's @1 lost all its PP due to the grudge!": [
+		"あいての　@0の @1は おんねんで　ＰＰが０になった！",
+		"@1 du @0 ennemi perd ses PP à cause de la Rancune!",
+		"@1 di @0 nemico perde tutti i Punti Potenza a causa di Rancore!",
+		"@1 von @0 (Gegner) hat aufgrund von Nachspiel alle AP verloren!",
+		"¡Rabia ha hecho que el movimiento @1 del @0 enemigo se quede sin PP!"
+	],
+	"@0 slept and became healthy!": [
+		"@0は　ねむって げんきに　なった！",
+		"@0 se sent mieux en dormant!",
+		"@0 ha recuperato le energie durante il sonno!",
+		"@0 hat im Schlaf Energie getankt!",
+		"¡@0 duerme y se recupera!"
+	],
+	"The foe's @0 slept and became healthy!": [
+		"あいての　@0は　ねむって げんきに　なった！",
+		"Le @0 ennemi se sent mieux en dormant!",
+		"@0 nemico ha recuperato le energie durante il sonno!",
+		"@0 (Gegner) hat im Schlaf Energie getankt!",
+		"¡El @0 enemigo duerme y se recupera!"
+	],
+	"It reduced the PP of @0's @1 by @2!": [
+		"@0の @1を　@2けずった！",
+		"Les PP de @1 de @0 baissent de @2!",
+		"@1 di @0 cala di @2 Punti Potenza!",
+		"@1 von @0 wird um @2 AP reduziert!",
+		"¡Ha reducido @2 PP del movimiento @1 de @0!"
+	],
+	"It reduced the PP of the foe's @0's @1 by @2!": [
+		"あいての　@0の @1を　@2けずった！",
+		"Les PP de @1 du @0 ennemi baissent de @2!",
+		"@1 di @0 nemico cala di @2 Punti Potenza!",
+		"@1 von @0 (Gegner) wird um @2 AP reduziert!",
+		"¡Ha reducido @2 PP del movimiento @1 del @0 enemigo!"
+	],
+	"@0 transformed into @1!": [
+		"@0は @1に　へんしんした！",
+		"@0 prend l'apparence de @1!",
+		"@0 si trasforma in @1!",
+		"@0 verwandelt sich in @1!",
+		"¡@0 se ha transformado en @1!"
+	],
+	"@0 transformed into the foe's @1!": [
+		"@0は あいての　@1に　へんしんした！",
+		"@0 prend l'apparence du @1 ennemi!",
+		"@0 si trasforma in @1 nemico!",
+		"@0 verwandelt sich in @1 (Gegner)!",
+		"¡@0 se ha transformado en el @1 enemigo!"
+	],
+	"The foe's @0 transformed into @1!": [
+		"あいての　@0は @1に　へんしんした！",
+		"Le @0 ennemi prend l'apparence du @1!",
+		"@0 nemico si trasforma in @1!",
+		"@0 (Gegner) verwandelt sich in @1!",
+		"¡El @0 enemigo se ha transformado en @1!"
+	],
+	"The foe's @0 transformed into the foe's @1!": [
+		"あいての　@0は あいての　@1に　へんしんした！",
+		"Le @0 ennemi prend l'apparence du @1 ennemi!",
+		"@0 nemico si trasforma in @1 nemico!",
+		"@0 (Gegner) verwandelt sich in @1 (Gegner)!",
+		"¡El @0 enemigo se ha transformado en el @1 enemigo!"
+	],
+	"@0 took aim at @1!": [
+		"@0は　@1に ねらいを　さだめた！",
+		"@0 vise @1!",
+		"@0 prende la mira su @1!",
+		"@0 zielt auf @1!",
+		"¡@0 ha apuntado a @1!"
+	],
+	"@0 took aim at the foe's @1!": [
+		"@0は　あいての@1に　 ねらいを　さだめた！",
+		"@0 vise le @1 ennemi!",
+		"@0 prende la mira su @1 nemico!",
+		"@0 zielt auf @1 (Gegner)!",
+		"¡@0 ha apuntado al @1 enemigo!"
+	],
+	"The foe's @0 took aim at @1!": [
+		"あいての　@0は　@1に ねらいを　さだめた！",
+		"Le @0 ennemi vise @1!",
+		"@0 nemico prende la mira su @1!",
+		"@0 (Gegner) zielt auf @1!",
+		"¡El @0 enemigo ha apuntado a @1!"
+	],
+	"The foe's @0 took aim at the foe's @1!": [
+		"あいての　@0は あいての　@1に ねらいを　さだめた！",
+		"Le @0 ennemi vise le @1 ennemi!",
+		"@0 nemico prende la mira su @1 nemico!",
+		"@0 (Gegner) zielt auf @1 (Gegner)!",
+		"¡El @0 enemigo ha apuntado al @1 enemigo!"
+	],
+	"@0 levitated with electromagnetism!": [
+		"@0は でんじりょくで　うかびあがった！",
+		"@0 lévite sur un champ magnétique!",
+		"@0 si solleva in aria a causa dell'elettromagnetismo!",
+		"@0 schwebt aufgrund von Elektromagnetismus!",
+		"¡@0 levita por electromagnetismo!"
+	],
+	"The foe's @0 levitated with electromagnetism!": [
+		"あいての　@0は でんじりょくで　うかびあがった！",
+		"Le @0 ennemi lévite sur un champ magnétique!",
+		"@0 nemico si solleva in aria a causa dell'elettromagnetismo!",
+		"@0 (Gegner) schwebt aufgrund von Elektromagnetismus!",
+		"¡El @0 enemigo levita por electromagnetismo!"
+	],
+	"@0's electromagnetism wore off!": [
+		"@0は でんじりょくが　なくなった！",
+		"Le magnétisme de @0 se dissipe!",
+		"Finito l'effetto dell'elettromagnetismo di @0!",
+		"Der Elektromagnetismus von @0 lässt nach!",
+		"¡El electromagnetismo de @0 ha desaparecido!"
+	],
+	"The electromagnetism of the foe's @0 wore off!": [
+		"あいての　@0は でんじりょくが　なくなった！",
+		"Le magnétisme du @0 ennemi se dissipe!",
+		"Finito l'effetto dell'elettromagnetismo di @0 nemico!",
+		"Der Elektromagnetismus von @0 (Gegner) lässt nach!",
+		"¡El electromagnetismo del @0 enemigo ha desaparecido!"
+	],
+	"@0 began charging power!": [
+		"@0は じゅうでんを　はじめた！",
+		"@0 se met à charger son énergie!",
+		"@0 si carica!",
+		"@0 lädt sich auf!",
+		"¡@0 carga energía!"
+	],
+	"The foe's @0 began charging power!": [
+		"あいての　@0は じゅうでんを　はじめた！",
+		"Le @0 ennemi se met à charger son énergie!",
+		"@0 nemico si carica!",
+		"@0 (Gegner) lädt sich auf!",
+		"¡El @0 enemigo carga energía!"
+	],
+	"@0 grew drowsy!": [
+		"@0の ねむけを　さそった！",
+		"Ça rend @0 somnolent!",
+		"@0 sta per assopirsi!",
+		"@0 wurde schläfrig gemacht!",
+		"¡@0 ha sido adormecido!"
+	],
+	"The foe's @0 grew drowsy!": [
+		"あいての　@0の ねむけを　さそった！",
+		"Ça rend le @0 ennemi somnolent!",
+		"@0 nemico sta per assopirsi!",
+		"@0 (Gegner) wurde schläfrig gemacht!",
+		"¡El @0 enemigo ha sido adormecido!"
+	],
+	"@0 became the center of attention!": [
+		"@0は ちゅうもくの　まとになった！",
+		"@0 devient le centre d'attention!",
+		"@0 è al centro dell'attenzione!",
+		"@0 zieht alle Aufmerksamkeit auf sich!",
+		"¡@0 se ha convertido en el centro de atención!"
+	],
+	"The foe's @0 became the center of attention!": [
+		"あいての　@0は ちゅうもくの　まとになった！",
+		"Le @0 ennemi devient le centre d'attention!",
+		"@0 nemico è al centro dell'attenzione!",
+		"@0 (Gegner) zieht alle Aufmerksamkeit auf sich!",
+		"¡El @0 enemigo se ha convertido en el centro de atención!"
+	],
+	"@0 switched stat changes with the target!": [
+		"@0は　あいてとじぶんの のうりょくへんかを　いれかえた！",
+		"@0 échange les changements de stats avec sa cible!",
+		"@0 scambia le modifiche alle statistiche con il suo bersaglio!",
+		"@0 tauscht die Statusveränderungen mit dem Ziel!",
+		"¡@0 ha intercambiado los cambios de características con el objetivo!"
+	],
+	"The foe's @0 switched stat changes with the target!": [
+		"あいての　@0は　あいてとじぶんの のうりょくへんかを　いれかえた！",
+		"Le @0 ennemi échange les changements de stats avec sa cible!",
+		"@0 nemico scambia le modifiche alle statistiche con il suo bersaglio!",
+		"@0 (Gegner) tauscht die Statusveränderungen mit dem Ziel!",
+		"¡El @0 enemigo ha intercambiado los cambios de características con el objetivo!"
+	],
+	"@0 switched all changes to its Attack and Sp. Atk with the target!": [
+		"@0は　あいてとじぶんの こうげきと　とくこうの のうりょくへんかを　いれかえた！",
+		"@0 échange tous les changements de son Attaque et de son Attaque Spéciale avec sa cible!",
+		"@0 scambia col bersaglio le modifiche ad Attacco e Attacco Speciale!",
+		"@0 tauscht alle Veränderungen seines Angriffs und Spezial-Angriffs mit dem Ziel!",
+		"¡@0 ha intercambiado todos los cambios de Ataque y Ataque Especial con el objetivo!"
+	],
+	"The foe's @0 switched all changes to its Attack and Sp. Atk with the target!": [
+		"あいての　@0は　あいてとじぶんの こうげきと　とくこうの のうりょくへんかを　いれかえた！",
+		"Le @0 ennemi échange tous les changements de son Attaque et de son Attaque Spéciale avec sa cible!",
+		"@0 nemico scambia col bersaglio le modifiche ad Attacco e Attacco Speciale!",
+		"@0 (Gegner) tauscht alle Veränderungen seines Angriffs und Spezial-Angriffs mit dem Ziel!",
+		"¡El @0 enemigo ha intercambiado todos los cambios de Ataque y Ataque Especial con el objetivo!"
+	],
+	"@0 switched all changes to its Defense and Sp. Def with the target!": [
+		"@0は　あいてとじぶんの ぼうぎょと　とくぼうの のうりょくへんかを　いれかえた！",
+		"@0 échange tous les changements de sa Défense et de sa Défense Spéciale avec sa cible!",
+		"@0 scambia col bersaglio tutte le modifiche a Difesa e Difesa Speciale!",
+		"@0 tauscht alle Veränderungen seiner Verteidigung und Spezial-Verteidigung mit dem Ziel!",
+		"¡@0 ha intercambiado todos los cambios de Defensa y Defensa Especial con el objetivo!"
+	],
+	"The foe's @0 switched all changes to its Defense and Sp. Def with the target!": [
+		"あいての　@0は　あいてとじぶんの ぼうぎょと　とくぼうの のうりょくへんかを　いれかえた！",
+		"Le @0 ennemi échange tous les changements de sa Défense et de sa Défense Spéciale avec sa cible!",
+		"@0 nemico scambia col bersaglio tutte le modifiche a Difesa e Difesa Speciale!",
+		"@0 (Gegner) tauscht alle Veränderungen seiner Verteidigung und Spezial-Verteidigung mit dem Ziel!",
+		"¡El @0 enemigo ha intercambiado todos los cambios de Defensa y Defensa Especial con el objetivo!"
+	],
+	"@0 switched items with its target!": [
+		"@0は　おたがいの どうぐを　いれかえた！",
+		"@0 échange son objet avec celui de sa cible!",
+		"@0 scambia lo strumento che ha con quello del bersaglio!",
+		"@0 tauscht Items mit dem Ziel!",
+		"¡@0 ha intercambiado objetos con su objetivo!"
+	],
+	"The foe's @0 switched items with its target!": [
+		"あいての　@0は　おたがいの どうぐを　いれかえた！",
+		"Le @0 ennemi échange son objet avec celui de sa cible!",
+		"@0 nemico scambia lo strumento che ha con quello del bersaglio!",
+		"@0 (Gegner) tauscht Items mit dem Ziel!",
+		"¡El @0 enemigo ha intercambiado objetos con su objetivo!"
+	],
+	"@0 obtained one @1.": [
+		"@0は @1を　てにいれた！",
+		"@0 obtient: @1!",
+		"@0 ottiene @1!",
+		"@0 erhält das Item @1!",
+		"¡@0 ha obtenido @1!"
+	],
+	"The foe's @0 obtained one @1.": [
+		"あいての　@0は @1を　てにいれた！",
+		"Le @0 ennemi obtient: @1!",
+		"@0 nemico ottiene @1!",
+		"@0 (Gegner) erhält das Item @1!",
+		"¡El @0 enemigo ha obtenido @1!"
+	],
+	"@0 learned @1!": [
+		"@0は @1を　おぼえた！",
+		"@0 apprend @1!",
+		"@0 impara @1!",
+		"@0 erlernt @1!",
+		"¡@0 ha aprendido @1!"
+	],
+	"The foe's @0 learned @1!": [
+		"あいての　@0は @1を　おぼえた！",
+		"Le @0 ennemi apprend @1!",
+		"@0 nemico impara @1!",
+		"@0 (Gegner) erlernt @1!",
+		"¡El @0 enemigo ha aprendido @1!"
+	],
+	"@0 sketched @1!": [
+		"@0は @1を　スケッチした！",
+		"@0 gribouille @1!",
+		"@0 disegna uno Schizzo di @1!",
+		"@0 setzt Nachahmer bei @1 ein!",
+		"¡@0 ha usado Esquema en @1!"
+	],
+	"The foe's @0 sketched @1!": [
+		"あいての　@0は @1を　スケッチした！",
+		"Le @0 ennemi gribouille @1!",
+		"@0 nemico disegna uno Schizzo di @1!",
+		"@0 (Gegner) setzt Nachahmer bei @1 ein!",
+		"¡El @0 enemigo ha usado Esquema en @1!"
+	],
+	"@0 became cloaked in mystical moonlight!": [
+		"@0は　しんぴてきな つきの　ひかりに　つつまれた！",
+		"@0 est baigné par des rayons de lune!",
+		"@0 è avvolto dalla luce mistica del chiaro di luna!",
+		"@0 wird in mysteriöses Mondlicht getaucht.",
+		"¡@0 ha quedado envuelto en una mística luz de luna!"
+	],
+	"The foe's @0 became cloaked in mystical moonlight!": [
+		"あいての　@0は　しんぴてきな つきの　ひかりに　つつまれた！",
+		"Le @0 ennemi est baigné par des rayons de lune!",
+		"@0 nemico è avvolto dalla luce mistica del chiaro di luna!",
+		"@0 (Gegner) wird in mysteriöses Mondlicht getaucht.",
+		"¡El @0 enemigo ha quedado envuelto en una mística luz de luna!"
+	],
+	"The healing wish came true for @0!": [
+		"いやしのねがいが @0に　とどいた！",
+		"Le Vœu Soin est exaucé et profite à @0!",
+		"Curardore giova a @0!",
+		"Das Heilopfer erreicht @0!",
+		"¡El deseo de curarse se ha hecho realidad para @0!"
+	],
+	"The healing wish came true for the foe's @0!": [
+		"いやしのねがいが あいての　@0に　とどいた！",
+		"Le Vœu Soin est exaucé et profite au @0 ennemi!",
+		"Curardore giova a @0 nemico!",
+		"Das Heilopfer erreicht @0 (Gegner)!",
+		"¡El deseo de curarse se ha hecho realidad para el @0 enemigo!"
+	],
+	"@0's wish came true!": [
+		"@0の ねがいごとが　かなった！",
+		"Le Vœu de @0 se réalise!",
+		"Il desiderio di @0 si avvera!",
+		"Wunschtraum von @0 erfüllt sich!",
+		"¡El deseo de @0 se ha hecho realidad!"
+	],
+	"The foe's @0's wish came true!": [
+		"あいての　@0の ねがいごとが　かなった！",
+		"Le Vœu du @0 ennemi se réalise!",
+		"Il desiderio di @0 nemico si avvera!",
+		"Wunschtraum von @0 (Gegner) erfüllt sich!",
+		"¡El deseo del @0 enemigo se ha hecho realidad!"
+	],
+	"@0 caused an uproar!": [
+		"@0は さわぎだした！",
+		"@0 provoque un Brouhaha!",
+		"@0 scatena una baraonda!",
+		"@0 verursacht Aufruhr!",
+		"¡@0 ha montado un alboroto!"
+	],
+	"The foe's @0 caused an uproar!": [
+		"あいての　@0は さわぎだした！",
+		"Le @0 ennemi provoque un Brouhaha!",
+		"@0 nemico scatena una baraonda!",
+		"@0 (Gegner) verursacht Aufruhr!",
+		"¡El @0 enemigo ha montado un alboroto!"
+	],
+	"The uproar woke up the @0!": [
+		"@0は さわがしくて　めが　さめた！",
+		"@0 est réveillé par le Brouhaha!",
+		"@0 si sveglia a causa di Baraonda!",
+		"@0 wird durch Aufruhr wach!",
+		"¡Alboroto ha despertado a @0!"
+	],
+	"The uproar woke up the foe's @0!": [
+		"あいての　@0は さわがしくて　めが　さめた！",
+		"Le @0 ennemi est réveillé par le Brouhaha!",
+		"@0 nemico si sveglia a causa di Baraonda!",
+		"@0 (Gegner) wird durch Aufruhr wach!",
+		"¡Alboroto ha despertado al @0 enemigo!"
+	],
+	"But the uproar kept @0 awake!": [
+		"しかし　@0は さわがしくて　ねむれない！",
+		"Mais le Brouhaha tient @0 éveillé!",
+		"Ma Baraonda tiene @0 sveglio!",
+		"Aber der Aufruhr hält @0 wach!",
+		"¡Pero el alboroto ha mantenido despierto a @0!"
+	],
+	"But the uproar kept the foe's @0 awake!": [
+		"しかし　あいての　@0は さわがしくて　ねむれない！",
+		"Mais le Brouhaha tient le @0 ennemi éveillé!",
+		"Ma Baraonda tiene @0 nemico sveglio!",
+		"Aber der Aufruhr hält @0 (Gegner) wach!",
+		"¡Pero el alboroto ha mantenido despierto al @0 enemigo!"
+	],
+	"But @0 can't sleep in an uproar!": [
+		"しかし　@0は さわいでいて　ねむれない！",
+		"Mais son Brouhaha empêche @0 de dormir!",
+		"Ma @0 non riesce a dormire con Baraonda!",
+		"@0 kann bei dem Aufruhr nicht schlafen!",
+		"¡Pero @0 no puede dormir con tanto alboroto!"
+	],
+	"But the foe's @0 can't sleep in an uproar!": [
+		"しかし　あいての　@0は さわいでいて　ねむれない！",
+		"Mais son Brouhaha empêche le @0 ennemi de dormir!",
+		"Ma @0 nemico non riesce a dormire con Baraonda!",
+		"@0 (Gegner) kann bei dem Aufruhr nicht schlafen!",
+		"¡Pero el @0 enemigo no puede dormir con tanto alboroto!"
+	],
+	"@0 is making an uproar!": [
+		"@0は さわいでいる！",
+		"@0 continue son Brouhaha!",
+		"@0 continua con Baraonda!",
+		"@0 ist in Aufruhr!",
+		"¡@0 está alborotado!"
+	],
+	"The foe's @0 is making an uproar!": [
+		"あいての　@0は さわいでいる！",
+		"Le @0 ennemi continue son Brouhaha!",
+		"@0 nemico continua con Baraonda!",
+		"@0 (Gegner) ist in Aufruhr!",
+		"¡El @0 enemigo está alborotado!"
+	],
+	"@0 calmed down.": [
+		"@0は おとなしくなった！",
+		"@0 se calme.",
+		"@0 si calma.",
+		"@0 beruhigt sich.",
+		"@0 se ha tranquilizado."
+	],
+	"The foe's @0 calmed down.": [
+		"あいての　@0は おとなしくなった！",
+		"Le @0 ennemi se calme.",
+		"@0 nemico si calma.",
+		"@0 (Gegner) beruhigt sich.",
+		"El @0 enemigo se ha tranquilizado."
+	],
+	"@0 stockpiled @1!": [
+		"@0は @1つ　たくわえた！",
+		"@0 utilise Stockage @1 fois!",
+		"@0 ha usato Accumulo la @1ª volta!",
+		"@0 hortet @1!",
+		"¡@0 ha reservado @1!"
+	],
+	"The foe's @0 stockpiled @1!": [
+		"あいての　@0は @1つ　たくわえた！",
+		"Le @0 ennemi utilise Stockage @1 fois!",
+		"@0 nemico ha usato Accumulo la @1ª volta!",
+		"@0 (Gegner) hortet @1!",
+		"¡El @0 enemigo ha reservado @1!"
+	],
+	"@0's stockpiled effect wore off!": [
+		"@0が たくわえていた　こうかが　きれた！",
+		"Les effets accumulés par @0 se dissipent!",
+		"Finito l'effetto di Accumulo di @0!",
+		"Der gehortete Effekt von @0 lässt nach!",
+		"¡Han desaparecido los efectos acumulados de @0!"
+	],
+	"The foe's @0's stockpiled effect wore off!": [
+		"あいての　@0が たくわえていた　こうかが　きれた！",
+		"Les effets accumulés par le @0 ennemi se dissipent!",
+		"Finito l'effetto di Accumulo di @0 nemico!",
+		"Der gehortete Effekt von @0 (Gegner) lässt nach!",
+		"¡Han desaparecido los efectos acumulados del @0 enemigo!"
+	],
+	"@0 can't use items anymore!": [
+		"@0には どうぐが　つかえなくなった！",
+		"@0 ne peut plus utiliser d'objets!",
+		"@0 non può usare strumenti!",
+		"@0 kann keine Items mehr einsetzen!",
+		"¡@0 no puede usar objetos!"
+	],
+	"The foe's @0 can't use items anymore!": [
+		"あいての　@0には どうぐが　つかえなくなった！",
+		"Le @0 ennemi ne peut plus utiliser d'objets!",
+		"@0 nemico non può usare strumenti!",
+		"@0 (Gegner) kann keine Items mehr einsetzen!",
+		"¡El @0 enemigo no puede usar objetos!"
+	],
+	"@0 can use items again!": [
+		"@0に どうぐが　つかえるようになった！",
+		"@0 peut de nouveau utiliser des objets!",
+		"@0 può di nuovo usare strumenti!",
+		"@0 kann wieder Items einsetzen!",
+		"¡@0 ya puede usar objetos de nuevo!"
+	],
+	"The foe's @0 can use items again!": [
+		"あいての　@0に どうぐが　つかえるようになった！",
+		"Le @0 ennemi peut de nouveau utiliser des objets!",
+		"@0 nemico può di nuovo usare strumenti!",
+		"@0 (Gegner) kann wieder Items einsetzen!",
+		"¡El @0 enemigo ya puede usar objetos de nuevo!"
+	],
+	"@0 planted its roots!": [
+		"@0は　ねを　はった！",
+		"@0 plante ses racines!",
+		"@0 pianta le radici!",
+		"@0 pflanzt seine Wurzeln!",
+		"¡@0 ha echado raíces!"
+	],
+	"The foe's @0 planted its roots!": [
+		"あいての　@0は　ねを　はった！",
+		"Le @0 ennemi plante ses racines!",
+		"@0 nemico pianta le radici!",
+		"@0 (Gegner) pflanzt seine Wurzeln!",
+		"¡El @0 enemigo ha echado raíces!"
+	],
+	"@0 absorbed nutrients with its roots!": [
+		"@0は　ねから ようぶんを　すいとった！",
+		"@0 absorbe des nutriments avec ses racines!",
+		"@0 assorbe sostanze nutritive con le radici!",
+		"@0 nimmt über seine Wurzeln Nährstoffe auf!",
+		"¡@0 ha absorbido nutrientes con las raíces!"
+	],
+	"The foe's @0 absorbed nutrients with its roots!": [
+		"あいての　@0は　ねから ようぶんを　すいとった！",
+		"Le @0 ennemi absorbe des nutriments avec ses racines!",
+		"@0 nemico assorbe sostanze nutritive con le radici!",
+		"@0 (Gegner) nimmt über seine Wurzeln Nährstoffe auf!",
+		"¡El @0 enemigo ha absorbido nutrientes con las raíces!"
+	],
+	"@0 anchored itself with its roots!": [
+		"@0は　ねをはって うごかない！",
+		"@0 s'accroche avec ses racines!",
+		"@0 è ancorato al suolo grazie alle radici!",
+		"@0 verankert seine Wurzeln!",
+		"¡@0 se ha fijado al suelo con sus raíces!"
+	],
+	"The foe's @0 anchored itself with its roots!": [
+		"あいての　@0は　ねをはって うごかない！",
+		"Le @0 ennemi s'accroche avec ses racines!",
+		"@0 nemico è ancorato al suolo grazie alle radici!",
+		"@0 (Gegner) verankert seine Wurzeln!",
+		"¡El @0 enemigo se ha fijado al suelo con sus raíces!"
+	],
+	"@0 is storing energy!": [
+		"@0は　がまんしている",
+		"@0 se concentre!",
+		"@0 accumula energia!",
+		"@0 speichert Energie!",
+		"¡@0 está acumulando energía!"
+	],
+	"The foe's @0 is storing energy!": [
+		"あいての　@0は　がまんしている",
+		"Le @0 ennemi se concentre!",
+		"@0 nemico accumula energia!",
+		"@0 (Gegner) speichert Energie!",
+		"¡El @0 enemigo está acumulando energía!"
+	],
+	"@0 unleashed energy!": [
+		"@0の がまんが　とかれた！",
+		"@0 envoie la sauce!",
+		"@0 libera energia!",
+		"@0 erzeugt Energie!",
+		"¡@0 ha liberado energía!"
+	],
+	"The foe's @0 unleashed energy!": [
+		"あいての　@0の がまんが　とかれた！",
+		"Le @0 ennemi envoie la sauce!",
+		"@0 nemico libera energia!",
+		"@0 (Gegner) erzeugt Energie!",
+		"¡El @0 enemigo ha liberado energía!"
+	],
+	"@0 waits for a target to make a move!": [
+		"@0は あいての　でかたを　うかがっている！",
+		"@0 attend que son ennemi agisse!",
+		"@0 aspetta la mossa del bersaglio!",
+		"@0 wartet auf einen Angriff!",
+		"¡@0 espera a que se haga algún movimiento!"
+	],
+	"The foe's @0 waits for a target to make a move!": [
+		"あいての　@0は あいての　でかたを　うかがっている！",
+		"Le @0 ennemi attend que son ennemi agisse!",
+		"@0 nemico aspetta la mossa del bersaglio!",
+		"@0 (Gegner) wartet auf einen Angriff!",
+		"¡El @0 enemigo espera a que se haga algún movimiento!"
+	],
+	"@0 snatched @1's move!": [
+		"@0は　@1の わざを　よこどりした！",
+		"@0 saisit la capacité de @1!",
+		"@0 ruba la mossa di @1 con Scippo!",
+		"@0 übernimmt Attacke von @1!",
+		"¡@0 ha robado el movimiento de @1!"
+	],
+	"@0 snatched the foe's @1's move!": [
+		"@0は　あいての　@1の わざを　よこどりした！",
+		"@0 saisit la capacité du @1 ennemi!",
+		"@0 ruba la mossa di @1 nemico con Scippo!",
+		"@0 übernimmt Attacke von @1 (Gegner)!",
+		"¡@0 ha robado el movimiento del @1 enemigo!"
+	],
+	"The foe's @0 snatched @1's move!": [
+		"あいての　@0は　@1の わざを　よこどりした！",
+		"Le @0 ennemi saisit la capacité de @1!",
+		"@0 nemico ruba la mossa di @1 con Scippo!",
+		"@0 (Gegner) übernimmt Attacke von @1!",
+		"¡El @0 enemigo ha robado el movimiento de @1!"
+	],
+	"The foe's @0 snatched the foe's @1's move!": [
+		"あいての　@0は あいての　@1の わざを　よこどりした！",
+		"Le @0 ennemi saisit la capacité du @1 ennemi!",
+		"@0 nemico ruba la mossa di @1 nemico con Scippo!",
+		"@0 (Gegner) übernimmt Attacke von @1 (Gegner)!",
+		"¡El @0 enemigo ha robado el movimiento del @1 enemigo!"
+	],
+	"@0 shrouded itself with Magic Coat!": [
+		"@0は マジックコートに　つつまれた！",
+		"@0 s'entoure du Reflet Magik!",
+		"@0 si avvolge in Magivelo!",
+		"@0 hüllt sich selbst in Magiemantel!",
+		"¡@0 se ha cubierto con Capa Mágica!"
+	],
+	"The foe's @0 shrouded itself with Magic Coat!": [
+		"あいての　@0は マジックコートに　つつまれた！",
+		"Le @0 ennemi s'entoure du Reflet Magik!",
+		"@0 nemico si avvolge in Magivelo!",
+		"@0 (Gegner) hüllt sich selbst in Magiemantel!",
+		"¡El @0 enemigo se ha cubierto con Capa Mágica!"
+	],
+	"@0 bounced the @1 back!": [
+		"@0は @1を　はねかえした！",
+		"@0 repousse @1! Retour à l'envoyeur!",
+		"@0 respinge @1, che rimanda al mittente!",
+		"@0 leitet @1 zurück!",
+		"¡@0 ha devuelto @1!"
+	],
+	"The foe's @0 bounced the @1 back!": [
+		"あいての　@0は @1を　はねかえした！",
+		"Le @0 ennemi repousse @1! Retour à l'envoyeur!",
+		"@0 nemico respinge @1, che rimanda al mittente!",
+		"@0 (Gegner) leitet @1 zurück!",
+		"¡El @0 enemigo ha devuelto @1!"
+	],
+	"@0 fled from battle!": [
+		"@0は せんとうから　りだつした！",
+		"@0 s'enfuit!",
+		"@0 se la dà a gambe!",
+		"@0 ist geflüchtet!",
+		"¡@0 ha huido del combate!"
+	],
+	"The foe's @0 fled from battle!": [
+		"あいての　@0は せんとうから　りだつした！",
+		"Le @0 ennemi s'enfuit!",
+		"@0 nemico se la dà a gambe!",
+		"@0 (Gegner) ist geflüchtet!",
+		"¡El @0 enemigo ha huido del combate!"
+	],
+	"@0 went back to @1!": [
+		"@0は @1のもとへ　もどっていく！",
+		"@0 revient vers @1!",
+		"@0 torna da @1!",
+		"@0 kommt zu @1 zurück!",
+		"¡@0 ha vuelto con @1!"
+	],
+	"The foe's @0 went back to @1!": [
+		"あいての　@0は @1のもとへ　もどっていく！",
+		"Le @0 ennemi revient vers @1!",
+		"@0 nemico torna da @1!",
+		"@0 (Gegner) kommt zu @1 zurück!",
+		"¡El @0 enemigo ha vuelto con @1!"
+	],
+	"@0 switched its Attack and Defense!": [
+		"@0は こうげきと　ぼうぎょを　いれかえた！",
+		"@0 échange son Attaque et sa Défense!",
+		"@0 inverte l'Attacco con la Difesa!",
+		"@0 tauscht Angriff und Verteidigung!",
+		"¡@0 ha cambiado su Ataque por su Defensa!"
+	],
+	"The foe's @0 switched its Attack and Defense!": [
+		"あいての　@0は こうげきと　ぼうぎょを　いれかえた！",
+		"Le @0 ennemi échange son Attaque et sa Défense!",
+		"@0 nemico inverte l'Attacco con la Difesa!",
+		"@0 (Gegner) tauscht Angriff und Verteidigung!",
+		"¡El @0 enemigo ha cambiado su Ataque por su Defensa!"
+	],
+	"@0 stole and ate its target's @1!": [
+		"@0は @1を　うばって　たべた！",
+		"@0 vole et mange l'objet @1 de la cible!",
+		"@0 ruba e mangia la @1 del bersaglio!",
+		"@0 hat dem Ziel das Item @1 gestohlen und es ihm weggegessen!",
+		"¡@0 ha robado y se ha comido la @1 del objetivo!"
+	],
+	"The foe's @0 stole and ate its target's @1!": [
+		"あいての　@0は @1を　うばって　たべた！",
+		"Le @0 ennemi vole et mange l'objet @1 de la cible!",
+		"@0 nemico ruba e mangia la @1 del bersaglio!",
+		"@0 (Gegner) hat dem Ziel das Item @1 gestohlen und es ihm weggegessen!",
+		"¡El @0 enemigo ha robado y se ha comido la @1 del objetivo!"
+	],
+	"@0 flung its @1!": [
+		"@0は @1を　なげつけた！",
+		"@0 lance son objet: @1!",
+		"@0 lancia @1!",
+		"@0 schleudert sein Item (@1)!",
+		"¡@0 ha tirado su @1!"
+	],
+	"The foe's @0 flung its @1!": [
+		"あいての　@0は @1を　なげつけた！",
+		"Le @0 ennemi lance son objet: @1!",
+		"@0 nemico lancia @1!",
+		"@0 (Gegner) schleudert sein Item (@1)!",
+		"¡El @0 enemigo ha tirado su @1!"
+	],
+	"@0 blew away @1!": [
+		"@0は @1を　ふきとばした！",
+		"@0 repousse @1!",
+		"@0 spazza via @1!",
+		"@0 bläst @1 weg!",
+		"¡@0 se ha deshecho de @1!"
+	],
+	"The foe's @0 blew away @1!": [
+		"あいての　@0は @1を　ふきとばした！",
+		"Le @0 ennemi repousse @1!",
+		"@0 nemico spazza via @1!",
+		"@0 (Gegner) bläst @1 weg!",
+		"¡El @0 enemigo se ha deshecho de @1!"
+	],
+	"@0 put in a substitute!": [
+		"@0の みがわりが　あらわれた！",
+		"@0 crée un clone!",
+		"Appare un sostituto di @0!",
+		"Ein Delegator von @0 ist erschienen!",
+		"¡@0 ha creado un sustituto!"
+	],
+	"The foe's @0 put in a substitute!": [
+		"あいての　@0の みがわりが　あらわれた！",
+		"Le @0 ennemi crée un clone!",
+		"Appare un sostituto di @0 nemico!",
+		"Ein Delegator von @0 (Gegner) ist erschienen!",
+		"¡El @0 enemigo ha creado un sustituto!"
+	],
+	"@0 already has a substitute!": [
+		"しかし　@0の みがわりは　すでに　でていた",
+		"@0 a déjà un clone!",
+		"@0 ha già un sostituto!",
+		"@0 hat bereits einen Delegator!",
+		"¡@0 ya tiene un sustituto!"
+	],
+	"The foe's @0 already has a substitute!": [
+		"しかし　あいての　@0の みがわりは　すでに　でていた",
+		"Le @0 ennemi a déjà un clone!",
+		"@0 nemico ha già un sostituto!",
+		"@0 (Gegner) hat bereits einen Delegator!",
+		"¡El @0 enemigo ya tiene un sustituto!"
+	],
+	"The substitute took damage for @0!": [
+		"@0に　かわって みがわりが　こうげきを　うけた！",
+		"Le clone prend les dégâts pour @0!",
+		"Il sostituto è colpito al posto di @0!",
+		"Der Delegator steckt den Schlag für @0 ein!",
+		"¡El sustituto recibe el daño en lugar de @0!"
+	],
+	"The substitute took damage for the foe's @0!": [
+		"あいての　@0に　かわって みがわりが　こうげきを　うけた！",
+		"Le clone prend les dégâts pour le @0 ennemi!",
+		"Il sostituto è colpito al posto di @0 nemico!",
+		"Der Delegator steckt den Schlag für @0 (Gegner) ein!",
+		"¡El sustituto recibe el daño en lugar del @0 enemigo!"
+	],
+	"@0's substitute faded!": [
+		"@0の みがわりは　きえてしまった…",
+		"Le clone de @0 disparaît...",
+		"Il sostituto di @0 svanisce!",
+		"Delegator von @0 lässt nach!",
+		"¡El sustituto de @0 se ha debilitado!"
+	],
+	"The foe's @0's substitute faded!": [
+		"あいての　@0の みがわりは　きえてしまった…",
+		"Le clone du @0 ennemi disparaît...",
+		"Il sostituto di @0 nemico svanisce!",
+		"Delegator von @0 (Gegner) lässt nach!",
+		"¡El sustituto del @0 enemigo se ha debilitado!"
+	],
+	"Wide Guard protected @0!": [
+		"@0は ワイドガードで　まもられた！",
+		"@0 est protégé par Garde Large!",
+		"@0 è protetto da Bodyguard!",
+		"@0 wird durch Rundumschutz geschützt!",
+		"¡@0 está protegido por Vastaguardia!"
+	],
+	"Wide Guard protected the foe's @0!": [
+		"あいての　@0は ワイドガードで　まもられた！",
+		"Le @0 ennemi est protégé par Garde Large!",
+		"@0 nemico è protetto da Bodyguard!",
+		"@0 (Gegner) wird durch Rundumschutz geschützt!",
+		"¡El @0 enemigo está protegido por Vastaguardia!"
+	],
+	"Quick Guard protected @0!": [
+		"@0は ファストガードで　まもられた！",
+		"@0 est protégé par Prévention!",
+		"@0 è protetto da Anticipo!",
+		"@0 wird durch Rapidschutz beschützt!",
+		"¡@0 está protegido por Anticipo!"
+	],
+	"Quick Guard protected the foe's @0!": [
+		"あいての　@0は ファストガードで　まもられた！",
+		"Le @0 ennemi est protégé par Prévention!",
+		"@0 nemico è protetto da Anticipo!",
+		"@0 (Gegner) wird durch Rapidschutz beschützt!",
+		"¡El @0 enemigo está protegido por Anticipo!"
+	],
+	"@0 was squeezed by @1!": [
+		"@0は @1に しめつけられた！",
+		"@0 est pris dans l'étreinte de @1!",
+		"@1 stritola @0 con Legatutto!",
+		"@1 setzt bei @0 Klammergriff ein!",
+		"¡Atadura de @1 oprime a @0!"
+	],
+	"@0 was squeezed by the foe's @1!": [
+		"@0は あいての　@1に しめつけられた！",
+		"@0 est pris dans l'étreinte du @1 ennemi!",
+		"@1 nemico stritola @0 con Legatutto!",
+		"@1 (Gegner) setzt bei @0 Klammergriff ein!",
+		"¡Atadura del @1 enemigo oprime a @0!"
+	],
+	"The foe's @0 was squeezed by @1!": [
+		"あいての　@0は @1に しめつけられた！",
+		"Le @0 ennemi est pris dans l'étreinte de @1!",
+		"@1 stritola @0 nemico con Legatutto!",
+		"@1 setzt bei @0 (Gegner) Klammergriff ein!",
+		"¡Atadura de @1 oprime al @0 enemigo!"
+	],
+	"The foe's @0 was squeezed by the foe's @1!": [
+		"あいての　@0は あいての　@1に しめつけられた！",
+		"Le @0 ennemi est pris dans l'étreinte du @1 ennemi!",
+		"@1 nemico stritola @0 nemico con Legatutto!",
+		"@1 (Gegner) setzt bei @0 (Gegner) Klammergriff ein!",
+		"¡Atadura del @1 enemigo oprime al @0 enemigo!"
+	],
+	"@0 was wrapped by @1!": [
+		"@0は @1に まきつかれた！",
+		"@0 est ligoté par @1!",
+		"@1 stritola @0 con Avvolgibotta!",
+		"@0 wurde von @1 umwickelt!",
+		"¡Repetición de @1 ha atrapado a @0!"
+	],
+	"@0 was wrapped by the foe's @1!": [
+		"@0は あいての　@1に まきつかれた！",
+		"@0 est ligoté par le @1 ennemi!",
+		"@1 nemico stritola @0 con Avvolgibotta!",
+		"@0 wurde von @1 (Gegner) umwickelt!",
+		"¡Repetición del @1 enemigo ha atrapado a @0!"
+	],
+	"The foe's @0 was wrapped by @1!": [
+		"あいての　@0は @1に まきつかれた！",
+		"Le @0 ennemi est ligoté par @1!",
+		"@1 stritola @0 nemico con Avvolgibotta!",
+		"@0 (Gegner) wurde von @1 umwickelt!",
+		"¡Repetición de @1 ha atrapado al @0 enemigo!"
+	],
+	"The foe's @0 was wrapped by the foe's @1!": [
+		"あいての　@0は あいての　@1に まきつかれた！",
+		"Le @0 ennemi est ligoté par le @1 ennemi!",
+		"@1 nemico stritola @0 nemico con Avvolgibotta!",
+		"@0 (Gegner) wurde von @1 (Gegner) umwickelt!",
+		"¡Repetición del @1 enemigo ha atrapado al @0 enemigo!"
+	],
+	"@1 clamped @0!": [
+		"@0は @1の　からに はさまれた！",
+		"@0 est pris dans le Claquoir de @1!",
+		"@1 stritola @0 con Tenaglia!",
+		"@0 wurde von @1 geschnappt!",
+		"¡@1 ha atenazado a @0!"
+	],
+	"The foe's @1 clamped @0!": [
+		"@0は あいての　@1の　からに はさまれた！",
+		"@0 est pris dans le Claquoir du @1 ennemi!",
+		"@1 nemico stritola @0 con Tenaglia!",
+		"@0 wurde von @1 (Gegner) geschnappt!",
+		"¡El @1 enemigo ha atenazado a @0!"
+	],
+	"@1 clamped the foe's @0!": [
+		"あいての　@0は @1の　からに はさまれた！",
+		"Le @0 ennemi est pris dans le Claquoir de @1!",
+		"@1 stritola @0 nemico con Tenaglia!",
+		"@0 (Gegner) wurde von @1 geschnappt!",
+		"¡@1 ha atenazado al @0 enemigo!"
+	],
+	"The foe's @1 clamped the foe's @0!": [
+		"あいての　@0は あいての　@1の　からに はさまれた！",
+		"Le @0 ennemi est pris dans le Claquoir du @1 ennemi!",
+		"@1 nemico stritola @0 nemico con Tenaglia!",
+		"@0 (Gegner) wurde von @1 (Gegner) geschnappt!",
+		"¡El @1 enemigo ha atenazado al @0 enemigo!"
+	],
+	"@0 became trapped in the vortex!": [
+		"@0は うずの　なかに　とじこめられた！",
+		"@0 est piégé dans le tourbillon!",
+		"@0 è intrappolato nel Mulinello!",
+		"@0 wird in dem Strudel gefangen!",
+		"¡@0 ha sido atrapado en el torbellino!"
+	],
+	"The foe's @0 became trapped in the vortex!": [
+		"あいての　@0は うずの　なかに　とじこめられた！",
+		"Le @0 ennemi est piégé dans le tourbillon!",
+		"@0 nemico è intrappolato nel Mulinello!",
+		"@0 (Gegner) wird in dem Strudel gefangen!",
+		"¡El @0 enemigo ha sido atrapado en el torbellino!"
+	],
+	"@0 became trapped in the fiery vortex!": [
+		"@0は ほのおの　うずに　とじこめられた！",
+		"@0 est piégé dans un tourbillon de feu!",
+		"@0 è intrappolato in un turbine di fuoco!",
+		"@0 wurde in wirbelndem Feuer eingeschlossen!",
+		"¡@0 ha quedado atrapado por Giro Fuego!"
+	],
+	"The foe's @0 became trapped in the fiery vortex!": [
+		"あいての　@0は ほのおの　うずに　とじこめられた！",
+		"Le @0 ennemi est piégé dans un tourbillon de feu!",
+		"@0 nemico è intrappolato in un turbine di fuoco!",
+		"@0 (Gegner) wurde in wirbelndem Feuer eingeschlossen!",
+		"¡El @0 enemigo ha quedado atrapado por Giro Fuego!"
+	],
+	"@0 became trapped by swirling magma!": [
+		"@0は マグマの　うずに　とじこめられた！",
+		"@0 est piégé dans un tourbillon de magma!",
+		"@0 è intrappolato in un turbine di magma!",
+		"@0 wurde von wirbelndem Magma gefangen!",
+		"¡@0 ha quedado atrapado en Lluvia Ígnea!"
+	],
+	"The foe's @0 became trapped by swirling magma!": [
+		"あいての　@0は マグマの　うずに　とじこめられた！",
+		"Le @0 ennemi est piégé dans un tourbillon de magma!",
+		"@0 nemico è intrappolato in un turbine di magma!",
+		"@0 (Gegner) wurde von wirbelndem Magma gefangen!",
+		"¡El @0 enemigo ha quedado atrapado en Lluvia Ígnea!"
+	],
+	"@0 became trapped by Sand Tomb!": [
+		"@0は すなじごくに　とらわれた！",
+		"@0 est piégé par le Tourbi-Sable!",
+		"@0 è intrappolato da Sabbiotomba!",
+		"@0 wurde durch Sandgrab gefangen!",
+		"¡Bucle Arena ha atrapado a @0!"
+	],
+	"The foe's @0 became trapped by Sand Tomb!": [
+		"あいての　@0は すなじごくに　とらわれた！",
+		"Le @0 ennemi est piégé par le Tourbi-Sable!",
+		"@0 nemico è intrappolato da Sabbiotomba!",
+		"@0 (Gegner) wurde durch Sandgrab gefangen!",
+		"¡Bucle Arena ha atrapado al @0 enemigo!"
+	],
+	"@0 has no moves left!": [
+		"@0は だすことのできる　わざが　ない！",
+		"@0 n'a plus de capacités!",
+		"@0 non ha più mosse da sferrare!",
+		"@0 hat keine Attacken mehr übrig!",
+		"¡A @0 no le quedan más movimientos!"
+	],
+	"The foe's @0 has no moves left!": [
+		"あいての　@0は だすことのできる　わざが　ない！",
+		"Le @0 ennemi n'a plus de capacités!",
+		"@0 nemico non ha più mosse da sferrare!",
+		"@0 (Gegner) hat keine Attacken mehr übrig!",
+		"¡Al @0 enemigo no le quedan más movimientos!"
+	],
+	"@0 is protected by Safeguard!": [
+		"@0は　 しんぴのベールに　まもられている！",
+		"L'équipe de @0 est protégée par Rune Protect!",
+		"Salvaguardia protegge @0!",
+		"Team von @0 wird durch Bodyguard geschützt!",
+		"¡@0 está protegido por Velo Sagrado!"
+	],
+	"The foe's @0 is protected by Safeguard!": [
+		"あいての　@0は　 しんぴのベールに　まもられている！",
+		"L'équipe du @0 ennemi est protégée par Rune Protect!",
+		"Salvaguardia protegge @0 nemico!",
+		"Team von @0 (Gegner) wird durch Bodyguard geschützt!",
+		"¡El @0 enemigo está protegido por Velo Sagrado!"
+	],
+	"@0 is protected by the mist!": [
+		"@0は　 しろいきりに　まもられている！",
+		"@0 est protégé par la Brume!",
+		"@0 è protetto dalla nebbia!",
+		"@0 wird durch Weißnebel geschützt!",
+		"¡@0 se ha protegido con Neblina!"
+	],
+	"The foe's @0 is protected by the mist!": [
+		"あいての　@0は　 しろいきりに　まもられている！",
+		"Le @0 ennemi est protégé par la Brume!",
+		"@0 nemico è protetto dalla nebbia!",
+		"@0 (Gegner) wird durch Weißnebel geschützt!",
+		"¡El @0 enemigo se ha protegido con Neblina!"
+	],
+	"@0 was dragged out!": [
+		"@0は せんとうに　ひきずりだされた！",
+		"@0 est traîné de force au combat!",
+		"@0 è trascinato nella lotta!",
+		"@0 wurde ausgewählt!",
+		"¡@0 ha sido arrastrado al combate!"
+	],
+	"The foe's @0 was dragged out!": [
+		"あいての　@0は せんとうに　ひきずりだされた！",
+		"Le @0 ennemi est traîné de force au combat!",
+		"@0 nemico è trascinato nella lotta!",
+		"@0 (Gegner) wurde ausgewählt!",
+		"¡El @0 enemigo ha sido arrastrado al combate!"
+	],
+	"@0 must recharge!": [
+		"@0は こうげきの　はんどうで　うごけない！",
+		"Le contrecoup empêche @0 de bouger!",
+		"@0 deve ricaricarsi!",
+		"@0 kann sich wegen des Rückstoßes durch den Angriff nicht bewegen.",
+		"¡@0 necesita recuperarse de su ataque!"
+	],
+	"The foe's @0 must recharge!": [
+		"あいての　@0は こうげきの　はんどうで　うごけない！",
+		"Le contrecoup empêche le @0 ennemi de bouger!",
+		"@0 nemico deve ricaricarsi!",
+		"@0 (Gegner) kann sich wegen des Rückstoßes durch den Angriff nicht bewegen.",
+		"¡El @0 enemigo necesita recuperarse de su ataque!"
+	],
+	"@0 is hurt by the spikes!": [
+		"@0は まきびしの　ダメージを　うけた！",
+		"@0 est blessé par les Picots!",
+		"@0 è colpito da Punte!",
+		"@0 wurde durch Stachler verletzt!",
+		"¡@0 ha sido herido por Púas!"
+	],
+	"The foe's @0 is hurt by the spikes!": [
+		"あいての　@0は まきびしの　ダメージを　うけた！",
+		"Le @0 ennemi est blessé par les Picots!",
+		"@0 nemico è colpito da Punte!",
+		"@0 (Gegner) wurde durch Stachler verletzt!",
+		"¡El @0 enemigo ha sido herido por Púas!"
+	],
+	"Pointed stones dug into @0!": [
+		"@0に とがった　いわが　くいこんだ！",
+		"Des pierres pointues transpercent @0!",
+		"Rocce aguzze colpiscono @0!",
+		"@0 wird von spitzen Steinen getroffen!",
+		"¡Se han clavado piedras puntiagudas en @0!"
+	],
+	"Pointed stones dug into the foe's @0!": [
+		"あいての　@0に とがった　いわが　くいこんだ！",
+		"Des pierres pointues transpercent le @0 ennemi!",
+		"Rocce aguzze colpiscono @0 nemico!",
+		"@0 (Gegner) wird von spitzen Steinen getroffen!",
+		"¡Se han clavado piedras puntiagudas en el @0 enemigo!"
+	],
+	"@0 twisted the dimensions!": [
+		"@0は じくうを　ゆがめた！",
+		"@0 fausse les dimensions!",
+		"@0 crea una dimensione distorta!",
+		"@0 hat die Dimensionen verdreht!",
+		"¡@0 ha alterado las dimensiones!"
+	],
+	"The foe's @0 twisted the dimensions!": [
+		"あいての　@0は じくうを　ゆがめた！",
+		"Le @0 ennemi fausse les dimensions!",
+		"@0 nemico crea una dimensione distorta!",
+		"@0 (Gegner) hat die Dimensionen verdreht!",
+		"¡El @0 enemigo ha alterado las dimensiones!"
+	],
+	"@0's perish count fell to @1!": [
+		"@0の ほろびのカウントが　@1になった！",
+		"Le compte à rebours du Requiem de @0 descend à @1!",
+		"Il conto alla rovescia di Ultimocanto per @0 scende a @1!",
+		"Abgesang von @0 steht bei @1!",
+		"¡La cuenta atrás de Canto Mortal de @0 ha bajado a @1!"
+	],
+	"The foe's @0's perish count fell to @1!": [
+		"あいての　@0の ほろびのカウントが　@1になった！",
+		"Le compte à rebours du Requiem du @0 ennemi descend à @1!",
+		"Il conto alla rovescia di Ultimocanto per @0 nemico scende a @1!",
+		"Abgesang von @0 (Gegner) steht bei @1!",
+		"¡La cuenta atrás de Canto Mortal del @0 enemigo ha bajado a @1!"
+	],
+	"@0 became cloaked in a freezing light!": [
+		"@0は つめたい　ひかりに　つつまれた！",
+		"@0 est baigné par une lumière blafarde!",
+		"@0 è avvolto da una luce fredda!",
+		"@0 wird von einem kühlen Licht umhüllt!",
+		"¡@0 ha quedado envuelto en una luz fría!"
+	],
+	"The foe's @0 became cloaked in a freezing light!": [
+		"あいての　@0は つめたい　ひかりに　つつまれた！",
+		"Le @0 ennemi est baigné par une lumière blafarde!",
+		"@0 nemico è avvolto da una luce fredda!",
+		"@0 (Gegner) wird von einem kühlen Licht umhüllt!",
+		"¡El @0 enemigo ha quedado envuelto en una luz fría!"
+	],
+	"@0 became cloaked in freezing air!": [
+		"@0は こごえる　くうきに　つつまれた！",
+		"@0 est entouré d'un air glacial!",
+		"@0 è avvolto da un'atmosfera gelida!",
+		"@0 wird in klirrend kalte Luft gehüllt!",
+		"¡@0 ha quedado envuelto en aire gélido!"
+	],
+	"The foe's @0 became cloaked in freezing air!": [
+		"あいての　@0は こごえる　くうきに　つつまれた！",
+		"Le @0 ennemi est entouré d'un air glacial!",
+		"@0 nemico è avvolto da un'atmosfera gelida!",
+		"@0 (Gegner) wird in klirrend kalte Luft gehüllt!",
+		"¡El @0 enemigo ha quedado envuelto en aire gélido!"
+	],
+	"@0 prevents escape with @1!": [
+		"@0の @1　で　にげられない！",
+		"@0 empêche la fuite avec @1!",
+		"@0 impedisce la fuga con @1!",
+		"@0 verhindert eine Flucht mit @1!",
+		"¡@0 impide la huida con @1!"
+	],
+	"The foe's @0 prevents escape with @1!": [
+		"あいての　@0の @1　で　にげられない！",
+		"Le @0 ennemi empêche la fuite avec @1!",
+		"@0 nemico impedisce la fuga con @1!",
+		"@0 (Gegner) verhindert eine Flucht mit @1!",
+		"¡El @0 enemigo impide la huida con @1!"
+	],
+	"@0 can no longer escape!": [
+		"@0は もう　にげられない！",
+		"@0 ne peut plus s'échapper!",
+		"@0 non può più scappare!",
+		"@0 kann nicht mehr fliehen!",
+		"¡@0 ya no puede escaparse!"
+	],
+	"The foe's @0 can no longer escape!": [
+		"あいての　@0は もう　にげられない！",
+		"Le @0 ennemi ne peut plus s'échapper!",
+		"@0 nemico non può più scappare!",
+		"@0 (Gegner) kann nicht mehr fliehen!",
+		"¡El @0 enemigo ya no puede escaparse!"
+	],
+	"@0 can't escape!": [
+		"@0は にげられない！",
+		"@0 ne peut pas s'échapper!",
+		"@0 non può scappare!",
+		"@0 kann nicht fliehen!",
+		"¡@0 no puede escaparse!"
+	],
+	"The foe's @0 can't escape!": [
+		"あいての　@0は にげられない！",
+		"Le @0 ennemi ne peut pas s'échapper!",
+		"@0 nemico non può scappare!",
+		"@0 (Gegner) kann nicht fliehen!",
+		"¡El @0 enemigo no puede escaparse!"
+	],
+	"   ": [
+		"@0の　 @1　で いれかえることが　できない！",
+		"   ",
+		"   ",
+		"   ",
+		"   "
+	],
+	"": [
+		"あいての　@0の　 @1　で いれかえることが　できない！",
+		"",
+		"",
+		"",
+		""
+	],
+	"@0 was prevented from healing!": [
+		"@0は かいふくどうさを　ふうじられた！",
+		"@0 ne peut pas guérir!",
+		"@0 non può curarsi!",
+		"Heilung von @0 wurde verhindert!",
+		"¡@0 no puede curarse!"
+	],
+	"The foe's @0 was prevented from healing!": [
+		"あいての　@0は かいふくどうさを　ふうじられた！",
+		"Le @0 ennemi ne peut pas guérir!",
+		"@0 nemico non può curarsi!",
+		"Heilung von @0 (Gegner) wurde verhindert!",
+		"¡El @0 enemigo no puede curarse!"
+	],
+	"@0's Heal Block wore off!": [
+		"@0の かいふくふうじの　こうかが　きれた！",
+		"@0 peut à nouveau guérir!",
+		"@0 può nuovamente curarsi!",
+		"@0 kann nun wieder geheilt werden!",
+		"¡Se han pasado los efectos de Anticura en @0!"
+	],
+	"The foe's @0's Heal Block wore off!": [
+		"あいての　@0の かいふくふうじの　こうかが　きれた！",
+		"Le @0 ennemi peut à nouveau guérir!",
+		"@0 nemico può nuovamente curarsi!",
+		"@0 (Gegner) kann nun wieder geheilt werden!",
+		"¡Se han pasado los efectos de Anticura en el @0 enemigo!"
+	],
+	"@0 was prevented from healing due to Heal Block!": [
+		"@0は かいふくふうじで　かいふく　できない！",
+		"@0 ne peut pas guérir à cause d'Anti-Soin!",
+		"@0 non può guarire a causa di Anticura!",
+		"@0 kann aufgrund von Heilblockade nicht geheilt werden!",
+		"¡@0 no puede curarse debido a Anticura!"
+	],
+	"The foe's @0 was prevented from healing due to Heal Block!": [
+		"あいての　@0は かいふくふうじで　かいふく　できない！",
+		"Le @0 ennemi ne peut pas guérir à cause d'Anti-Soin!",
+		"@0 nemico non può guarire a causa di Anticura!",
+		"@0 (Gegner) kann aufgrund von Heilblockade nicht geheilt werden!",
+		"¡El @0 enemigo no puede curarse debido a Anticura!"
+	],
+	"@0 can't use @1 because of Heal Block!": [
+		"@0は　かいふくふうじで @1が　だせない！",
+		"@0 ne peut pas utiliser @1 à cause d'Anti-Soin!",
+		"@0 non può usare @1 a causa di Anticura!",
+		"@0 kann @1 aufgrund der Heilblockade nicht einsetzen.",
+		"¡@0 no puede usar @1 debido a Anticura!"
+	],
+	"The foe's @0 can't use @1 because of Heal Block!": [
+		"あいての　@0は　かいふくふうじで @1が　だせない！",
+		"Le @0 ennemi ne peut pas utiliser @1 à cause d'Anti-Soin!",
+		"@0 nemico non può usare @1 a causa di Anticura!",
+		"@0 (Gegner) kann @1 aufgrund der Heilblockade nicht einsetzen.",
+		"¡El @0 enemigo no puede usar @1 debido a Anticura!"
+	],
+	"@0's HP is full!": [
+		"しかし　@0は たいりょくが　まんたんだ！",
+		"Les PV de @0 sont au maximum!",
+		"@0 ha già tutti i Punti Salute!",
+		"@0 hat volle KP!",
+		"¡Los PS de @0 están al máximo!"
+	],
+	"The foe's @0's HP is full!": [
+		"しかし　あいての　@0は たいりょくが　まんたんだ！",
+		"Les PV du @0 ennemi sont au maximum!",
+		"@0 nemico ha già tutti i Punti Salute!",
+		"@0 (Gegner) hat volle KP!",
+		"¡Los PS del @0 enemigo están al máximo!"
+	],
+	"@0 transformed into the @1 type!": [
+		"@0は @1タイプに　なった！",
+		"@0 prend le type @1!",
+		"@0 si trasforma nel tipo @1!",
+		"@0 verwandelt sich zu Typ @1!",
+		"¡@0 ha cambiado a tipo @1!"
+	],
+	"The foe's @0 transformed into the @1 type!": [
+		"あいての　@0は @1タイプに　なった！",
+		"Le @0 ennemi prend le type @1!",
+		"@0 nemico si trasforma nel tipo @1!",
+		"@0 (Gegner) verwandelt sich zu Typ @1!",
+		"¡El @0 enemigo ha cambiado a tipo @1!"
+	],
+	"@0 had its energy drained!": [
+		"@0から たいりょくを　すいとった！",
+		"L'énergie de @0 est drainée!",
+		"Viene prelevata energia da @0!",
+		"@0 wurde Energie abgesaugt!",
+		"¡La energía de @0 ha sido absorbida!"
+	],
+	"The foe's @0 had its energy drained!": [
+		"あいての　@0から たいりょくを　すいとった！",
+		"L'énergie du @0 ennemi est drainée!",
+		"Viene prelevata energia da @0 nemico!",
+		"@0 (Gegner) wurde Energie abgesaugt!",
+		"¡La energía del @0 enemigo ha sido absorbida!"
+	],
+	"@0 kept going and crashed!": [
+		"いきおいあまって　@0は じめんに　ぶつかった！",
+		"@0 s'écrase au sol!",
+		"@0 si sbilancia e si schianta!",
+		"@0 macht weiter und bricht zusammen!",
+		"¡@0 ha fallado y se ha caído!"
+	],
+	"The foe's @0 kept going and crashed!": [
+		"いきおいあまって　あいての　@0は じめんに　ぶつかった！",
+		"Le @0 ennemi s'écrase au sol!",
+		"@0 nemico si sbilancia e si schianta!",
+		"@0 (Gegner) macht weiter und bricht zusammen!",
+		"¡El @0 enemigo ha fallado y se ha caído!"
+	],
+	"@0 cannot use @1!": [
+		"@0は @1を　つかえない！",
+		"Impossible pour @0 d'utiliser la capacité @1!",
+		"@0 non può utilizzare @1!",
+		"@0 kann @1 nicht einsetzen!",
+		"¡@0 no puede usar @1!"
+	],
+	"The foe's @0 cannot use @1!": [
+		"あいての　@0は @1を　つかえない！",
+		"Impossible pour le @0 ennemi d'utiliser la capacité @1!",
+		"@0 nemico non può utilizzare @1!",
+		"@0 (Gegner) kann @1 nicht einsetzen!",
+		"¡El @0 enemigo no puede usar @1!"
+	],
+	"@0 restored its health using its @1!": [
+		"@0は @1で たいりょくを　かいふくした！",
+		"@1 de @0 restaure son énergie!",
+		"@1 ristabilisce la salute di @0!",
+		"@1 füllt KP von @0 auf!",
+		"¡@0 ha restaurado su salud con @1!"
+	],
+	"The foe's @0 restored its health using its @1!": [
+		"あいての　@0は @1で たいりょくを　かいふくした！",
+		"@1 du @0 ennemi restaure son énergie!",
+		"@1 ristabilisce la salute di @0 nemico!",
+		"@1 füllt KP von @0 (Gegner) auf!",
+		"¡El @0 enemigo ha restaurado su salud con @1!"
+	],
+	"@0 restored @2's PP using its @1!": [
+		"@0は @1で @2のＰＰを　かいふくした！",
+		"@1 de @0 restaure les PP de @2!",
+		"@0 ristabilisce i Punti Potenza di @2 con @1!",
+		"@1 von @0 füllt AP von @2 auf!",
+		"¡@1 de @0 ha restaurado los PP de @2!"
+	],
+	"The foe's @0 restored @2's PP using its @1!": [
+		"あいての　@0は @1で @2のＰＰを　かいふくした！",
+		"@1 du @0 ennemi restaure les PP de @2!",
+		"@0 nemico ristabilisce i Punti Potenza di @2 con @1!",
+		"@1 von @0 (Gegner) füllt AP von @2 auf!",
+		"¡@1 del @0 enemigo ha restaurado los PP de @2!"
+	],
+	"@0 restored a little HP using its @1!": [
+		"@0は @1で すこし　かいふく",
+		"@1 de @0 restaure un peu ses PV!",
+		"@1 ristabilisce parte dei Punti Salute di @0!",
+		"@1 von @0 füllt einige KP auf!",
+		"¡@0 ha restaurado un poco sus PS con @1!"
+	],
+	"The foe's @0 restored a little HP using its @1!": [
+		"あいての　@0は @1で すこし　かいふく",
+		"@1 du @0 ennemi restaure un peu ses PV!",
+		"@1 ristabilisce parte dei Punti Salute di @0 nemico!",
+		"@1 von @0 (Gegner) füllt einige KP auf!",
+		"¡El @0 enemigo ha restaurado un poco sus PS con @1!"
+	],
+	"@0's @1 cured its poison!": [
+		"@0は @1で どく　が　なおった！",
+		"@1 de @0 le guérit de son empoisonnement!",
+		"@0 guarisce dall'avvelenamento grazie a @1!",
+		"@1 von @0 heilt die Vergiftung!",
+		"¡@0 ha usado @1 para curar su envenenamiento!"
+	],
+	"The foe's @0's @1 cured its poison!": [
+		"あいての　@0は @1で どく　が　なおった！",
+		"@1 du @0 ennemi le guérit de son empoisonnement!",
+		"@0 nemico guarisce dall'avvelenamento grazie a @1!",
+		"@1 von @0 (Gegner) heilt die Vergiftung!",
+		"¡El @0 enemigo ha usado @1 para curar su envenenamiento!"
+	],
+	"@0's @1 cured its paralysis!": [
+		"@0は @1で まひ　が　なおった！",
+		"@1 de @0 le sort de sa paralysie!",
+		"@0 guarisce dalla paralisi grazie a @1!",
+		"@1 von @0 heilt die Paralyse!",
+		"¡@0 se ha curado de la parálisis con @1!"
+	],
+	"The foe's @0's @1 cured its paralysis!": [
+		"あいての　@0は @1で まひ　が　なおった！",
+		"@1 du @0 ennemi le sort de sa paralysie!",
+		"@0 nemico guarisce dalla paralisi grazie a @1!",
+		"@1 von @0 (Gegner) heilt die Paralyse!",
+		"¡El @0 enemigo se ha curado de la parálisis con @1!"
+	],
+	"@0's @1 woke it up!": [
+		"@0は @1で めを　さました！",
+		"@1 de @0 le réveille!",
+		"@0 si è svegliato grazie a @1!",
+		"@1 hat bewirkt, dass @0 aufwacht!",
+		"¡@0 se ha despertado con @1!"
+	],
+	"The foe's @0's @1 woke it up!": [
+		"あいての　@0は @1で めを　さました！",
+		"@1 du @0 ennemi le réveille!",
+		"@0 nemico si è svegliato grazie a @1!",
+		"@1 hat bewirkt, dass @0 (Gegner) aufwacht!",
+		"¡El @0 enemigo se ha despertado con @1!"
+	],
+	"@0's @1 defrosted it!": [
+		"@0は @1で こおりじょうたいが　なおった！",
+		"@1 de @0 le dégèle!",
+		"@0 si è scongelato grazie a @1!",
+		"@1 von @0 taut es auf!",
+		"¡@0 se ha descongelado con @1!"
+	],
+	"The foe's @0's @1 defrosted it!": [
+		"あいての　@0は @1で こおりじょうたいが　なおった！",
+		"@1 du @0 ennemi le dégèle!",
+		"@0 nemico si è scongelato grazie a @1!",
+		"@1 von @0 (Gegner) taut es auf!",
+		"¡El @0 enemigo se ha descongelado con @1!"
+	],
+	"@0's @1 healed its burn!": [
+		"@0は @1で やけどが　なおった！",
+		"@1 de @0 le guérit de sa brûlure!",
+		"@1 guarisce la scottatura di @0!",
+		"@1 von @0 heilt die Verbrennung!",
+		"¡@0 se ha curado las quemaduras con @1!"
+	],
+	"The foe's @0's @1 healed its burn!": [
+		"あいての　@0は @1で やけどが　なおった！",
+		"@1 du @0 ennemi le guérit de sa brûlure!",
+		"@1 guarisce la scottatura di @0 nemico!",
+		"@1 von @0 (Gegner) heilt die Verbrennung!",
+		"¡El @0 enemigo se ha curado las quemaduras con @1!"
+	],
+	"@0's @1 snapped it out of its confusion!": [
+		"@0は @1で こんらんが　なおった！",
+		"@1 de @0 le tire de sa confusion!",
+		"@1 guarisce la confusione di @0!",
+		"@1 von @0 hebt die Verwirrung auf!",
+		"¡@0 se ha librado de la confusión con @1!"
+	],
+	"The foe's @0's @1 snapped it out of its confusion!": [
+		"あいての　@0は @1で こんらんが　なおった！",
+		"@1 du @0 ennemi le tire de sa confusion!",
+		"@1 guarisce la confusione di @0 nemico!",
+		"@1 von @0 (Gegner) hebt die Verwirrung auf!",
+		"¡El @0 enemigo se ha librado de la confusión con @1!"
+	],
+	"@0 cured its infatuation status using its @1!": [
+		"@0は @1で メロメロじょうたいが　なおった！",
+		"@1 de @0 fait faner son amour!",
+		"@0 si disamora grazie a @1!",
+		"@1 von @0 hebt sein Gefühl der Anziehung auf.",
+		"¡@0 ya no está enamorado gracias a @1!"
+	],
+	"The foe's @0 cured its infatuation status using its @1!": [
+		"あいての　@0は @1で メロメロじょうたいが　なおった！",
+		"@1 du @0 ennemi fait faner son amour!",
+		"@0 nemico si disamora grazie a @1!",
+		"@1 von @0 (Gegner) hebt sein Gefühl der Anziehung auf.",
+		"¡El @0 enemigo ya no está enamorado gracias a @1!"
+	],
+	"The @1 raised @0's Attack!": [
+		"@0は @1で こうげきが　あがった！",
+		"@1 de @0 fait augmenter son Attaque!",
+		"@1 aumenta l'Attacco di @0!",
+		"@1 von @0 erhöht seinen Angriff!",
+		"¡El Ataque de @0 ha subido con @1!"
+	],
+	"The @1 raised the foe's @0's Attack!": [
+		"あいての　@0は @1で こうげきが　あがった！",
+		"@1 du @0 ennemi fait augmenter son Attaque!",
+		"@1 aumenta l'Attacco di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Angriff!",
+		"¡El Ataque del @0 enemigo ha subido con @1!"
+	],
+	"The @1 raised @0's Defense!": [
+		"@0は @1で ぼうぎょが　あがった！",
+		"@1 de @0 fait augmenter sa Défense!",
+		"@1 aumenta la Difesa di @0!",
+		"@1 von @0 erhöht seine Verteidigung!",
+		"¡La Defensa de @0 ha subido con @1!"
+	],
+	"The @1 raised the foe's @0's Defense!": [
+		"あいての　@0は @1で ぼうぎょが　あがった！",
+		"@1 du @0 ennemi fait augmenter sa Défense!",
+		"@1 aumenta la Difesa di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Verteidigung!",
+		"¡La Defensa del @0 enemigo ha subido con @1!"
+	],
+	"The @1 raised @0's Special Attack!": [
+		"@0は @1で とくこうが　あがった！",
+		"@1 de @0 fait augmenter son Attaque Spéciale!",
+		"@1 aumenta l'Attacco Speciale di @0!",
+		"@1 von @0 erhöht seinen Spezial-Angriff!",
+		"¡El Ataque Especial de @0 ha subido con @1!"
+	],
+	"The @1 raised the foe's @0's Special Attack!": [
+		"あいての　@0は @1で とくこうが　あがった！",
+		"@1 du @0 ennemi fait augmenter son Attaque Spéciale!",
+		"@1 aumenta l'Attacco Speciale di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Spezial-Angriff!",
+		"¡El Ataque Especial del @0 enemigo ha subido con @1!"
+	],
+	"The @1 raised @0's Special Defense!": [
+		"@0は @1で とくぼうが　あがった！",
+		"@1 de @0 fait augmenter sa Défense Spéciale!",
+		"@1 aumenta la Difesa Speciale di @0!",
+		"@1 von @0 erhöht seine Spezial-Verteidigung!",
+		"¡La Defensa Especial de @0 ha subido con @1!"
+	],
+	"The @1 raised the foe's @0's Special Defense!": [
+		"あいての　@0は @1で とくぼうが　あがった！",
+		"@1 du @0 ennemi fait augmenter sa Défense Spéciale!",
+		"@1 aumenta la Difesa Speciale di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Spezial-Verteidigung!",
+		"¡La Defensa Especial del @0 enemigo ha subido con @1!"
+	],
+	"The @1 raised @0's Speed!": [
+		"@0は @1で すばやさが　あがった！",
+		"@1 de @0 fait augmenter sa Vitesse!",
+		"@1 aumenta la Velocità di @0!",
+		"@1 von @0 erhöht seine Initiative!",
+		"¡La Velocidad de @0 ha subido con @1!"
+	],
+	"The @1 raised the foe's @0's Speed!": [
+		"あいての　@0は @1で すばやさが　あがった！",
+		"@1 du @0 ennemi fait augmenter sa Vitesse!",
+		"@1 aumenta la Velocità di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Initiative!",
+		"¡La Velocidad del @0 enemigo ha subido con @1!"
+	],
+	"The @1 raised @0's accuracy!": [
+		"@0は @1で めいちゅうりつが　あがった！",
+		"@1 de @0 fait augmenter sa Précision!",
+		"@1 aumenta la precisione di @0!",
+		"@1 von @0 erhöht seine Genauigkeit!",
+		"¡La Precisión de @0 ha subido con @1!"
+	],
+	"The @1 raised the foe's @0's accuracy!": [
+		"あいての　@0は @1で めいちゅうりつが　あがった！",
+		"@1 du @0 ennemi fait augmenter sa Précision!",
+		"@1 aumenta la precisione di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Genauigkeit!",
+		"¡La Precisión del @0 enemigo ha subido con @1!"
+	],
+	"The @1 raised @0's evasiveness!": [
+		"@0は @1で かいひりつが　あがった！",
+		"@1 de @0 fait augmenter son Esquive!",
+		"@1 aumenta l'elusione di @0!",
+		"@1 von @0 erhöht seinen Fluchtwert!",
+		"¡La Evasión de @0 ha subido con @1!"
+	],
+	"The @1 raised the foe's @0's evasiveness!": [
+		"あいての　@0は @1で かいひりつが　あがった！",
+		"@1 du @0 ennemi fait augmenter son Esquive!",
+		"@1 aumenta l'elusione di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Fluchtwert!",
+		"¡La Evasión del @0 enemigo ha subido con @1!"
+	],
+	"The @1 sharply raised @0's Attack!": [
+		"@0は @1で こうげきが　ぐーんと　あがった！",
+		"@1 de @0 fait beaucoup augmenter son Attaque!",
+		"@1 aumenta molto l'Attacco di @0!",
+		"@1 von @0 erhöht seinen Angriff stark!",
+		"¡El Ataque de @0 ha subido mucho con @1!"
+	],
+	"The @1 sharply raised the foe's @0's Attack!": [
+		"あいての　@0は @1で こうげきが　ぐーんと　あがった！",
+		"@1 du @0 ennemi fait beaucoup augmenter son Attaque!",
+		"@1 aumenta molto l'Attacco di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Angriff stark!",
+		"¡El Ataque del @0 enemigo ha subido mucho con @1!"
+	],
+	"The @1 sharply raised @0's Defense!": [
+		"@0は @1で ぼうぎょが　ぐーんと　あがった！",
+		"@1 de @0 fait beaucoup augmenter sa Défense!",
+		"@1 aumenta molto la Difesa di @0!",
+		"@1 von @0 erhöht seine Verteidigung stark!",
+		"¡La Defensa de @0 ha subido mucho con @1!"
+	],
+	"The @1 sharply raised the foe's @0's Defense!": [
+		"あいての　@0は @1で ぼうぎょが　ぐーんと　あがった！",
+		"@1 du @0 ennemi fait beaucoup augmenter sa Défense!",
+		"@1 aumenta molto la Difesa di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Verteidigung stark!",
+		"¡La Defensa del @0 enemigo ha subido mucho con @1!"
+	],
+	"The @1 sharply raised @0's Special Attack!": [
+		"@0は @1で とくこうが　ぐーんと　あがった！",
+		"@1 de @0 fait beaucoup augmenter son Attaque Spéciale!",
+		"@1 aumenta molto l'Attacco Speciale di @0!",
+		"@1 von @0 erhöht seinen Spezial-Angriff stark!",
+		"¡El Ataque Especial de @0 ha subido mucho con @1!"
+	],
+	"The @1 sharply raised the foe's @0's Special Attack!": [
+		"あいての　@0は @1で とくこうが　ぐーんと　あがった！",
+		"@1 du @0 ennemi fait beaucoup augmenter son Attaque Spéciale!",
+		"@1 aumenta molto l'Attacco Speciale di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Spezial-Angriff stark!",
+		"¡El Ataque Especial del @0 enemigo ha subido mucho con @1!"
+	],
+	"The @1 sharply raised @0's Special Defense!": [
+		"@0は @1で とくぼうが　ぐーんと　あがった！",
+		"@1 de @0 fait beaucoup augmenter sa Défense Spéciale!",
+		"@1 aumenta molto la Difesa Speciale di @0!",
+		"@1 von @0 erhöht seine Spezial-Verteidigung stark!",
+		"¡La Defensa Especial de @0 ha subido mucho con @1!"
+	],
+	"The @1 sharply raised the foe's @0's Special Defense!": [
+		"あいての　@0は @1で とくぼうが　ぐーんと　あがった！",
+		"@1 du @0 ennemi fait beaucoup augmenter sa Défense Spéciale!",
+		"@1 aumenta molto la Difesa Speciale di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Spezial-Verteidigung stark!",
+		"¡La Defensa Especial del @0 enemigo ha subido mucho con @1!"
+	],
+	"The @1 sharply raised @0's Speed!": [
+		"@0は @1で すばやさが　ぐーんと　あがった！",
+		"@1 de @0 fait beaucoup augmenter sa Vitesse!",
+		"@1 aumenta molto la Velocità di @0!",
+		"@1 von @0 erhöht seine Initiative stark!",
+		"¡La Velocidad de @0 ha subido mucho con @1!"
+	],
+	"The @1 sharply raised the foe's @0's Speed!": [
+		"あいての　@0は @1で すばやさが　ぐーんと　あがった！",
+		"@1 du @0 ennemi fait beaucoup augmenter sa Vitesse!",
+		"@1 aumenta molto la Velocità di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Initiative stark!",
+		"¡La Velocidad del @0 enemigo ha subido mucho con @1!"
+	],
+	"The @1 sharply raised @0's accuracy!": [
+		"@0は @1で めいちゅうりつが　ぐーんと　あがった！",
+		"@1 de @0 fait beaucoup augmenter sa Précision!",
+		"@1 aumenta molto la precisione di @0!",
+		"@1 von @0 erhöht seine Genauigkeit stark!",
+		"¡La Precisión de @0 ha subido mucho con @1!"
+	],
+	"The @1 sharply raised the foe's @0's accuracy!": [
+		"あいての　@0は @1で めいちゅうりつが　ぐーんと　あがった！",
+		"@1 du @0 ennemi fait beaucoup augmenter sa Précision!",
+		"@1 aumenta molto la precisione di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Genauigkeit stark!",
+		"¡La Precisión del @0 enemigo ha subido mucho con @1!"
+	],
+	"The @1 sharply raised @0's evasiveness!": [
+		"@0は @1で かいひりつが　ぐーんと　あがった！",
+		"@1 de @0 fait beaucoup augmenter son Esquive!",
+		"@1 aumenta molto l'elusione di @0!",
+		"@1 von @0 erhöht seinen Fluchtwert stark!",
+		"¡La Evasión de @0 ha subido mucho con @1!"
+	],
+	"The @1 sharply raised the foe's @0's evasiveness!": [
+		"あいての　@0は @1で かいひりつが　ぐーんと　あがった！",
+		"@1 du @0 ennemi fait beaucoup augmenter son Esquive!",
+		"@1 aumenta molto l'elusione di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Fluchtwert stark!",
+		"¡La Evasión del @0 enemigo ha subido mucho con @1!"
+	],
+	"The @1 drastically raised @0's Attack!": [
+		"@0は @1で こうげきが　ぐぐーんと　あがった！",
+		"@1 de @0 fait énormément augmenter son Attaque!",
+		"@1 aumenta moltissimo l'Attacco di @0!",
+		"@1 von @0 erhöht seinen Angriff drastisch!",
+		"¡El Ataque de @0 ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised the foe's @0's Attack!": [
+		"あいての　@0は @1で こうげきが　ぐぐーんと　あがった！",
+		"@1 du @0 ennemi fait énormément augmenter son Attaque!",
+		"@1 aumenta moltissimo l'Attacco di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Angriff drastisch!",
+		"¡El Ataque del @0 enemigo ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised @0's Defense!": [
+		"@0は @1で ぼうぎょが　ぐぐーんと　あがった！",
+		"@1 de @0 fait énormément augmenter sa Défense!",
+		"@1 aumenta moltissimo la Difesa di @0!",
+		"@1 von @0 erhöht seine Verteidigung drastisch!",
+		"¡La Defensa de @0 ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised the foe's @0's Defense!": [
+		"あいての　@0は @1で ぼうぎょが　ぐぐーんと　あがった！",
+		"@1 du @0 ennemi fait énormément augmenter sa Défense!",
+		"@1 aumenta moltissimo la Difesa di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Verteidigung drastisch!",
+		"¡La Defensa del @0 enemigo ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised @0's Special Attack!": [
+		"@0は @1で とくこうが　ぐぐーんと　あがった！",
+		"@1 de @0 fait énormément augmenter son Attaque Spéciale!",
+		"@1 aumenta moltissimo l'Attacco Speciale di @0!",
+		"@1 von @0 erhöht seinen Spezial-Angriff drastisch!",
+		"¡El Ataque Especial de @0 ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised the foe's @0's Special Attack!": [
+		"あいての　@0は @1で とくこうが　ぐぐーんと　あがった！",
+		"@1 du @0 ennemi fait énormément augmenter son Attaque Spéciale!",
+		"@1 aumenta moltissimo l'Attacco Speciale di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Spezial-Angriff drastisch!",
+		"¡El Ataque Especial del @0 enemigo ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised @0's Special Defense!": [
+		"@0は @1で とくぼうが　ぐぐーんと　あがった！",
+		"@1 de @0 fait énormément augmenter sa Défense Spéciale!",
+		"@1 aumenta moltissimo la Difesa Speciale di @0!",
+		"@1 von @0 erhöht seine Spezial-Verteidigung drastisch!",
+		"¡La Defensa Especial de @0 ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised the foe's @0's Special Defense!": [
+		"あいての　@0は @1で とくぼうが　ぐぐーんと　あがった！",
+		"@1 du @0 ennemi fait énormément augmenter sa Défense Spéciale!",
+		"@1 aumenta moltissimo la Difesa Speciale di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Spezial-Verteidigung drastisch!",
+		"¡La Defensa Especial del @0 enemigo ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised @0's Speed!": [
+		"@0は @1で すばやさが　ぐぐーんと　あがった！",
+		"@1 de @0 fait énormément augmenter sa Vitesse!",
+		"@1 aumenta moltissimo la Velocità di @0!",
+		"@1 von @0 erhöht seine Initiative drastisch!",
+		"¡La Velocidad de @0 ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised the foe's @0's Speed!": [
+		"あいての　@0は @1で すばやさが　ぐぐーんと　あがった！",
+		"@1 du @0 ennemi fait énormément augmenter sa Vitesse!",
+		"@1 aumenta moltissimo la Velocità di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Initiative drastisch!",
+		"¡La Velocidad del @0 enemigo ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised @0's accuracy!": [
+		"@0は @1で めいちゅうりつが　ぐぐーんと　あがった！",
+		"@1 de @0 fait énormément augmenter sa Précision!",
+		"@1 aumenta moltissimo la precisione di @0!",
+		"@1 von @0 erhöht seine Genauigkeit drastisch!",
+		"¡La Precisión de @0 ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised the foe's @0's accuracy!": [
+		"あいての　@0は @1で めいちゅうりつが　ぐぐーんと　あがった！",
+		"@1 du @0 ennemi fait énormément augmenter sa Précision!",
+		"@1 aumenta moltissimo la precisione di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seine Genauigkeit drastisch!",
+		"¡La Precisión del @0 enemigo ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised @0's evasiveness!": [
+		"@0は @1で かいひりつが　ぐぐーんと　あがった！",
+		"@1 de @0 fait énormément augmenter son Esquive!",
+		"@1 aumenta moltissimo l'elusione di @0!",
+		"@1 von @0 erhöht seinen Fluchtwert drastisch!",
+		"¡La Evasión de @0 ha subido muchísimo con @1!"
+	],
+	"The @1 drastically raised the foe's @0's evasiveness!": [
+		"あいての　@0は @1で かいひりつが　ぐぐーんと　あがった！",
+		"@1 du @0 ennemi fait énormément augmenter son Esquive!",
+		"@1 aumenta moltissimo l'elusione di @0 nemico!",
+		"@1 von @0 (Gegner) erhöht seinen Fluchtwert drastisch!",
+		"¡La Evasión del @0 enemigo ha subido muchísimo con @1!"
+	],
+	"@0 used the @1 to get pumped!": [
+		"@0は @1を　つかって はりきりだした！",
+		"@0 est plein d'énergie grâce à l'objet: @1!",
+		"@0 usa @1: ha più probabilità di sferrare brutti colpi!",
+		"@0 pumpt sich mittels @1 auf!",
+		"¡@0 usa @1 para aumentar el índice de golpe crítico!"
+	],
+	"The foe's @0 used the @1 to get pumped!": [
+		"あいての　@0は @1を　つかって はりきりだした！",
+		"Le @0 ennemi est plein d'énergie grâce à l'objet: @1!",
+		"@0 nemico usa @1: ha più probabilità di sferrare brutti colpi!",
+		"@0 (Gegner) pumpt sich mittels @1 auf!",
+		"¡El @0 enemigo usa @1 para aumentar el índice de golpe crítico!"
+	],
+	"@0 fled using its @1!": [
+		"@0は　もっていた @1を　つかって　にげた！",
+		"@0 fuit en utilisant l'objet @1!",
+		"@0 fugge usando @1!",
+		"@0 flieht durch Einsatz von @1!",
+		"¡@0 se ha escapado usando @1!"
+	],
+	"The foe's @0 fled using its @1!": [
+		"あいての　@0は　もっていた @1を　つかって　にげた！",
+		"Le @0 ennemi fuit en utilisant l'objet @1!",
+		"@0 nemico fugge usando @1!",
+		"@0 (Gegner) flieht durch Einsatz von @1!",
+		"¡El @0 enemigo se ha escapado usando @1!"
+	],
+	"@0 hung on using its @1!": [
+		"@0は @1で　もちこたえた！",
+		"@0 tient bon grâce à l'objet @1!",
+		"@0 resiste usando @1!",
+		"@0 hält mithilfe von @1 durch!",
+		"¡@0 ha resistido usando @1!"
+	],
+	"The foe's @0 hung on using its @1!": [
+		"あいての　@0は @1で　もちこたえた！",
+		"Le @0 ennemi tient bon grâce à l'objet @1!",
+		"@0 nemico resiste usando @1!",
+		"@0 (Gegner) hält mithilfe von @1 durch!",
+		"¡El @0 enemigo ha resistido usando @1!"
+	],
+	"@0 restored its status using its @1!": [
+		"@0は　@1で ステータスを　もとに　もどした！",
+		"@1 de @0 restaure ses stats!",
+		"@1 ristabilisce le statistiche di @0!",
+		"@1 von @0 stellt seine Statuswerte wieder her!",
+		"¡@1 de @0 ha restaurado sus características!"
+	],
+	"The foe's @0 restored its status using its @1!": [
+		"あいての　@0は　@1で ステータスを　もとに　もどした！",
+		"@1 du @0 ennemi restaure ses stats!",
+		"@1 ristabilisce le statistiche di @0 nemico!",
+		"@1 von @0 (Gegner) stellt seine Statuswerte wieder her!",
+		"¡@1 del @0 enemigo ha restaurado sus características!"
+	],
+	"@0 lost some of its HP!": [
+		"@0は いのちが　すこし　けずられた！",
+		"@0 perd quelques PV!",
+		"@0 perde qualche Punto Salute!",
+		"@0 verliert einige KP!",
+		"¡Los PS de @0 han disminuido un poco!"
+	],
+	"The foe's @0 lost some of its HP!": [
+		"あいての　@0は いのちが　すこし　けずられた！",
+		"Le @0 ennemi perd quelques PV!",
+		"@0 nemico perde qualche Punto Salute!",
+		"@0 (Gegner) verliert einige KP!",
+		"¡Los PS del @0 enemigo han disminuido un poco!"
+	],
+	"...But @0 is not here!": [
+		"…しかし　@0は このばに　いなかった！",
+		"... Mais @0 n'était plus là!",
+		"Ma @0 in questo momento non c'è!",
+		"Aber @0 ist gar nicht dort!",
+		"¡Pero @0 no estaba ahí!"
+	],
+	"...But the foe's @0 is not here!": [
+		"…しかし　あいての　@0は このばに　いなかった！",
+		"... Mais le @0 ennemi n'était plus là!",
+		"Ma @0 nemico in questo momento non c'è!",
+		"Aber @0 (Gegner) ist gar nicht dort!",
+		"¡Pero el @0 enemigo no estaba ahí!"
+	],
+	"...But @0 was not holding a usable item!": [
+		"…しかし　@0は つかえる　どうぐを　もっていなかった！",
+		"... Mais @0 n'avait plus d'objet!",
+		"Ma @0 non ha più strumenti da usare!",
+		"Aber @0 trägt kein Item bei sich, das es einsetzen könnte!",
+		"¡Pero @0 no tiene ningún objeto que pueda usar!"
+	],
+	"...But the foe's @0 was not holding a usable item!": [
+		"…しかし　あいての　@0は つかえる　どうぐを　もっていなかった！",
+		"... Mais le @0 ennemi n'avait plus d'objet!",
+		"Ma @0 nemico non ha più strumenti da usare!",
+		"Aber @0 (Gegner) trägt kein Item bei sich, das es einsetzen könnte!",
+		"¡Pero el @0 enemigo no tiene ningún objeto que pueda usar!"
+	],
+	"@0 became fully charged due to its @1!": [
+		"@0は　@1で ちからが　みなぎった！",
+		"@0 est complètement chargé grâce à l'objet @1!",
+		"@0 è completamente carico grazie a @1!",
+		"Dank @1 ist @0 sofort bereit!",
+		"¡@0 ya está listo gracias a @1!"
+	],
+	"The foe's @0 became fully charged due to its @1!": [
+		"あいての　@0は　@1で ちからが　みなぎった！",
+		"Le @0 ennemi est complètement chargé grâce à l'objet @1!",
+		"@0 nemico è completamente carico grazie a @1!",
+		"Dank @1 ist @0 (Gegner) sofort bereit!",
+		"¡El @0 enemigo ya está listo gracias a @1!"
+	],
+	"@0's @1 let it move first!": [
+		"@0は　@1で こうどうが　はやくなった！",
+		"@1 de @0 lui permet d'agir en premier!",
+		"@0 fa la prima mossa grazie a @1!",
+		"Dank @1 kann @0 den ersten Zug machen!",
+		"¡@0 se mueve primero gracias a @1!"
+	],
+	"The foe's @0's @1 let it move first!": [
+		"あいての　@0は　@1で こうどうが　はやくなった！",
+		"@1 du @0 ennemi lui permet d'agir en premier!",
+		"@0 nemico fa la prima mossa grazie a @1!",
+		"Dank @1 kann @0 (Gegner) den ersten Zug machen!",
+		"¡El @0 enemigo se mueve primero gracias a @1!"
+	],
+	"@0 boosted the accuracy of its next move using its @1!": [
+		"@0は　@1で つぎに　くりだす　わざが あたりやすくなった！",
+		"@0 augmente la Précision de sa prochaine capacité avec l'objet: @1!",
+		"@0 aumenta la precisione della sua prossima mossa con @1!",
+		"@0 verbessert die Genauigkeit seiner nächsten Attacke mithilfe von @1!",
+		"¡@0 ha aumentado la Precisión de su próximo movimiento usando @1!"
+	],
+	"The foe's @0 boosted the accuracy of its next move using its @1!": [
+		"あいての　@0は　@1で つぎに　くりだす　わざが あたりやすくなった！",
+		"Le @0 ennemi augmente la Précision de sa prochaine capacité avec l'objet: @1!",
+		"@0 nemico aumenta la precisione della sua prossima mossa con @1!",
+		"@0 (Gegner) verbessert die Genauigkeit seiner nächsten Attacke mithilfe von @1!",
+		"¡El @0 enemigo ha aumentado la Precisión de su próximo movimiento usando @1!"
+	],
+	"@0 is hurt by @1's @2!": [
+		"@0は @1の　@2で ダメージを　うけた！",
+		"@2 de @1 blesse @0!",
+		"@2 di @1 ferisce @0!",
+		"@0 wird durch @2 von @1 verletzt!",
+		"¡@0 ha sido herido por @2 de @1!"
+	],
+	"@0 is hurt by the foe's @1's @2!": [
+		"@0は あいての　@1の　@2で ダメージを　うけた！",
+		"@2 du @1 ennemi blesse @0!",
+		"@2 di @1 nemico ferisce @0!",
+		"@0 wird durch @2 von @1 (Gegner) verletzt!",
+		"¡@0 ha sido herido por @2 del @1 enemigo!"
+	],
+	"The foe's @0 is hurt by @1's @2!": [
+		"あいての　@0は @1の　@2で ダメージを　うけた！",
+		"@2 de @1 blesse le @0 ennemi!",
+		"@2 di @1 ferisce @0 nemico!",
+		"@0 (Gegner) wird durch @2 von @1 verletzt!",
+		"¡El @0 enemigo ha sido herido por @2 de @1!"
+	],
+	"The foe's @0 is hurt by the foe's @1's @2!": [
+		"あいての　@0は あいての　@1の　@2で ダメージを　うけた！",
+		"@2 du @1 ennemi blesse le @0 ennemi!",
+		"@2 di @1 nemico ferisce @0 nemico!",
+		"@0 (Gegner) wird durch @2 von @1 (Gegner) verletzt!",
+		"¡El @0 enemigo ha sido herido por @2 del @1 enemigo!"
+	],
+	"@0 is hurt by its @1!": [
+		"@0は　@1で ダメージを　うけた！",
+		"@0 est blessé par l'objet: @1!",
+		"@0 è ferito da @1!",
+		"@0 wurde durch das Item @1 verletzt!",
+		"¡@0 ha sido dañado por el objeto @1!"
+	],
+	"The foe's @0 is hurt by its @1!": [
+		"あいての　@0は　@1で ダメージを　うけた！",
+		"Le @0 ennemi est blessé par l'objet: @1!",
+		"@0 nemico è ferito da @1!",
+		"@0 (Gegner) wurde durch das Item @1 verletzt!",
+		"¡El @0 enemigo ha sido dañado por el objeto @1!"
+	],
+	"@0 is getting pumped!": [
+		"@0は はりきっている！",
+		"@0 se gonfle!",
+		"@0 si prepara alla lotta!",
+		"@0 pumpt sich auf!",
+		"¡@0 se está preparando para luchar!"
+	],
+	"The foe's @0 is getting pumped!": [
+		"あいての　@0は はりきっている！",
+		"Le @0 ennemi se gonfle!",
+		"@0 nemico si prepara alla lotta!",
+		"@0 (Gegner) pumpt sich auf!",
+		"¡El @0 enemigo se está preparando para luchar!"
+	],
+	"@0 is ready to help @1!": [
+		"@0は @1を てだすけする　たいせいに　はいった！",
+		"@0 est prêt à aider @1!",
+		"@0 è pronto ad aiutare @1!",
+		"@0 will @1 helfen!",
+		"¡@0 está listo para ayudar a @1!"
+	],
+	"The foe's @0 is ready to help @1!": [
+		"あいての　@0は @1を てだすけする　たいせいに　はいった！",
+		"Le @0 ennemi est prêt à aider le @1 ennemi!",
+		"@0 nemico è pronto ad aiutare @1!",
+		"@0 (Gegner) will @1 helfen!",
+		"¡El @0 enemigo está listo para ayudar a @1!"
+	],
+	"@0 copied @1's stat changes!": [
+		"@0は @1の のうりょく　へんかを　コピーした！",
+		"@0 copie les changements de stats de @1!",
+		"@0 copia le modifiche alle statistiche di @1!",
+		"@0 kopiert die Statusveränderungen von @1!",
+		"¡@0 copia los cambios en las características de @1!"
+	],
+	"The foe's @0 copied @1's stat changes!": [
+		"あいての　@0は @1の のうりょく　へんかを　コピーした！",
+		"Le @0 ennemi copie les changements de stats de @1!",
+		"@0 nemico copia le modifiche alle statistiche di @1!",
+		"@0 (Gegner) kopiert die Statusveränderungen von @1!",
+		"¡El @0 enemigo copia los cambios en las características de @1!"
+	],
+	"@0 knocked off @1's @2!": [
+		"@0は @1の @2を　はたきおとした！",
+		"@0 fait tomber l'objet @2 de @1!",
+		"@0 fa cadere @2 di @1!",
+		"@0 schnappt sich @2 von @1!",
+		"¡@0 hace caer el objeto @2 de @1!"
+	],
+	"@0 knocked off the foe's @1's @2!": [
+		"@0は　あいての　@1の @2を　はたきおとした！",
+		"@0 fait tomber l'objet @2 du @1 ennemi!",
+		"@0 fa cadere @2 di @1 nemico!",
+		"@0 schnappt sich @2 von @1 (Gegner)!",
+		"¡@0 hace caer el objeto @2 del @1 enemigo!"
+	],
+	"The foe's @0 knocked off @1's @2!": [
+		"あいての　@0は　@1の @2を　はたきおとした！",
+		"Le @0 ennemi fait tomber l'objet @2 de @1!",
+		"@0 nemico fa cadere @2 di @1!",
+		"@0 (Gegner) schnappt sich @2 von @1!",
+		"¡El @0 enemigo hace caer el objeto @2 de @1!"
+	],
+	"The foe's @0 knocked off the foe's @1's @2!": [
+		"あいての　@0は あいての　@1の @2を　はたきおとした！",
+		"Le @0 ennemi fait tomber l'objet @2 du @1 ennemi!",
+		"@0 nemico fa cadere @2 di @1 nemico!",
+		"@0 (Gegner) schnappt sich @2 von @1 (Gegner)!",
+		"¡El @0 enemigo hace caer el objeto @2 del @1 enemigo!"
+	],
+	"@0 stole @1's @2!": [
+		"@0は @1から @2を　うばいとった！",
+		"@0 vole l'objet @2 à @1!",
+		"@0 ruba @2 di @1!",
+		"@0 stiehlt @2 von @1!",
+		"¡@0 le ha robado @2 a @1!"
+	],
+	"@0 stole the foe's @1's @2!": [
+		"@0は あいての　@1から @2を　うばいとった！",
+		"@0 vole l'objet @2 au @1 ennemi!",
+		"@0 ruba @2 di @1 nemico!",
+		"@0 stiehlt @2 von @1 (Gegner)!",
+		"¡@0 le ha robado @2 al @1 enemigo!"
+	],
+	"The foe's @0 stole @1's @2!": [
+		"あいての　@0は @1から @2を　うばいとった！",
+		"Le @0 ennemi vole l'objet @2 à @1!",
+		"@0 nemico ruba @2 di @1!",
+		"@0 (Gegner) stiehlt @2 von @1!",
+		"¡El @0 enemigo le ha robado @2 a @1!"
+	],
+	"The foe's @0 stole the foe's @1's @2!": [
+		"あいての　@0は あいての　@1から @2を　うばいとった！",
+		"Le @0 ennemi vole l'objet @2 au @1 ennemi!",
+		"@0 nemico ruba @2 di @1 nemico!",
+		"@0 (Gegner) stiehlt @2 von @1 (Gegner)!",
+		"¡El @0 enemigo le ha robado @2 al @1 enemigo!"
+	],
+	"@0 cut its own HP and laid a curse on @1!": [
+		"@0は じぶんの　たいりょくを　けずって @1に　のろいを　かけた！",
+		"@0 sacrifie ses PV et lance une Malédiction à @1!",
+		"@0 riduce i suoi Punti Salute per lanciare Maledizione su @1!",
+		"@0 nimmt einen Teil seiner KP und legt einen Fluch auf @1!",
+		"¡@0 reduce sus PS y maldice a @1!"
+	],
+	"@0 cut its own HP and laid a curse on the foe's @1!": [
+		"@0は じぶんの　たいりょくを　けずって あいての　@1に　のろいを　かけた！",
+		"@0 sacrifie ses PV et lance une Malédiction au @1 ennemi!",
+		"@0 riduce i suoi Punti Salute per lanciare Maledizione su @1 nemico!",
+		"@0 nimmt einen Teil seiner KP und legt einen Fluch auf @1 (Gegner)!",
+		"¡@0 reduce sus PS y maldice al @1 enemigo!"
+	],
+	"The foe's @0 cut its own HP and laid a curse on @1!": [
+		"あいての　@0は じぶんの　たいりょくを　けずって @1に　のろいを　かけた！",
+		"Le @0 ennemi sacrifie ses PV et lance une Malédiction à @1!",
+		"@0 nemico riduce i suoi Punti Salute per lanciare Maledizione su @1!",
+		"@0 (Gegner) nimmt einen Teil seiner KP und legt einen Fluch auf @1!",
+		"¡El @0 enemigo reduce sus PS y maldice a @1!"
+	],
+	"The foe's @0 cut its own HP and laid a curse on the foe's @1!": [
+		"あいての　@0は じぶんの　たいりょくを　けずって あいての　@1に　のろいを　かけた！",
+		"Le @0 ennemi sacrifie ses PV et lance une Malédiction au @1 ennemi!",
+		"@0 nemico riduce i suoi Punti Salute per lanciare Maledizione su @1 nemico!",
+		"@0 (Gegner) nimmt einen Teil seiner KP und legt einen Fluch auf @1 (Gegner)!",
+		"¡El @0 enemigo reduce sus PS y maldice al @1 enemigo!"
+	],
+	"@0 is afflicted by the curse!": [
+		"@0は のろわれている！",
+		"@0 est touché par la Malédiction!",
+		"@0 è colpito da Maledizione!",
+		"@0 wurde durch Fluch verletzt!",
+		"¡@0 es víctima de una maldición!"
+	],
+	"The foe's @0 is afflicted by the curse!": [
+		"あいての　@0は のろわれている！",
+		"Le @0 ennemi est touché par la Malédiction!",
+		"@0 nemico è colpito da Maledizione!",
+		"@0 (Gegner) wurde durch Fluch verletzt!",
+		"¡El @0 enemigo es víctima de una maldición!"
+	],
+	"@0 foresaw an attack!": [
+		"@0は みらいに　こうげきを　よちした！",
+		"@0 prévoit une attaque!",
+		"@0 presagisce il futuro imminente!",
+		"@0 sieht eine Attacke voraus!",
+		"¡@0 ha previsto el ataque!"
+	],
+	"The foe's @0 foresaw an attack!": [
+		"あいての　@0は みらいに　こうげきを　よちした！",
+		"Le @0 ennemi prévoit une attaque!",
+		"@0 nemico presagisce il futuro imminente!",
+		"@0 (Gegner) sieht eine Attacke voraus!",
+		"¡El @0 enemigo ha previsto el ataque!"
+	],
+	"@0 chose Doom Desire as its destiny!": [
+		"@0は はめつのねがいを　みらいに　たくした！",
+		"@0 souhaite le déclenchement de Carnareket!",
+		"@0 affida al futuro il suo Obbliderio!",
+		"@0 äußert einen Kismetwunsch für die Zukunft!",
+		"¡@0 expresa su deseo oculto para el futuro!"
+	],
+	"The foe's @0 chose Doom Desire as its destiny!": [
+		"あいての　@0は はめつのねがいを　みらいに　たくした！",
+		"Le @0 ennemi souhaite le déclenchement de Carnareket!",
+		"@0 nemico affida al futuro il suo Obbliderio!",
+		"@0 (Gegner) äußert einen Kismetwunsch für die Zukunft!",
+		"¡El @0 enemigo expresa su deseo oculto para el futuro!"
+	],
+	"@0 took the @1 attack!": [
+		"@0は @1の　こうげきを　うけた！",
+		"@0 reçoit l'attaque @1!",
+		"@0 subisce @1!",
+		"@0 wurde von @1 getroffen!",
+		"¡@0 ha sufrido el ataque @1!"
+	],
+	"The foe's @0 took the @1 attack!": [
+		"あいての　@0は @1の　こうげきを　うけた！",
+		"Le @0 ennemi reçoit l'attaque @1!",
+		"@0 nemico subisce @1!",
+		"@0 (Gegner) wurde von @1 getroffen!",
+		"¡El @0 enemigo ha sufrido el ataque @1!"
+	],
+	"@0 couldn't stay airborne because of gravity!": [
+		"@0は じゅうりょくの　えいきょうで くうちゅうに　いられなくなった！",
+		"@0 ne peut pas rester en l'air à cause de la Gravité!",
+		"@0 non riesce a rimanere in aria a causa di Gravità!",
+		"@0 kann aufgrund von Erdanziehung nicht mehr in der Luft bleiben!",
+		"¡@0 no ha podido mantenerse en el aire por la gravedad!"
+	],
+	"The foe's @0 couldn't stay airborne because of gravity!": [
+		"あいての　@0は じゅうりょくの　えいきょうで くうちゅうに　いられなくなった！",
+		"Le @0 ennemi ne peut pas rester en l'air à cause de la Gravité!",
+		"@0 nemico non riesce a rimanere in aria a causa di Gravità!",
+		"@0 (Gegner) kann aufgrund von Erdanziehung nicht mehr in der Luft bleiben!",
+		"¡El @0 enemigo no ha podido mantenerse en el aire por la gravedad!"
+	],
+	"@0 can't use @1 because of gravity!": [
+		"@0は じゅうりょくが　つよくて @1が　だせない！",
+		"@0 ne peut pas utiliser @1 à cause de la Gravité!",
+		"Gravità impedisce a @0 di usare @1!",
+		"@0 kann @1 aufgrund von Erdanziehung nicht einsetzen!",
+		"¡@0 no puede usar @1 debido a la gravedad!"
+	],
+	"The foe's @0 can't use @1 because of gravity!": [
+		"あいての　@0は じゅうりょくが　つよくて @1が　だせない！",
+		"Le @0 ennemi ne peut pas utiliser @1 à cause de la Gravité!",
+		"Gravità impedisce a @0 nemico di usare @1!",
+		"@0 (Gegner) kann @1 aufgrund von Erdanziehung nicht einsetzen!",
+		"¡El @0 enemigo no puede usar @1 debido a la gravedad!"
+	],
+	"@0's type changed to match @1's!": [
+		"@0は @1と おなじタイプになった！",
+		"@0 a pris le même type que @1!",
+		"@0 assume il tipo di @1!",
+		"@0 hat den Typ von @1 angenommen!",
+		"¡@0 ahora es del mismo tipo que @1!"
+	],
+	"@0's type changed to match the foe's @1's!": [
+		"@0は あいての　@1と おなじタイプになった！",
+		"@0 a pris le même type que le @1 ennemi!",
+		"@0 assume il tipo di @1 nemico!",
+		"@0 hat den Typ von @1 (Gegner) angenommen!",
+		"¡@0 ahora es del mismo tipo que el @1 enemigo!"
+	],
+	"The foe's @0's type changed to match @1's!": [
+		"あいての　@0は @1と おなじタイプになった！",
+		"Le @0 ennemi a pris le même type que @1!",
+		"@0 nemico assume il tipo di @1!",
+		"@0 (Gegner) hat den Typ von @1 angenommen!",
+		"¡El @0 enemigo ahora es del mismo tipo que @1!"
+	],
+	"The foe's @0's type changed to match the foe's @1's!": [
+		"あいての　@0は あいての　@1と おなじタイプになった！",
+		"Le @0 ennemi a pris le même type que le @1 ennemi!",
+		"@0 nemico assume il tipo di @1 nemico!",
+		"@0 (Gegner) hat den Typ von @1 (Gegner) angenommen!",
+		"¡El @0 enemigo ahora es del mismo tipo que el @1 enemigo!"
+	],
+	"@0 shared its power with the target!": [
+		"@0は おたがいのパワーを　シェアした！",
+		"@0 partage ses forces avec sa cible!",
+		"@0 condivide la sua forza!",
+		"@0 teilt Kräfte auf!",
+		"¡@0 comparte su fuerza con el objetivo!"
+	],
+	"The foe's @0 shared its power with the target!": [
+		"あいての　@0は おたがいのパワーを　シェアした！",
+		"Le @0 ennemi partage ses forces avec sa cible!",
+		"@0 nemico condivide la sua forza!",
+		"@0 (Gegner) teilt Kräfte auf!",
+		"¡El @0 enemigo comparte su fuerza con el objetivo!"
+	],
+	"@0 shared its guard with the target!": [
+		"@0は おたがいのガードを　シェアした！",
+		"@0 partage sa garde avec sa cible!",
+		"@0 condivide le sue capacità difensive!",
+		"@0 teilt Schutzkräfte auf!",
+		"¡@0 comparte su guardia con el objetivo!"
+	],
+	"The foe's @0 shared its guard with the target!": [
+		"あいての　@0は おたがいのガードを　シェアした！",
+		"Le @0 ennemi partage sa garde avec sa cible!",
+		"@0 nemico condivide le sue capacità difensive!",
+		"@0 (Gegner) teilt Schutzkräfte auf!",
+		"¡El @0 enemigo comparte su guardia con el objetivo!"
+	],
+	"@0 became nimble!": [
+		"@0は みがるになった！",
+		"@0 est devenu très vif!",
+		"@0 diventa velocissimo!",
+		"@0 ist leichter geworden!",
+		"¡@0 es ahora más ligero!"
+	],
+	"The foe's @0 became nimble!": [
+		"あいての　@0は みがるになった！",
+		"Le @0 ennemi est devenu très vif!",
+		"@0 nemico diventa velocissimo!",
+		"@0 (Gegner) ist leichter geworden!",
+		"¡El @0 enemigo es ahora más ligero!"
+	],
+	"The bursting flame hit @0!": [
+		"@0にも ひばなが　ふりかかった！",
+		"@0 est arrosé d'une gerbe d'étincelles!",
+		"Le fiamme raggiungono anche @0!",
+		"@0 wurde ebenfalls vom Funkenflug erfasst!",
+		"¡Las chispas también han alcanzado a @0!"
+	],
+	"The bursting flame hit the foe's @0!": [
+		"あいての　@0にも ひばなが　ふりかかった！",
+		"Le @0 ennemi est arrosé d'une gerbe d'étincelles!",
+		"Le fiamme raggiungono anche @0 nemico!",
+		"@0 (Gegner) wurde ebenfalls vom Funkenflug erfasst!",
+		"¡Las chispas también han alcanzado al @0 enemigo!"
+	],
+	"@0's @1 was burnt up!": [
+		"@0の @1は　やけてなくなった！",
+		"@1 de @0 se fait détruire par le feu!",
+		"Lo strumento @1 di @0 viene distrutto dal fuoco!",
+		"@1 von @0 ist verbrannt und somit nutzlos geworden!",
+		"¡@0 ha perdido @1 porque se ha calcinado!"
+	],
+	"The foe's @0's @1 was burnt up!": [
+		"あいての　@0の @1は　やけてなくなった！",
+		"@1 du @0 ennemi se fait détruire par le feu!",
+		"Lo strumento @1 di @0 nemico viene distrutto dal fuoco!",
+		"@1 von @0 (Gegner) ist verbrannt und somit nutzlos geworden!",
+		"¡El @0 enemigo ha perdido @1 porque se ha calcinado!"
+	],
+	"@0 received @2 from @1!": [
+		"@0は @1から @2を　うけとった！",
+		"@0 obtient l'objet @2 de @1!",
+		"@0 ottiene @2 di @1!",
+		"@0 erhält @2 von @1!",
+		"¡@0 ha recibido @2 de @1!"
+	],
+	"@0 received @2 from the foe's @1!": [
+		"@0は あいての　@1から @2を　うけとった！",
+		"@0 obtient l'objet @2 du @1 ennemi!",
+		"@0 ottiene @2 di @1 nemico!",
+		"@0 erhält @2 von @1 (Gegner)!",
+		"¡@0 ha recibido @2 del @1 enemigo!"
+	],
+	"The foe's @0 received @2 from @1!": [
+		"あいての　@0は @1から @2を　うけとった！",
+		"Le @0 ennemi obtient l'objet @2 de @1!",
+		"@0 nemico ottiene @2 di @1!",
+		"@0 (Gegner) erhält @2 von @1!",
+		"¡El @0 enemigo ha recibido @2 de @1!"
+	],
+	"The foe's @0 received @2 from the foe's @1!": [
+		"あいての　@0は あいての　@1から @2を　うけとった！",
+		"Le @0 ennemi obtient l'objet @2 du @1 ennemi!",
+		"@0 nemico ottiene @2 di @1 nemico!",
+		"@0 (Gegner) erhält @2 von @1 (Gegner)!",
+		"¡El @0 enemigo ha recibido @2 del @1 enemigo!"
+	],
+	"@0 took @1 into the sky!": [
+		"@0は　@1を じょうくうに　つれさった！",
+		"@0 emporte @1 haut dans le ciel!",
+		"@0 trascina @1 in alto nel cielo!",
+		"@0 entführt @1 in luftige Höhen!",
+		"¡@0 se ha llevado a @1 por los aires!"
+	],
+	"@0 took the foe's @1 into the sky!": [
+		"@0は　あいての　@1を じょうくうに　つれさった！",
+		"@0 emporte le @1 ennemi haut dans le ciel!",
+		"@0 trascina @1 nemico in alto nel cielo!",
+		"@0 entführt @1 (Gegner) in luftige Höhen!",
+		"¡@0 se ha llevado al @1 enemigo por los aires!"
+	],
+	"The foe's @0 took @1 into the sky!": [
+		"あいての　@0は　@1を じょうくうに　つれさった！",
+		"Le @0 ennemi emporte @1 haut dans le ciel!",
+		"@0 nemico trascina @1 in alto nel cielo!",
+		"@0 (Gegner) entführt @1 in luftige Höhen!",
+		"¡El @0 enemigo se ha llevado a @1 por los aires!"
+	],
+	"The foe's @0 took the foe's @1 into the sky!": [
+		"あいての　@0は あいての　@1を じょうくうに　つれさった！",
+		"Le @0 ennemi emporte le @1 ennemi haut dans le ciel!",
+		"@0 nemico trascina @1 nemico in alto nel cielo!",
+		"@0 (Gegner) entführt @1 (Gegner) in luftige Höhen!",
+		"¡El @0 enemigo se ha llevado al @1 enemigo por los aires!"
+	],
+	"@0 was freed from the Sky Drop!": [
+		"@0は フリーフォールから　かいほうされた！",
+		"@0 est lâché en Chute Libre!",
+		"@0 si libera da Cadutalibera!",
+		"@0 wurde aus dem Freien Fall befreit!",
+		"¡@0 se ha liberado de Caída Libre!"
+	],
+	"The foe's @0 was freed from the Sky Drop!": [
+		"あいての　@0は フリーフォールから　かいほうされた！",
+		"Le @0 ennemi est lâché en Chute Libre!",
+		"@0 nemico si libera da Cadutalibera!",
+		"@0 (Gegner) wurde aus dem Freien Fall befreit!",
+		"¡El @0 enemigo se ha liberado de Caída Libre!"
+	],
+	"@0 fell straight down!": [
+		"@0は うちおとされて　じめんに　おちた！",
+		"Touché par Anti-Air, @0 s'écrase au sol!",
+		"Abbattimento fa schiantare @0 al suolo!",
+		"@0 wurde davongeschleudert und ist herabgestürzt!",
+		"¡@0 ha sido derribado y sufre daño!"
+	],
+	"The foe's @0 fell straight down!": [
+		"あいての　@0は うちおとされて　じめんに　おちた！",
+		"Touché par Anti-Air, le @0 ennemi s'écrase au sol!",
+		"Abbattimento fa schiantare @0 nemico al suolo!",
+		"@0 (Gegner) wurde davon- geschleudert und ist herabgestürzt!",
+		"¡El @0 enemigo ha sido derribado y sufre daño!"
+	],
+	"@0's move was postponed!": [
+		"@0の じゅんばんを　さきおくりした！",
+		"@0 doit retourner à la queue!",
+		"Il turno di @0 slitta!",
+		"@0 hat sich vorgedrängelt!",
+		"¡@0 ha retrasado su turno!"
+	],
+	"The foe's @0's move was postponed!": [
+		"あいての　@0の じゅんばんを　さきおくりした！",
+		"Le @0 ennemi doit retourner à la queue!",
+		"Il turno di @0 nemico slitta!",
+		"@0 (Gegner) hat sich vorgedrängelt!",
+		"¡El @0 enemigo ha retrasado su turno!"
+	],
+	"@0 took the kind offer!": [
+		"@0は おことばに　あまえることにした！",
+		"@0 accepte avec joie!",
+		"@0 approfitta della Cortesia!",
+		"@0 lässt sich auf Galanterie ein!",
+		"¡@0 ha decidido aprovechar la oportunidad!"
+	],
+	"The foe's @0 took the kind offer!": [
+		"あいての　@0は おことばに　あまえることにした！",
+		"Le @0 ennemi accepte avec joie!",
+		"@0 nemico approfitta della Cortesia!",
+		"@0 (Gegner) lässt sich auf Galanterie ein!",
+		"¡El @0 enemigo ha decidido aprovechar la oportunidad!"
+	],
+	"@0 and @1 switched places!": [
+		"@0と @1は　ばしょを　いれかえた！",
+		"@0 et @1 échangent leur place!",
+		"@0 e @1 si scambiano di posto!",
+		"@0 und @1 haben den Platz getauscht!",
+		"¡@0 y @1 han intercambiado sus posiciones!"
+	],
+	"The foe's @0 and @1 switched places!": [
+		"あいての　@0と @1は　ばしょを　いれかえた！",
+		"Les @0 et @1 ennemis échangent leur place!",
+		"@0 e @1 nemici si scambiano di posto!",
+		"@0 (Gegner) und @1 (Gegner) haben den Platz getauscht!",
+		"¡El @0 y el @1 enemigos han intercambiado sus posiciones!"
+	],
+	"@0 was hurled into the air!": [
+		"@0を ちゅうに　うかせた！",
+		"Ça fait léviter @0!",
+		"@0 è stato lanciato in aria!",
+		"@0 wurde zum Schweben gebracht!",
+		"¡@0 ha sido lanzado por los aires!"
+	],
+	"The foe's @0 was hurled into the air!": [
+		"あいての　@0を ちゅうに　うかせた！",
+		"Ça fait léviter le @0 ennemi!",
+		"@0 nemico è stato lanciato in aria!",
+		"@0 (Gegner) wurde zum Schweben gebracht!",
+		"¡El @0 enemigo ha sido lanzado por los aires!"
+	],
+	"@0 was freed from the telekinesis!": [
+		"@0は テレキネシスから　かいほうされた！",
+		"@0 est libéré de Lévikinésie!",
+		"@0 si libera da Telecinesi!",
+		"@0 wurde von der Wirkung von Telekinese befreit!",
+		"¡@0 se ha liberado de Telequinesis!"
+	],
+	"The foe's @0 was freed from the telekinesis!": [
+		"あいての　@0は テレキネシスから　かいほうされた！",
+		"Le @0 ennemi est libéré de Lévikinésie!",
+		"@0 nemico si libera da Telecinesi!",
+		"@0 (Gegner) wurde von der Wirkung von Telekinese befreit!",
+		"¡El @0 enemigo se ha liberado de Telequinesis!"
+	],
+	"@0 is waiting for @1's move...": [
+		"@0は @1を　まっている…",
+		"@0 attend @1...",
+		"@0 attende @1...",
+		"@0 wartet auf @1...",
+		"@0 está esperando a @1..."
+	],
+	"@0 is waiting for the foe's @1...": [
+		"@0は あいての　@1を　まっている…",
+		"@0 attend le @1 ennemi...",
+		"@0 attende @1 nemico...",
+		"@0 wartet auf @1 (Gegner)...",
+		"@0 está esperando al @1 enemigo..."
+	],
+	"The foe's @0 is waiting for @1's move...": [
+		"あいての　@0は @1を　まっている…",
+		"Le @0 ennemi attend @1...",
+		"@0 nemico attende @1...",
+		"@0 (Gegner) wartet auf @1...",
+		"El @0 enemigo está esperando a @1..."
+	],
+	"The foe's @0 is waiting for the foe's @1's move...": [
+		"あいての　@0は あいての　@1を　まっている…",
+		"Le @0 ennemi attend le @1 ennemi...",
+		"@0 nemico attende @1 nemico...",
+		"@0 (Gegner) wartet auf @1 (Gegner)...",
+		"El @0 enemigo está esperando al @1 enemigo..."
+	],
+	"It is completely synchronized with @0!": [
+		"@0と いきが　ピッタリだ！",
+		"Il est parfaitement synchro avec @0!",
+		"Si sincronizza alla perfezione con @0!",
+		"Die Harmonie mit @0 könnte gar nicht besser sein!",
+		"¡Sincronización perfecta con @0!"
+	],
+	"It is completely synchronized with the foe's @0!": [
+		"あいての　@0と いきが　ピッタリだ！",
+		"Il est parfaitement synchro avec le @0 ennemi!",
+		"Si sincronizza alla perfezione con @0 nemico!",
+		"Die Harmonie mit @0 (Gegner) könnte gar nicht besser sein!",
+		"¡Sincronización perfecta con el @0 enemigo!"
+	],
+	"@0 is hurt by the sea of fire!": [
+		"@0は ひのうみの　ダメージをうけた！",
+		"@0 est plongé dans un océan de feu!",
+		"@0 è ferito da un mare di fiamme!",
+		"@0 nimmt Schaden durch das Meer aus Feuer.",
+		"¡@0 ha sido herido por un mar de llamas!"
+	],
+	"The foe's @0 is hurt by the sea of fire!": [
+		"あいての　@0は ひのうみの　ダメージをうけた！",
+		"Le @0 ennemi est plongé dans un océan de feu!",
+		"@0 nemico è ferito da un mare di fiamme!",
+		"@0 (Gegner) nimmt Schaden durch das Meer aus Feuer.",
+		"¡El @0 enemigo ha sido herido por un mar de llamas!"
+	],
+	/* Move translations */
+	"Absorb": [
+		"すいとる",
+		"Vol-Vie",
+		"Assorbimento",
+		"Absorber",
+		"Absorber"
+	],
+	"Acid": [
+		"ようかいえき",
+		"Acide",
+		"Acido",
+		"Säure",
+		"Ácido"
+	],
+	"Acid Armor": [
+		"とける",
+		"Acidarmure",
+		"Scudo Acido",
+		"Säurepanzer",
+		"Armad. Ácida"
+	],
+	"Acid Spray": [
+		"アシッドボム",
+		"Bombe Acide",
+		"Acidobomba",
+		"Säurespeier",
+		"Bomba Ácida"
+	],
+	"Acrobatics": [
+		"アクロバット",
+		"Acrobatie",
+		"Acrobazia",
+		"Akrobatik",
+		"Acróbata"
+	],
+	"Acupressure": [
+		"つぼをつく",
+		"Acupression",
+		"Acupressione",
+		"Akupressur",
+		"Acupresión"
+	],
+	"Aerial Ace": [
+		"つばめがえし",
+		"Aéropique",
+		"Aeroassalto",
+		"Aero-Ass",
+		"Golpe Aéreo"
+	],
+	"Aeroblast": [
+		"エアロブラスト",
+		"Aéroblast",
+		"Aerocolpo",
+		"Luftstoß",
+		"Aerochorro"
+	],
+	"After You": [
+		"おさきにどうぞ",
+		"Après Vous",
+		"Cortesia",
+		"Galanterie",
+		"Cede Paso"
+	],
+	"Agility": [
+		"こうそくいどう",
+		"Hâte",
+		"Agilità",
+		"Agilität",
+		"Agilidad"
+	],
+	"Air Cutter": [
+		"エアカッター",
+		"Tranch'Air",
+		"Aerasoio",
+		"Windschnitt",
+		"Aire Afilado"
+	],
+	"Air Slash": [
+		"エアスラッシュ",
+		"Lame d'Air",
+		"Eterelama",
+		"Luftschnitt",
+		"Tajo Aéreo"
+	],
+	"Ally Switch": [
+		"サイドチェンジ",
+		"Interversion",
+		"Cambiaposto",
+		"Seitentausch",
+		"Cambio Banda"
+	],
+	"Amnesia": [
+		"ドわすれ",
+		"Amnésie",
+		"Amnesia",
+		"Amnesie",
+		"Amnesia"
+	],
+	"AncientPower": [
+		"げんしのちから",
+		"Pouv.Antique",
+		"Forzantica",
+		"Antik-Kraft",
+		"Poder Pasado"
+	],
+	"Aqua Jet": [
+		"アクアジェット",
+		"Aqua-Jet",
+		"Acquagetto",
+		"Wasserdüse",
+		"Acua Jet"
+	],
+	"Aqua Ring": [
+		"アクアリング",
+		"Anneau Hydro",
+		"Acquanello",
+		"Wasserring",
+		"Acua Aro"
+	],
+	"Aqua Tail": [
+		"アクアテール",
+		"Hydroqueue",
+		"Idrondata",
+		"Nassschweif",
+		"Acua Cola"
+	],
+	"Arm Thrust": [
+		"つっぱり",
+		"Cogne",
+		"Sberletese",
+		"Armstoß",
+		"Empujón"
+	],
+	"Aromatherapy": [
+		"アロマセラピー",
+		"Aromathérapi",
+		"Aromaterapia",
+		"Aromakur",
+		"Aromaterapia"
+	],
+	"Assist": [
+		"ねこのて",
+		"Assistance",
+		"Assistente",
+		"Zuschuss",
+		"Ayuda"
+	],
+	"Assurance": [
+		"ダメおし",
+		"Assurance",
+		"Garanzia",
+		"Gewissheit",
+		"Buena Baza"
+	],
+	"Astonish": [
+		"おどろかす",
+		"Étonnement",
+		"Sgomento",
+		"Erstauner",
+		"Impresionar"
+	],
+	"Attack Order": [
+		"こうげきしれい",
+		"Appel Attak",
+		"Comandourto",
+		"Schlagbefehl",
+		"Al Ataque"
+	],
+	"Attract": [
+		"メロメロ",
+		"Attraction",
+		"Attrazione",
+		"Anziehung",
+		"Atracción"
+	],
+	"Aura Sphere": [
+		"はどうだん",
+		"Aurasphère",
+		"Forzasfera",
+		"Aurasphäre",
+		"Esfera Aural"
+	],
+	"Aurora Beam": [
+		"オーロラビーム",
+		"Onde Boréale",
+		"Raggiaurora",
+		"Aurorastrahl",
+		"Rayo Aurora"
+	],
+	"Autotomize": [
+		"ボディパージ",
+		"Allègement",
+		"Sganciapesi",
+		"Autotomie",
+		"Aligerar"
+	],
+	"Avalanche": [
+		"ゆきなだれ",
+		"Avalanche",
+		"Slavina",
+		"Lawine",
+		"Alud"
+	],
+	"Barrage": [
+		"たまなげ",
+		"Pilonnage",
+		"Att. Pioggia",
+		"Stakkato",
+		"Presa"
+	],
+	"Barrier": [
+		"バリアー",
+		"Bouclier",
+		"Barriera",
+		"Barriere",
+		"Barrera"
+	],
+	"Baton Pass": [
+		"バトンタッチ",
+		"Relais",
+		"Staffetta",
+		"Staffette",
+		"Relevo"
+	],
+	"Beat Up": [
+		"ふくろだたき",
+		"Baston",
+		"Picchiaduro",
+		"Prügler",
+		"Paliza"
+	],
+	"Belly Drum": [
+		"はらだいこ",
+		"Cognobidon",
+		"Panciamburo",
+		"Bauchtrommel",
+		"Tambor"
+	],
+	"Bestow": [
+		"ギフトパス",
+		"Passe-Cadeau",
+		"Cediregalo",
+		"Offerte",
+		"Ofrenda"
+	],
+	"Bide": [
+		"がまん",
+		"Patience",
+		"Pazienza",
+		"Geduld",
+		"Venganza"
+	],
+	"Bind": [
+		"しめつける",
+		"Étreinte",
+		"Legatutto",
+		"Klammergriff",
+		"Atadura"
+	],
+	"Bite": [
+		"かみつく",
+		"Morsure",
+		"Morso",
+		"Biss",
+		"Mordisco"
+	],
+	"Blast Burn": [
+		"ブラストバーン",
+		"Rafale Feu",
+		"Incendio",
+		"Lohekanonade",
+		"Anillo Ígneo"
+	],
+	"Blaze Kick": [
+		"ブレイズキック",
+		"Pied Brûleur",
+		"Calciardente",
+		"Feuerfeger",
+		"Patada Ígnea"
+	],
+	"Blizzard": [
+		"ふぶき",
+		"Blizzard",
+		"Bora",
+		"Blizzard",
+		"Ventisca"
+	],
+	"Block": [
+		"とおせんぼう",
+		"Barrage",
+		"Blocco",
+		"Rückentzug",
+		"Bloqueo"
+	],
+	"Blue Flare": [
+		"あおいほのお",
+		"Flamme Bleue",
+		"Fuocoblu",
+		"Blauflammen",
+		"Llama Azul"
+	],
+	"Body Slam": [
+		"のしかかり",
+		"Plaquage",
+		"Corposcontro",
+		"Bodyslam",
+		"Golpe Cuerpo"
+	],
+	"Bolt Strike": [
+		"らいげき",
+		"ChargeFoudre",
+		"Lucesiluro",
+		"Blitzschlag",
+		"At. Fulgor"
+	],
+	"Bone Club": [
+		"ホネこんぼう",
+		"Massd'Os",
+		"Ossoclava",
+		"Knochenkeule",
+		"Hueso Palo"
+	],
+	"Bone Rush": [
+		"ボーンラッシュ",
+		"Charge-Os",
+		"Ossoraffica",
+		"Knochenhatz",
+		"Ataque Óseo"
+	],
+	"Bonemerang": [
+		"ホネブーメラン",
+		"Osmerang",
+		"Ossomerang",
+		"Knochmerang",
+		"Huesomerang"
+	],
+	"Bounce": [
+		"とびはねる",
+		"Rebond",
+		"Rimbalzo",
+		"Sprungfeder",
+		"Bote"
+	],
+	"Brave Bird": [
+		"ブレイブバード",
+		"Rapace",
+		"Baldeali",
+		"Sturzflug",
+		"Pájaro Osado"
+	],
+	"Brick Break": [
+		"かわらわり",
+		"Casse-Brique",
+		"Breccia",
+		"Durchbruch",
+		"Demolición"
+	],
+	"Brine": [
+		"しおみず",
+		"Saumure",
+		"Acquadisale",
+		"Lake",
+		"Salmuera"
+	],
+	"Bubble": [
+		"あわ",
+		"Écume",
+		"Bolla",
+		"Blubber",
+		"Burbuja"
+	],
+	"BubbleBeam": [
+		"バブルこうせん",
+		"Bulles d'O",
+		"Bollaraggio",
+		"Blubbstrahl",
+		"Rayo Burbuja"
+	],
+	"Bug Bite": [
+		"むしくい",
+		"Piqûre",
+		"Coleomorso",
+		"Käferbiss",
+		"Picadura"
+	],
+	"Bug Buzz": [
+		"むしのさざめき",
+		"Bourdon",
+		"Ronzio",
+		"Käfergebrumm",
+		"Zumbido"
+	],
+	"Bulk Up": [
+		"ビルドアップ",
+		"Gonflette",
+		"Granfisico",
+		"Protzer",
+		"Corpulencia"
+	],
+	"Bulldoze": [
+		"じならし",
+		"Piétisol",
+		"Battiterra",
+		"Dampfwalze",
+		"Terratemblor"
+	],
+	"Bullet Punch": [
+		"バレットパンチ",
+		"Pisto-Poing",
+		"Pugnoscarica",
+		"Patronenhieb",
+		"Puño Bala"
+	],
+	"Bullet Seed": [
+		"タネマシンガン",
+		"Balle Graine",
+		"Semitraglia",
+		"Kugelsaat",
+		"Recurrente"
+	],
+	"Calm Mind": [
+		"めいそう",
+		"Plénitude",
+		"Calmamente",
+		"Gedankengut",
+		"Paz Mental"
+	],
+	"Camouflage": [
+		"ほごしょく",
+		"Camouflage",
+		"Camuffamento",
+		"Tarnung",
+		"Camuflaje"
+	],
+	"Captivate": [
+		"ゆうわく",
+		"Séduction",
+		"Incanto",
+		"Liebreiz",
+		"Seducción"
+	],
+	"Charge": [
+		"じゅうでん",
+		"Chargeur",
+		"Sottocarica",
+		"Ladevorgang",
+		"Carga"
+	],
+	"Charge Beam": [
+		"チャージビーム",
+		"Rayon Chargé",
+		"Raggioscossa",
+		"Ladestrahl",
+		"Rayo Carga"
+	],
+	"Charm": [
+		"あまえる",
+		"Charme",
+		"Fascino",
+		"Charme",
+		"Encanto"
+	],
+	"Chatter": [
+		"おしゃべり",
+		"Babil",
+		"Schiamazzo",
+		"Geschwätz",
+		"Cháchara"
+	],
+	"Chip Away": [
+		"なしくずし",
+		"Attrition",
+		"Insidia",
+		"Zermürben",
+		"Guardia Baja"
+	],
+	"Circle Throw": [
+		"ともえなげ",
+		"Projection",
+		"Ribaltiro",
+		"Überkopfwurf",
+		"Llave Giro"
+	],
+	"Clamp": [
+		"からではさむ",
+		"Claquoir",
+		"Tenaglia",
+		"Schnapper",
+		"Tenaza"
+	],
+	"Clear Smog": [
+		"クリアスモッグ",
+		"Bain de Smog",
+		"Pulifumo",
+		"Klärsmog",
+		"Nieblaclara"
+	],
+	"Close Combat": [
+		"インファイト",
+		"Close Combat",
+		"Zuffa",
+		"Nahkampf",
+		"A Bocajarro"
+	],
+	"Coil": [
+		"とぐろをまく",
+		"Enroulement",
+		"Arrotola",
+		"Einrollen",
+		"Enrosque"
+	],
+	"Comet Punch": [
+		"れんぞくパンチ",
+		"Poing Comète",
+		"Cometapugno",
+		"Kometenhieb",
+		"Puño Cometa"
+	],
+	"Confuse Ray": [
+		"あやしいひかり",
+		"Onde Folie",
+		"Stordiraggio",
+		"Konfustrahl",
+		"Rayo Confuso"
+	],
+	"Confusion": [
+		"ねんりき",
+		"Choc Mental",
+		"Confusione",
+		"Konfusion",
+		"Confusión"
+	],
+	"Constrict": [
+		"からみつく",
+		"Constriction",
+		"Limitazione",
+		"Umklammerung",
+		"Restricción"
+	],
+	"Conversion": [
+		"テクスチャー",
+		"Adaptation",
+		"Conversione",
+		"Umwandlung",
+		"Conversión"
+	],
+	"Conversion 2": [
+		"テクスチャー２",
+		"Conversion 2",
+		"Conversione2",
+		"Umwandlung2",
+		"Conversión2"
+	],
+	"Copycat": [
+		"まねっこ",
+		"Photocopie",
+		"Copione",
+		"Imitator",
+		"Copión"
+	],
+	"Cosmic Power": [
+		"コスモパワー",
+		"Force Cosmik",
+		"Cosmoforza",
+		"Kosmik-Kraft",
+		"Masa Cósmica"
+	],
+	"Cotton Guard": [
+		"コットンガード",
+		"Cotogarde",
+		"Cotonscudo",
+		"Watteschild",
+		"Rizo Algodón"
+	],
+	"Cotton Spore": [
+		"わたほうし",
+		"Spore Coton",
+		"Cottonspora",
+		"Baumwollsaat",
+		"Esporagodón"
+	],
+	"Counter": [
+		"カウンター",
+		"Riposte",
+		"Contatore",
+		"Konter",
+		"Contador"
+	],
+	"Covet": [
+		"ほしがる",
+		"Implore",
+		"Supplica",
+		"Bezirzer",
+		"Antojo"
+	],
+	"Crabhammer": [
+		"クラブハンマー",
+		"Pince-Masse",
+		"Martellata",
+		"Krabbhammer",
+		"Martillazo"
+	],
+	"Cross Chop": [
+		"クロスチョップ",
+		"Coup-Croix",
+		"Incrocolpo",
+		"Kreuzhieb",
+		"Tajo Cruzado"
+	],
+	"Cross Poison": [
+		"クロスポイズン",
+		"Poison-Croix",
+		"Velenocroce",
+		"Giftstreich",
+		"Veneno X"
+	],
+	"Crunch": [
+		"かみくだく",
+		"Mâchouille",
+		"Sgranocchio",
+		"Knirscher",
+		"Triturar"
+	],
+	"Crush Claw": [
+		"ブレイククロー",
+		"Éclategriffe",
+		"Tritartigli",
+		"Zermalmklaue",
+		"Garra Brutal"
+	],
+	"Crush Grip": [
+		"にぎりつぶす",
+		"Presse",
+		"Sbriciolmano",
+		"Quetschgriff",
+		"Agarrón"
+	],
+	"Curse": [
+		"のろい",
+		"Malédiction",
+		"Maledizione",
+		"Fluch",
+		"Maldición"
+	],
+	"Cut": [
+		"いあいぎり",
+		"Coupe",
+		"Taglio",
+		"Zerschneider",
+		"Corte"
+	],
+	"Dark Pulse": [
+		"あくのはどう",
+		"Vibrobscur",
+		"Neropulsar",
+		"Finsteraura",
+		"Pulso Umbrío"
+	],
+	"Dark Void": [
+		"ダークホール",
+		"Trou Noir",
+		"Vuototetro",
+		"Schlummerort",
+		"Brecha Negra"
+	],
+	"Defend Order": [
+		"ぼうぎょしれい",
+		"Appel Défens",
+		"Comandoscudo",
+		"Blockbefehl",
+		"A Defender"
+	],
+	"Defense Curl": [
+		"まるくなる",
+		"Boul'Armure",
+		"Ricciolscudo",
+		"Einigler",
+		"Rizo Defensa"
+	],
+	"Defog": [
+		"きりばらい",
+		"Anti-Brume",
+		"Scacciabruma",
+		"Auflockern",
+		"Despejar"
+	],
+	"Destiny Bond": [
+		"みちづれ",
+		"Prlvt Destin",
+		"Destinobbl.",
+		"Abgangsbund",
+		"Mismodestino"
+	],
+	"Detect": [
+		"みきり",
+		"Détection",
+		"Individua",
+		"Scanner",
+		"Detección"
+	],
+	"Dig": [
+		"あなをほる",
+		"Tunnel",
+		"Fossa",
+		"Schaufler",
+		"Excavar"
+	],
+	"Disable": [
+		"かなしばり",
+		"Entrave",
+		"Inibitore",
+		"Aussetzer",
+		"Anulación"
+	],
+	"Discharge": [
+		"ほうでん",
+		"Coup d'Jus",
+		"Scarica",
+		"Ladungsstoß",
+		"Chispazo"
+	],
+	"Dive": [
+		"ダイビング",
+		"Plongée",
+		"Sub",
+		"Taucher",
+		"Buceo"
+	],
+	"Dizzy Punch": [
+		"ピヨピヨパンチ",
+		"Uppercut",
+		"Stordipugno",
+		"Irrschlag",
+		"Puño Mareo"
+	],
+	"Doom Desire": [
+		"はめつのねがい",
+		"Carnareket",
+		"Obbliderio",
+		"Kismetwunsch",
+		"Deseo Oculto"
+	],
+	"Double Hit": [
+		"ダブルアタック",
+		"Coup Double",
+		"Doppiosmash",
+		"Doppelschlag",
+		"Doble Golpe"
+	],
+	"Double Kick": [
+		"にどげり",
+		"Double Pied",
+		"Doppiocalcio",
+		"Doppelkick",
+		"Doble Patada"
+	],
+	"Double Team": [
+		"かげぶんしん",
+		"Reflet",
+		"Doppioteam",
+		"Doppelteam",
+		"Doble Equipo"
+	],
+	"Double-Edge": [
+		"すてみタックル",
+		"Damoclès",
+		"Sdoppiatore",
+		"Risikotackle",
+		"Doble Filo"
+	],
+	"DoubleSlap": [
+		"おうふくビンタ",
+		"Torgnoles",
+		"Doppiasberla",
+		"Duplexhieb",
+		"Doblebofetón"
+	],
+	"Draco Meteor": [
+		"りゅうせいぐん",
+		"Draco Météor",
+		"Dragobolide",
+		"Draco Meteor",
+		"Cometa Draco"
+	],
+	"Dragon Claw": [
+		"ドラゴンクロー",
+		"Dracogriffe",
+		"Dragartigli",
+		"Drachenklaue",
+		"Garra Dragón"
+	],
+	"Dragon Dance": [
+		"りゅうのまい",
+		"Danse Draco",
+		"Dragodanza",
+		"Drachentanz",
+		"Danza Dragón"
+	],
+	"Dragon Pulse": [
+		"りゅうのはどう",
+		"Dracochoc",
+		"Dragopulsar",
+		"Drachenpuls",
+		"Pulso Dragón"
+	],
+	"Dragon Rage": [
+		"りゅうのいかり",
+		"Draco-Rage",
+		"Ira di Drago",
+		"Drachenwut",
+		"Furia Dragón"
+	],
+	"Dragon Rush": [
+		"ドラゴンダイブ",
+		"Dracocharge",
+		"Dragofuria",
+		"Drachenstoß",
+		"Carga Dragón"
+	],
+	"Dragon Tail": [
+		"ドラゴンテール",
+		"Draco-Queue",
+		"Codadrago",
+		"Drachenrute",
+		"Cola Dragón"
+	],
+	"DragonBreath": [
+		"りゅうのいぶき",
+		"Dracosouffle",
+		"Dragospiro",
+		"Feuerodem",
+		"Dragoaliento"
+	],
+	"Drain Punch": [
+		"ドレインパンチ",
+		"Vampipoing",
+		"Assorbipugno",
+		"Ableithieb",
+		"Puño Drenaje"
+	],
+	"Dream Eater": [
+		"ゆめくい",
+		"Dévorêve",
+		"Mangiasogni",
+		"Traumfresser",
+		"Come Sueños"
+	],
+	"Drill Peck": [
+		"ドリルくちばし",
+		"Bec Vrille",
+		"Perforbecco",
+		"Bohrschnabel",
+		"Pico Taladro"
+	],
+	"Drill Run": [
+		"ドリルライナー",
+		"Tunnelier",
+		"Giravvita",
+		"Schlagbohrer",
+		"Taladradora"
+	],
+	"Dual Chop": [
+		"ダブルチョップ",
+		"Double Baffe",
+		"Doppiocolpo",
+		"Doppelhieb",
+		"Golpe Bis"
+	],
+	"DynamicPunch": [
+		"ばくれつパンチ",
+		"Dynamopoing",
+		"Dinamipugno",
+		"Wuchtschlag",
+		"Puñodinámico"
+	],
+	"Earth Power": [
+		"だいちのちから",
+		"Telluriforce",
+		"Geoforza",
+		"Erdkräfte",
+		"Tierra Viva"
+	],
+	"Earthquake": [
+		"じしん",
+		"Séisme",
+		"Terremoto",
+		"Erdbeben",
+		"Terremoto"
+	],
+	"Echoed Voice": [
+		"エコーボイス",
+		"Écho",
+		"Echeggiavoce",
+		"Widerhall",
+		"Eco Voz"
+	],
+	"Egg Bomb": [
+		"タマゴばくだん",
+		"Bomb'Œuf",
+		"Uovobomba",
+		"Eierbombe",
+		"Bomba Huevo"
+	],
+	"Electro Ball": [
+		"エレキボール",
+		"Boule Élek",
+		"Energisfera",
+		"Elektroball",
+		"Bola Voltio"
+	],
+	"Electroweb": [
+		"エレキネット",
+		"Toile Élek",
+		"Elettrotela",
+		"Elektronetz",
+		"Electrotela"
+	],
+	"Embargo": [
+		"さしおさえ",
+		"Embargo",
+		"Divieto",
+		"Itemsperre",
+		"Embargo"
+	],
+	"Ember": [
+		"ひのこ",
+		"Flammèche",
+		"Braciere",
+		"Glut",
+		"Ascuas"
+	],
+	"Encore": [
+		"アンコール",
+		"Encore",
+		"Ripeti",
+		"Zugabe",
+		"Otra Vez"
+	],
+	"Endeavor": [
+		"がむしゃら",
+		"Effort",
+		"Rimonta",
+		"Notsituation",
+		"Esfuerzo"
+	],
+	"Endure": [
+		"こらえる",
+		"Ténacité",
+		"Resistenza",
+		"Ausdauer",
+		"Aguante"
+	],
+	"Energy Ball": [
+		"エナジーボール",
+		"Éco-Sphère",
+		"Energipalla",
+		"Energieball",
+		"Energibola"
+	],
+	"Entrainment": [
+		"なかまづくり",
+		"Ten-danse",
+		"Saltamicizia",
+		"Zwango",
+		"Danza Amiga"
+	],
+	"Eruption": [
+		"ふんか",
+		"Éruption",
+		"Eruzione",
+		"Eruption",
+		"Estallido"
+	],
+	"Explosion": [
+		"だいばくはつ",
+		"Explosion",
+		"Esplosione",
+		"Explosion",
+		"Explosión"
+	],
+	"Extrasensory": [
+		"じんつうりき",
+		"Extrasenseur",
+		"Extrasenso",
+		"Sondersensor",
+		"Paranormal"
+	],
+	"ExtremeSpeed": [
+		"しんそく",
+		"Vit.Extrême",
+		"Extrarapido",
+		"Turbotempo",
+		"Vel. Extrema"
+	],
+	"Facade": [
+		"からげんき",
+		"Façade",
+		"Facciata",
+		"Fassade",
+		"Imagen"
+	],
+	"Faint Attack": [
+		"だましうち",
+		"Feinte",
+		"Finta",
+		"Finte",
+		"Finta"
+	],
+	"Fake Out": [
+		"ねこだまし",
+		"Bluff",
+		"Bruciapelo",
+		"Mogelhieb",
+		"Sorpresa"
+	],
+	"Fake Tears": [
+		"うそなき",
+		"Croco Larme",
+		"Falselacrime",
+		"Trugträne",
+		"Llanto Falso"
+	],
+	"False Swipe": [
+		"みねうち",
+		"Faux-Chage",
+		"Falsofinale",
+		"Trugschlag",
+		"Falsotortazo"
+	],
+	"FeatherDance": [
+		"フェザーダンス",
+		"Danse-Plume",
+		"Danzadipiume",
+		"Daunenreigen",
+		"Danza Pluma"
+	],
+	"Feint": [
+		"フェイント",
+		"Ruse",
+		"Fintoattacco",
+		"Offenlegung",
+		"Amago"
+	],
+	"Fiery Dance": [
+		"ほのおのまい",
+		"Danse du Feu",
+		"Voldifuoco",
+		"Feuerreigen",
+		"Danza Llama"
+	],
+	"Final Gambit": [
+		"いのちがけ",
+		"Tout ou Rien",
+		"Azzardo",
+		"Wagemut",
+		"Sacrificio"
+	],
+	"Fire Blast": [
+		"だいもんじ",
+		"Déflagration",
+		"Fuocobomba",
+		"Feuersturm",
+		"Llamarada"
+	],
+	"Fire Fang": [
+		"ほのおのキバ",
+		"Crocs Feu",
+		"Rogodenti",
+		"Feuerzahn",
+		"Colm. Ígneo"
+	],
+	"Fire Pledge": [
+		"ほのおのちかい",
+		"Aire de Feu",
+		"Fiammapatto",
+		"Feuersäulen",
+		"Voto Fuego"
+	],
+	"Fire Punch": [
+		"ほのおのパンチ",
+		"Poing de Feu",
+		"Fuocopugno",
+		"Feuerschlag",
+		"Puño Fuego"
+	],
+	"Fire Spin": [
+		"ほのおのうず",
+		"Danseflamme",
+		"Turbofuoco",
+		"Feuerwirbel",
+		"Giro Fuego"
+	],
+	"Fissure": [
+		"じわれ",
+		"Abîme",
+		"Abisso",
+		"Geofissur",
+		"Fisura"
+	],
+	"Flail": [
+		"じたばた",
+		"Fléau",
+		"Flagello",
+		"Dreschflegel",
+		"Azote"
+	],
+	"Flame Burst": [
+		"はじけるほのお",
+		"Rebondifeu",
+		"Pirolancio",
+		"Funkenflug",
+		"Pirotecnia"
+	],
+	"Flame Charge": [
+		"ニトロチャージ",
+		"Nitrocharge",
+		"Nitrocarica",
+		"Nitroladung",
+		"Nitrocarga"
+	],
+	"Flame Wheel": [
+		"かえんぐるま",
+		"Roue de Feu",
+		"Ruotafuoco",
+		"Flammenrad",
+		"Rueda Fuego"
+	],
+	"Flamethrower": [
+		"かえんほうしゃ",
+		"Lance-Flamme",
+		"Lanciafiamme",
+		"Flammenwurf",
+		"Lanzallamas"
+	],
+	"Flare Blitz": [
+		"フレアドライブ",
+		"Boutefeu",
+		"Fuococarica",
+		"Flammenblitz",
+		"Envite Ígneo"
+	],
+	"Flash": [
+		"フラッシュ",
+		"Flash",
+		"Flash",
+		"Blitz",
+		"Destello"
+	],
+	"Flash Cannon": [
+		"ラスターカノン",
+		"Luminocanon",
+		"Cannonflash",
+		"Lichtkanone",
+		"Foco Respl."
+	],
+	"Flatter": [
+		"おだてる",
+		"Flatterie",
+		"Adulazione",
+		"Schmeichler",
+		"Camelo"
+	],
+	"Fling": [
+		"なげつける",
+		"Dégommage",
+		"Lancio",
+		"Schleuder",
+		"Lanzamiento"
+	],
+	"Fly": [
+		"そらをとぶ",
+		"Vol",
+		"Volo",
+		"Fliegen",
+		"Vuelo"
+	],
+	"Focus Blast": [
+		"きあいだま",
+		"Exploforce",
+		"Focalcolpo",
+		"Fokusstoß",
+		"Onda Certera"
+	],
+	"Focus Energy": [
+		"きあいだめ",
+		"Puissance",
+		"Focalenergia",
+		"Energiefokus",
+		"Foco Energía"
+	],
+	"Focus Punch": [
+		"きあいパンチ",
+		"Mitra-Poing",
+		"Centripugno",
+		"Power-Punch",
+		"Puño Certero"
+	],
+	"Follow Me": [
+		"このゆびとまれ",
+		"Par Ici",
+		"Sonoqui",
+		"Spotlight",
+		"Señuelo"
+	],
+	"Force Palm": [
+		"はっけい",
+		"Forte-Paume",
+		"Palmoforza",
+		"Kraftwelle",
+		"Palmeo"
+	],
+	"Foresight": [
+		"みやぶる",
+		"Clairvoyance",
+		"Preveggenza",
+		"Gesichte",
+		"Profecía"
+	],
+	"Foul Play": [
+		"イカサマ",
+		"Tricherie",
+		"Ripicca",
+		"Schmarotzer",
+		"Juego Sucio"
+	],
+	"Freeze Shock": [
+		"フリーズボルト",
+		"Éclair Gelé",
+		"Elettrogelo",
+		"Frostvolt",
+		"Rayo Gélido"
+	],
+	"Frenzy Plant": [
+		"ハードプラント",
+		"Végé-Attak",
+		"Radicalbero",
+		"Fauna-Statue",
+		"Planta Feroz"
+	],
+	"Frost Breath": [
+		"こおりのいぶき",
+		"SouffleGlacé",
+		"Alitogelido",
+		"Eisesodem",
+		"Vaho Gélido"
+	],
+	"Frustration": [
+		"やつあたり",
+		"Frustration",
+		"Frustrazione",
+		"Frustration",
+		"Frustración"
+	],
+	"Fury Attack": [
+		"みだれづき",
+		"Furie",
+		"Furia",
+		"Furienschlag",
+		"Ataque Furia"
+	],
+	"Fury Cutter": [
+		"れんぞくぎり",
+		"Taillade",
+		"Tagliofuria",
+		"Zornklinge",
+		"Cortefuria"
+	],
+	"Fury Swipes": [
+		"みだれひっかき",
+		"Combo-Griffe",
+		"Sfuriate",
+		"Kratzfurie",
+		"Golpes Furia"
+	],
+	"Fusion Bolt": [
+		"クロスサンダー",
+		"Éclair Croix",
+		"Incrotuono",
+		"Kreuzdonner",
+		"Rayo Fusión"
+	],
+	"Fusion Flare": [
+		"クロスフレイム",
+		"Flamme Croix",
+		"Incrofiamma",
+		"Kreuzflamme",
+		"Llama Fusión"
+	],
+	"Future Sight": [
+		"みらいよち",
+		"Prescience",
+		"Divinazione",
+		"Seher",
+		"Premonición"
+	],
+	"Gastro Acid": [
+		"いえき",
+		"Suc Digestif",
+		"Gastroacido",
+		"Magensäfte",
+		"Bilis"
+	],
+	"Gear Grind": [
+		"ギアソーサー",
+		"Lancécrou",
+		"Ingracolpo",
+		"Klikkdiskus",
+		"Rueda Doble"
+	],
+	"Giga Drain": [
+		"ギガドレイン",
+		"Giga-Sangsue",
+		"Gigassorbim.",
+		"Gigasauger",
+		"Gigadrenado"
+	],
+	"Giga Impact": [
+		"ギガインパクト",
+		"Giga Impact",
+		"Gigaimpatto",
+		"Gigastoß",
+		"Giga Impacto"
+	],
+	"Glaciate": [
+		"こごえるせかい",
+		"ÈreGlaciaire",
+		"Gelamondo",
+		"Eiszeit",
+		"Mundo Gélido"
+	],
+	"Glare": [
+		"へびにらみ",
+		"Intimidation",
+		"Bagliore",
+		"Giftblick",
+		"Deslumbrar"
+	],
+	"Grass Knot": [
+		"くさむすび",
+		"Nœud Herbe",
+		"Laccioerboso",
+		"Strauchler",
+		"Hierba Lazo"
+	],
+	"Grass Pledge": [
+		"くさのちかい",
+		"Aire d'Herbe",
+		"Erbapatto",
+		"Pflanzsäulen",
+		"Voto Planta"
+	],
+	"GrassWhistle": [
+		"くさぶえ",
+		"Siffl'Herbe",
+		"Meloderba",
+		"Grasflöte",
+		"Silbato"
+	],
+	"Gravity": [
+		"じゅうりょく",
+		"Gravité",
+		"Gravità",
+		"Erdanziehung",
+		"Gravedad"
+	],
+	"Growl": [
+		"なきごえ",
+		"Rugissement",
+		"Ruggito",
+		"Heuler",
+		"Gruñido"
+	],
+	"Growth": [
+		"せいちょう",
+		"Croissance",
+		"Crescita",
+		"Wachstum",
+		"Desarrollo"
+	],
+	"Grudge": [
+		"おんねん",
+		"Rancune",
+		"Rancore",
+		"Nachspiel",
+		"Rabia"
+	],
+	"Guard Split": [
+		"ガードシェア",
+		"PartageGarde",
+		"Paridifesa",
+		"Schutzteiler",
+		"Isoguardia"
+	],
+	"Guard Swap": [
+		"ガードスワップ",
+		"Permugarde",
+		"Barattoscudo",
+		"Schutztausch",
+		"Cambia Def."
+	],
+	"Guillotine": [
+		"ハサミギロチン",
+		"Guillotine",
+		"Ghigliottina",
+		"Guillotine",
+		"Guillotina"
+	],
+	"Gunk Shot": [
+		"ダストシュート",
+		"Détricanon",
+		"Sporcolancio",
+		"Mülltreffer",
+		"Lanza Mugre"
+	],
+	"Gust": [
+		"かぜおこし",
+		"Tornade",
+		"Raffica",
+		"Windstoß",
+		"Tornado"
+	],
+	"Gyro Ball": [
+		"ジャイロボール",
+		"Gyroballe",
+		"Vortexpalla",
+		"Gyroball",
+		"Giro Bola"
+	],
+	"Hail": [
+		"あられ",
+		"Grêle",
+		"Grandine",
+		"Hagelsturm",
+		"Granizo"
+	],
+	"Hammer Arm": [
+		"アームハンマー",
+		"Marto-Poing",
+		"Martelpugno",
+		"Hammerarm",
+		"Machada"
+	],
+	"Harden": [
+		"かたくなる",
+		"Armure",
+		"Rafforzatore",
+		"Härtner",
+		"Fortaleza"
+	],
+	"Haze": [
+		"くろいきり",
+		"Buée Noire",
+		"Nube",
+		"Dunkelnebel",
+		"Niebla"
+	],
+	"Head Charge": [
+		"アフロブレイク",
+		"Peignée",
+		"Ricciolata",
+		"Steinschädel",
+		"Ariete"
+	],
+	"Head Smash": [
+		"もろはのずつき",
+		"Fracass'Tête",
+		"Zuccata",
+		"Kopfstoß",
+		"Testarazo"
+	],
+	"Headbutt": [
+		"ずつき",
+		"Coup d'Boule",
+		"Bottintesta",
+		"Kopfnuss",
+		"Golpe Cabeza"
+	],
+	"Heal Bell": [
+		"いやしのすず",
+		"Glas de Soin",
+		"Rintoccasana",
+		"Vitalglocke",
+		"Campana Cura"
+	],
+	"Heal Block": [
+		"かいふくふうじ",
+		"Anti-Soin",
+		"Anticura",
+		"Heilblockade",
+		"Anticura"
+	],
+	"Heal Order": [
+		"かいふくしれい",
+		"Appel Soins",
+		"Comandocura",
+		"Heilbefehl",
+		"Auxilio"
+	],
+	"Heal Pulse": [
+		"いやしのはどう",
+		"Vibra Soin",
+		"Ondasana",
+		"Heilwoge",
+		"Pulso Cura"
+	],
+	"Healing Wish": [
+		"いやしのねがい",
+		"Vœu Soin",
+		"Curardore",
+		"Heilopfer",
+		"Deseo Cura"
+	],
+	"Heart Stamp": [
+		"ハートスタンプ",
+		"Crèvecœur",
+		"Cuorestampo",
+		"Herzstempel",
+		"Arrumaco"
+	],
+	"Heart Swap": [
+		"ハートスワップ",
+		"Permucœur",
+		"Cuorbaratto",
+		"Statustausch",
+		"Cambia Almas"
+	],
+	"Heat Crash": [
+		"ヒートスタンプ",
+		"Tacle Feu",
+		"Marchiafuoco",
+		"Brandstempel",
+		"Golpe Calor"
+	],
+	"Heat Wave": [
+		"ねっぷう",
+		"Canicule",
+		"Ondacalda",
+		"Hitzewelle",
+		"Onda Ígnea"
+	],
+	"Heavy Slam": [
+		"ヘビーボンバー",
+		"Tacle Lourd",
+		"Pesobomba",
+		"Rammboss",
+		"Cuerpopesado"
+	],
+	"Helping Hand": [
+		"てだすけ",
+		"Coup d'Main",
+		"Altruismo",
+		"Rechte Hand",
+		"Refuerzo"
+	],
+	"Hex": [
+		"たたりめ",
+		"Châtiment",
+		"Sciagura",
+		"Bürde",
+		"Infortunio"
+	],
+	"Hi Jump Kick": [
+		"とびひざげり",
+		"Pied Voltige",
+		"Calcinvolo",
+		"Turmkick",
+		"Pat. S. Alta"
+	],
+	"Hidden Power": [
+		"めざめるパワー",
+		"Puis. Cachée",
+		"Introforza",
+		"Kraftreserve",
+		"Poder Oculto"
+	],
+	"Hone Claws": [
+		"つめとぎ",
+		"Aiguisage",
+		"Unghiaguzze",
+		"Klauenwetzer",
+		"Afilagarras"
+	],
+	"Horn Attack": [
+		"つのでつく",
+		"Koud'Korne",
+		"Incornata",
+		"Hornattacke",
+		"Cornada"
+	],
+	"Horn Drill": [
+		"つのドリル",
+		"Empal'Korne",
+		"Perforcorno",
+		"Hornbohrer",
+		"Perforador"
+	],
+	"Horn Leech": [
+		"ウッドホーン",
+		"Encornebois",
+		"Legnicorno",
+		"Holzgeweih",
+		"Astadrenaje"
+	],
+	"Howl": [
+		"とおぼえ",
+		"Grondement",
+		"Gridodilotta",
+		"Jauler",
+		"Aullido"
+	],
+	"Hurricane": [
+		"ぼうふう",
+		"Vent Violent",
+		"Tifone",
+		"Orkan",
+		"Vendaval"
+	],
+	"Hydro Cannon": [
+		"ハイドロカノン",
+		"Hydroblast",
+		"Idrocannone",
+		"Aquahaubitze",
+		"Hidrocañón"
+	],
+	"Hydro Pump": [
+		"ハイドロポンプ",
+		"Hydrocanon",
+		"Idropompa",
+		"Hydropumpe",
+		"Hidrobomba"
+	],
+	"Hyper Beam": [
+		"はかいこうせん",
+		"Ultralaser",
+		"Iper Raggio",
+		"Hyperstrahl",
+		"Hiperrayo"
+	],
+	"Hyper Fang": [
+		"ひっさつまえば",
+		"Croc de Mort",
+		"Iperzanna",
+		"Hyperzahn",
+		"Hip.Colmillo"
+	],
+	"Hyper Voice": [
+		"ハイパーボイス",
+		"Mégaphone",
+		"Granvoce",
+		"Schallwelle",
+		"Vozarrón"
+	],
+	"Hypnosis": [
+		"さいみんじゅつ",
+		"Hypnose",
+		"Ipnosi",
+		"Hypnose",
+		"Hipnosis"
+	],
+	"Ice Ball": [
+		"アイスボール",
+		"Ball'Glace",
+		"Palla Gelo",
+		"Frostbeule",
+		"Bola Hielo"
+	],
+	"Ice Beam": [
+		"れいとうビーム",
+		"Laser Glace",
+		"Geloraggio",
+		"Eisstrahl",
+		"Rayo Hielo"
+	],
+	"Ice Burn": [
+		"コールドフレア",
+		"Feu Glacé",
+		"Vampagelida",
+		"Frosthauch",
+		"Llama Gélida"
+	],
+	"Ice Fang": [
+		"こおりのキバ",
+		"Crocs Givre",
+		"Gelodenti",
+		"Eiszahn",
+		"Colm. Hielo"
+	],
+	"Ice Punch": [
+		"れいとうパンチ",
+		"Poinglace",
+		"Gelopugno",
+		"Eishieb",
+		"Puño Hielo"
+	],
+	"Ice Shard": [
+		"こおりのつぶて",
+		"Éclats Glace",
+		"Geloscheggia",
+		"Eissplitter",
+		"Canto Helado"
+	],
+	"Icicle Crash": [
+		"つららおとし",
+		"Chute Glace",
+		"Scagliagelo",
+		"Eiszapfhagel",
+		"Chuzos"
+	],
+	"Icicle Spear": [
+		"つららばり",
+		"Stalagtite",
+		"Gelolancia",
+		"Eisspeer",
+		"Carámbano"
+	],
+	"Icy Wind": [
+		"こごえるかぜ",
+		"Vent Glace",
+		"Ventogelato",
+		"Eissturm",
+		"Viento Hielo"
+	],
+	"Imprison": [
+		"ふういん",
+		"Possessif",
+		"Esclusiva",
+		"Begrenzer",
+		"Cerca"
+	],
+	"Incinerate": [
+		"やきつくす",
+		"Calcination",
+		"Bruciatutto",
+		"Einäschern",
+		"Calcinación"
+	],
+	"Inferno": [
+		"れんごく",
+		"Feu d'Enfer",
+		"Marchiatura",
+		"Inferno",
+		"Infierno"
+	],
+	"Ingrain": [
+		"ねをはる",
+		"Racines",
+		"Radicamento",
+		"Verwurzler",
+		"Arraigo"
+	],
+	"Iron Defense": [
+		"てっぺき",
+		"Mur de Fer",
+		"Ferroscudo",
+		"Eisenabwehr",
+		"Def. Férrea"
+	],
+	"Iron Head": [
+		"アイアンヘッド",
+		"Tête de Fer",
+		"Metaltestata",
+		"Eisenschädel",
+		"Cabezahierro"
+	],
+	"Iron Tail": [
+		"アイアンテール",
+		"Queue de Fer",
+		"Codacciaio",
+		"Eisenschweif",
+		"Cola Férrea"
+	],
+	"Judgment": [
+		"さばきのつぶて",
+		"Jugement",
+		"Giudizio",
+		"Urteilskraft",
+		"Sentencia"
+	],
+	"Jump Kick": [
+		"とびげり",
+		"Pied Sauté",
+		"Calciosalto",
+		"Sprungkick",
+		"Patada Salto"
+	],
+	"Karate Chop": [
+		"からてチョップ",
+		"Poing-Karaté",
+		"Colpokarate",
+		"Karateschlag",
+		"Golpe Karate"
+	],
+	"Kinesis": [
+		"スプーンまげ",
+		"Télékinésie",
+		"Cinèsi",
+		"Psykraft",
+		"Kinético"
+	],
+	"Knock Off": [
+		"はたきおとす",
+		"Sabotage",
+		"Privazione",
+		"Abschlag",
+		"Desarme"
+	],
+	"Last Resort": [
+		"とっておき",
+		"Dernierecour",
+		"Ultimascelta",
+		"Zuflucht",
+		"Última Baza"
+	],
+	"Lava Plume": [
+		"ふんえん",
+		"Ébullilave",
+		"Lavasbuffo",
+		"Flammensturm",
+		"Humareda"
+	],
+	"Leaf Blade": [
+		"リーフブレード",
+		"Lame-Feuille",
+		"Fendifoglia",
+		"Laubklinge",
+		"Hoja Aguda"
+	],
+	"Leaf Storm": [
+		"リーフストーム",
+		"Tempêteverte",
+		"Verdebufera",
+		"Blättersturm",
+		"Lluevehojas"
+	],
+	"Leaf Tornado": [
+		"グラスミキサー",
+		"Phytomixeur",
+		"Vorticerba",
+		"Grasmixer",
+		"Ciclón Hojas"
+	],
+	"Leech Life": [
+		"きゅうけつ",
+		"Vampirisme",
+		"Sanguisuga",
+		"Blutsauger",
+		"Chupavidas"
+	],
+	"Leech Seed": [
+		"やどりぎのタネ",
+		"Vampigraine",
+		"Parassiseme",
+		"Egelsamen",
+		"Drenadoras"
+	],
+	"Leer": [
+		"にらみつける",
+		"Groz'Yeux",
+		"Fulmisguardo",
+		"Silberblick",
+		"Malicioso"
+	],
+	"Lick": [
+		"したでなめる",
+		"Léchouille",
+		"Leccata",
+		"Schlecker",
+		"Lengüetazo"
+	],
+	"Light Screen": [
+		"ひかりのかべ",
+		"Mur Lumière",
+		"Schermoluce",
+		"Lichtschild",
+		"Pantalla Luz"
+	],
+	"Lock-On": [
+		"ロックオン",
+		"Verrouillage",
+		"Localizza",
+		"Zielschuss",
+		"Fijar Blanco"
+	],
+	"Lovely Kiss": [
+		"あくまのキッス",
+		"Grobisou",
+		"Demonbacio",
+		"Todeskuss",
+		"Beso Amoroso"
+	],
+	"Low Kick": [
+		"けたぐり",
+		"Balayage",
+		"Colpo Basso",
+		"Fußkick",
+		"Patada Baja"
+	],
+	"Low Sweep": [
+		"ローキック",
+		"Balayette",
+		"Calciobasso",
+		"Fußtritt",
+		"Puntapié"
+	],
+	"Lucky Chant": [
+		"おまじない",
+		"Air Veinard",
+		"Fortuncanto",
+		"Beschwörung",
+		"Conjuro"
+	],
+	"Lunar Dance": [
+		"みかづきのまい",
+		"Danse-Lune",
+		"Lunardanza",
+		"Lunartanz",
+		"Danza Lunar"
+	],
+	"Luster Purge": [
+		"ラスターパージ",
+		"Lumi-Éclat",
+		"Abbagliante",
+		"Scheinwerfer",
+		"Resplandor"
+	],
+	"Mach Punch": [
+		"マッハパンチ",
+		"Mach Punch",
+		"Pugnorapido",
+		"Tempohieb",
+		"Ultrapuño"
+	],
+	"Magic Coat": [
+		"マジックコート",
+		"Reflet Magik",
+		"Magivelo",
+		"Magiemantel",
+		"Capa Mágica"
+	],
+	"Magic Room": [
+		"マジックルーム",
+		"Zone Magique",
+		"Magicozona",
+		"Magieraum",
+		"Zona Mágica"
+	],
+	"Magical Leaf": [
+		"マジカルリーフ",
+		"Feuillemagik",
+		"Fogliamagica",
+		"Zauberblatt",
+		"Hoja Mágica"
+	],
+	"Magma Storm": [
+		"マグマストーム",
+		"Vortex Magma",
+		"Magmaclisma",
+		"Lavasturm",
+		"Lluvia Ígnea"
+	],
+	"Magnet Bomb": [
+		"マグネットボム",
+		"Bombaimant",
+		"Bombagnete",
+		"Magnetbombe",
+		"Bomba Imán"
+	],
+	"Magnet Rise": [
+		"でんじふゆう",
+		"Vol Magnétik",
+		"Magnetascesa",
+		"Magnetflug",
+		"Levitón"
+	],
+	"Magnitude": [
+		"マグニチュード",
+		"Ampleur",
+		"Magnitudo",
+		"Intensität",
+		"Magnitud"
+	],
+	"Me First": [
+		"さきどり",
+		"Moi d'Abord",
+		"Precedenza",
+		"Egotrip",
+		"Yo Primero"
+	],
+	"Mean Look": [
+		"くろいまなざし",
+		"Regard Noir",
+		"Malosguardo",
+		"Horrorblick",
+		"Mal de Ojo"
+	],
+	"Meditate": [
+		"ヨガのポーズ",
+		"Yoga",
+		"Meditazione",
+		"Meditation",
+		"Meditación"
+	],
+	"Mega Drain": [
+		"メガドレイン",
+		"Méga-Sangsue",
+		"Megassorbim.",
+		"Megasauger",
+		"Megaagotar"
+	],
+	"Mega Kick": [
+		"メガトンキック",
+		"Ultimawashi",
+		"Megacalcio",
+		"Megakick",
+		"Megapatada"
+	],
+	"Mega Punch": [
+		"メガトンパンチ",
+		"Ultimapoing",
+		"Megapugno",
+		"Megahieb",
+		"Megapuño"
+	],
+	"Megahorn": [
+		"メガホーン",
+		"Mégacorne",
+		"Megacorno",
+		"Vielender",
+		"Megacuerno"
+	],
+	"Memento": [
+		"おきみやげ",
+		"Souvenir",
+		"Memento",
+		"Memento-Mori",
+		"Legado"
+	],
+	"Metal Burst": [
+		"メタルバースト",
+		"Fulmifer",
+		"Metalscoppio",
+		"Metallstoß",
+		"Repr. Metal"
+	],
+	"Metal Claw": [
+		"メタルクロー",
+		"Griffe Acier",
+		"Ferrartigli",
+		"Metallklaue",
+		"Garra Metal"
+	],
+	"Metal Sound": [
+		"きんぞくおん",
+		"Strido-Son",
+		"Ferrostrido",
+		"Metallsound",
+		"Eco Metálico"
+	],
+	"Meteor Mash": [
+		"コメットパンチ",
+		"Poing Météor",
+		"Meteorpugno",
+		"Sternenhieb",
+		"Puño Meteoro"
+	],
+	"Metronome": [
+		"ゆびをふる",
+		"Métronome",
+		"Metronomo",
+		"Metronom",
+		"Metrónomo"
+	],
+	"Milk Drink": [
+		"ミルクのみ",
+		"Lait à Boire",
+		"Buonlatte",
+		"Milchgetränk",
+		"Batido"
+	],
+	"Mimic": [
+		"ものまね",
+		"Copie",
+		"Mimica",
+		"Mimikry",
+		"Mimético"
+	],
+	"Mind Reader": [
+		"こころのめ",
+		"Lire-Esprit",
+		"Leggimente",
+		"Willensleser",
+		"Telépata"
+	],
+	"Minimize": [
+		"ちいさくなる",
+		"Lilliput",
+		"Minimizzato",
+		"Komprimator",
+		"Reducción"
+	],
+	"Miracle Eye": [
+		"ミラクルアイ",
+		"Œil Miracle",
+		"Miracolvista",
+		"Wunderauge",
+		"Gran Ojo"
+	],
+	"Mirror Coat": [
+		"ミラーコート",
+		"Voile Miroir",
+		"Specchiovelo",
+		"Spiegelcape",
+		"Manto Espejo"
+	],
+	"Mirror Move": [
+		"オウムがえし",
+		"Mimique",
+		"Speculmossa",
+		"Spiegeltrick",
+		"Mov. Espejo"
+	],
+	"Mirror Shot": [
+		"ミラーショット",
+		"Miroi-Tir",
+		"Cristalcolpo",
+		"Spiegelsalve",
+		"Disp. Espejo"
+	],
+	"Mist": [
+		"しろいきり",
+		"Brume",
+		"Nebbia",
+		"Weißnebel",
+		"Neblina"
+	],
+	"Mist Ball": [
+		"ミストボール",
+		"Ball'Brume",
+		"Foschisfera",
+		"Nebelball",
+		"Bola Neblina"
+	],
+	"Moonlight": [
+		"つきのひかり",
+		"Rayon Lune",
+		"Lucelunare",
+		"Mondschein",
+		"Luz Lunar"
+	],
+	"Morning Sun": [
+		"あさのひざし",
+		"Aurore",
+		"Mattindoro",
+		"Morgengrauen",
+		"Sol Matinal"
+	],
+	"Mud Bomb": [
+		"どろばくだん",
+		"Boue-Bombe",
+		"Pantanobomba",
+		"Schlammbombe",
+		"Bomba Fango"
+	],
+	"Mud Shot": [
+		"マッドショット",
+		"Tir de Boue",
+		"Colpodifango",
+		"Lehmschuss",
+		"Disp. Lodo"
+	],
+	"Mud Sport": [
+		"どろあそび",
+		"Lance-Boue",
+		"Fangata",
+		"Lehmsuhler",
+		"Chapoteolodo"
+	],
+	"Mud-Slap": [
+		"どろかけ",
+		"Coud'Boue",
+		"Fangosberla",
+		"Lehmschelle",
+		"Bofetón Lodo"
+	],
+	"Muddy Water": [
+		"だくりゅう",
+		"Ocroupi",
+		"Fanghiglia",
+		"Lehmbrühe",
+		"Agua Lodosa"
+	],
+	"Nasty Plot": [
+		"わるだくみ",
+		"Machination",
+		"Congiura",
+		"Ränkeschmied",
+		"Maquinación"
+	],
+	"Natural Gift": [
+		"しぜんのめぐみ",
+		"Don Naturel",
+		"Dononaturale",
+		"Beerenkräfte",
+		"Don Natural"
+	],
+	"Nature Power": [
+		"しぜんのちから",
+		"Force-Nature",
+		"Naturforza",
+		"Natur-Kraft",
+		"Adaptación"
+	],
+	"Needle Arm": [
+		"ニードルアーム",
+		"Poing Dard",
+		"Pugnospine",
+		"Nietenranke",
+		"Brazo Pincho"
+	],
+	"Night Daze": [
+		"ナイトバースト",
+		"Explonuit",
+		"Urtoscuro",
+		"Nachtflut",
+		"Pulso Noche"
+	],
+	"Night Shade": [
+		"ナイトヘッド",
+		"Ténèbres",
+		"Ombra Nott.",
+		"Nachtnebel",
+		"Tinieblas"
+	],
+	"Night Slash": [
+		"つじぎり",
+		"Tranche-Nuit",
+		"Nottesferza",
+		"Nachthieb",
+		"Tajo Umbrío"
+	],
+	"Nightmare": [
+		"あくむ",
+		"Cauchemar",
+		"Incubo",
+		"Nachtmahr",
+		"Pesadilla"
+	],
+	"Octazooka": [
+		"オクタンほう",
+		"Octazooka",
+		"Octazooka",
+		"Octazooka",
+		"Pulpocañón"
+	],
+	"Odor Sleuth": [
+		"かぎわける",
+		"Flair",
+		"Segugio",
+		"Schnüffler",
+		"Rastreo"
+	],
+	"Ominous Wind": [
+		"あやしいかぜ",
+		"Vent Mauvais",
+		"Funestovento",
+		"Unheilböen",
+		"Vien. Aciago"
+	],
+	"Outrage": [
+		"げきりん",
+		"Colère",
+		"Oltraggio",
+		"Wutanfall",
+		"Enfado"
+	],
+	"Overheat": [
+		"オーバーヒート",
+		"Surchauffe",
+		"Vampata",
+		"Hitzekoller",
+		"Sofoco"
+	],
+	"Pain Split": [
+		"いたみわけ",
+		"Balance",
+		"Malcomune",
+		"Leidteiler",
+		"Divide Dolor"
+	],
+	"Pay Day": [
+		"ネコにこばん",
+		"Jackpot",
+		"Giornopaga",
+		"Zahltag",
+		"Día de Pago"
+	],
+	"Payback": [
+		"しっぺがえし",
+		"Représailles",
+		"Rivincita",
+		"Gegenstoß",
+		"Vendetta"
+	],
+	"Peck": [
+		"つつく",
+		"Picpic",
+		"Beccata",
+		"Schnabel",
+		"Picotazo"
+	],
+	"Perish Song": [
+		"ほろびのうた",
+		"Requiem",
+		"Ultimocanto",
+		"Abgesang",
+		"Canto Mortal"
+	],
+	"Petal Dance": [
+		"はなびらのまい",
+		"Danse-Fleur",
+		"Petalodanza",
+		"Blättertanz",
+		"Danza Pétalo"
+	],
+	"Pin Missile": [
+		"ミサイルばり",
+		"Dard-Nuée",
+		"Missilspillo",
+		"Nadelrakete",
+		"Pin Misil"
+	],
+	"Pluck": [
+		"ついばむ",
+		"Picore",
+		"Spennata",
+		"Pflücker",
+		"Picoteo"
+	],
+	"Poison Fang": [
+		"どくどくのキバ",
+		"Crochetvenin",
+		"Velenodenti",
+		"Giftzahn",
+		"Colmillo Ven"
+	],
+	"Poison Gas": [
+		"どくガス",
+		"Gaz Toxik",
+		"Velenogas",
+		"Giftwolke",
+		"Gas Venenoso"
+	],
+	"Poison Jab": [
+		"どくづき",
+		"Direct Toxik",
+		"Velenpuntura",
+		"Gifthieb",
+		"Puya Nociva"
+	],
+	"Poison Sting": [
+		"どくばり",
+		"Dard-Venin",
+		"Velenospina",
+		"Giftstachel",
+		"Picotazo Ven"
+	],
+	"Poison Tail": [
+		"ポイズンテール",
+		"Queue-Poison",
+		"Velenocoda",
+		"Giftschweif",
+		"Cola Veneno"
+	],
+	"PoisonPowder": [
+		"どくのこな",
+		"Poudre Toxik",
+		"Velenpolvere",
+		"Giftpuder",
+		"Polvo Veneno"
+	],
+	"Pound": [
+		"はたく",
+		"Écras'Face",
+		"Botta",
+		"Pfund",
+		"Destructor"
+	],
+	"Powder Snow": [
+		"こなゆき",
+		"Poudreuse",
+		"Polneve",
+		"Pulverschnee",
+		"Nieve Polvo"
+	],
+	"Power Gem": [
+		"パワージェム",
+		"Rayon Gemme",
+		"Gemmoforza",
+		"Juwelenkraft",
+		"Joya de Luz"
+	],
+	"Power Split": [
+		"パワーシェア",
+		"PartageForce",
+		"Pariattacco",
+		"Kraftteiler",
+		"Isofuerza"
+	],
+	"Power Swap": [
+		"パワースワップ",
+		"Permuforce",
+		"Barattoforza",
+		"Krafttausch",
+		"Cambia Fue."
+	],
+	"Power Trick": [
+		"パワートリック",
+		"Astuce Force",
+		"Ingannoforza",
+		"Krafttrick",
+		"Truco Fuerza"
+	],
+	"Power Whip": [
+		"パワーウィップ",
+		"Mégafouet",
+		"Vigorcolpo",
+		"Blattgeißel",
+		"Latigazo"
+	],
+	"Present": [
+		"プレゼント",
+		"Cadeau",
+		"Regalino",
+		"Geschenk",
+		"Presente"
+	],
+	"Protect": [
+		"まもる",
+		"Abri",
+		"Protezione",
+		"Schutzschild",
+		"Protección"
+	],
+	"Psybeam": [
+		"サイケこうせん",
+		"Rafale Psy",
+		"Psicoraggio",
+		"Psystrahl",
+		"Psicorrayo"
+	],
+	"Psych Up": [
+		"じこあんじ",
+		"Boost",
+		"Psicamisù",
+		"Psycho-Plus",
+		"Más Psique"
+	],
+	"Psychic": [
+		"サイコキネシス",
+		"Psyko",
+		"Psichico",
+		"Psychokinese",
+		"Psíquico"
+	],
+	"Psycho Boost": [
+		"サイコブースト",
+		"Psycho Boost",
+		"Psicoslancio",
+		"Psyschub",
+		"Psicoataque"
+	],
+	"Psycho Cut": [
+		"サイコカッター",
+		"Coupe Psycho",
+		"Psicotaglio",
+		"Psychoklinge",
+		"Psico-corte"
+	],
+	"Psycho Shift": [
+		"サイコシフト",
+		"Échange Psy",
+		"Psicotrasfer",
+		"Psybann",
+		"Psico-cambio"
+	],
+	"Psyshock": [
+		"サイコショック",
+		"Choc Psy",
+		"Psicoshock",
+		"Psychoschock",
+		"Psicocarga"
+	],
+	"Psystrike": [
+		"サイコブレイク",
+		"Frappe Psy",
+		"Psicobotta",
+		"Psychostoß",
+		"Onda Mental"
+	],
+	"Psywave": [
+		"サイコウェーブ",
+		"Vague Psy",
+		"Psiconda",
+		"Psywelle",
+		"Psicoonda"
+	],
+	"Punishment": [
+		"おしおき",
+		"Punition",
+		"Punizione",
+		"Strafattacke",
+		"Castigo"
+	],
+	"Pursuit": [
+		"おいうち",
+		"Poursuite",
+		"Inseguimento",
+		"Verfolgung",
+		"Persecución"
+	],
+	"Quash": [
+		"さきおくり",
+		"À la Queue",
+		"Spintone",
+		"Verzögerung",
+		"Último Lugar"
+	],
+	"Quick Attack": [
+		"でんこうせっか",
+		"Vive-Attaque",
+		"Att. Rapido",
+		"Ruckzuckhieb",
+		"At. Rápido"
+	],
+	"Quick Guard": [
+		"ファストガード",
+		"Prévention",
+		"Anticipo",
+		"Rapidschutz",
+		"Anticipo"
+	],
+	"Quiver Dance": [
+		"ちょうのまい",
+		"Papillodanse",
+		"Eledanza",
+		"Falterreigen",
+		"Danza Aleteo"
+	],
+	"Rage": [
+		"いかり",
+		"Frénésie",
+		"Ira",
+		"Raserei",
+		"Furia"
+	],
+	"Rage Powder": [
+		"いかりのこな",
+		"PoudreFureur",
+		"Polverabbia",
+		"Wutpulver",
+		"Polvo Ira"
+	],
+	"Rain Dance": [
+		"あまごい",
+		"Danse Pluie",
+		"Pioggiadanza",
+		"Regentanz",
+		"Danza Lluvia"
+	],
+	"Rapid Spin": [
+		"こうそくスピン",
+		"Tour Rapide",
+		"Rapigiro",
+		"Turbodreher",
+		"Giro Rápido"
+	],
+	"Razor Leaf": [
+		"はっぱカッター",
+		"Tranch'Herbe",
+		"Foglielama",
+		"Rasierblatt",
+		"Hoja Afilada"
+	],
+	"Razor Shell": [
+		"シェルブレード",
+		"Coquilame",
+		"Conchilama",
+		"Kalkklinge",
+		"Concha Filo"
+	],
+	"Razor Wind": [
+		"かまいたち",
+		"Coupe-Vent",
+		"Ventagliente",
+		"Klingensturm",
+		"V. Cortante"
+	],
+	"Recover": [
+		"じこさいせい",
+		"Soin",
+		"Ripresa",
+		"Genesung",
+		"Recuperación"
+	],
+	"Recycle": [
+		"リサイクル",
+		"Recyclage",
+		"Riciclo",
+		"Aufbereitung",
+		"Reciclaje"
+	],
+	"Reflect": [
+		"リフレクター",
+		"Protection",
+		"Riflesso",
+		"Reflektor",
+		"Reflejo"
+	],
+	"Reflect Type": [
+		"ミラータイプ",
+		"Copie Type",
+		"Riflettipo",
+		"Typenspiegel",
+		"Clonatipo"
+	],
+	"Refresh": [
+		"リフレッシュ",
+		"Régénération",
+		"Rinfrescata",
+		"Heilung",
+		"Alivio"
+	],
+	"Relic Song": [
+		"いにしえのうた",
+		"ChantAntique",
+		"Cantoantico",
+		"Urgesang",
+		"Cantoarcaico"
+	],
+	"Rest": [
+		"ねむる",
+		"Repos",
+		"Riposo",
+		"Erholung",
+		"Descanso"
+	],
+	"Retaliate": [
+		"かたきうち",
+		"Vengeance",
+		"Nemesi",
+		"Heimzahlung",
+		"Represalia"
+	],
+	"Return": [
+		"おんがえし",
+		"Retour",
+		"Ritorno",
+		"Rückkehr",
+		"Retroceso"
+	],
+	"Revenge": [
+		"リベンジ",
+		"Vendetta",
+		"Vendetta",
+		"Vergeltung",
+		"Desquite"
+	],
+	"Reversal": [
+		"きしかいせい",
+		"Contre",
+		"Contropiede",
+		"Gegenschlag",
+		"Inversión"
+	],
+	"Roar": [
+		"ほえる",
+		"Hurlement",
+		"Boato",
+		"Brüller",
+		"Rugido"
+	],
+	"Roar of Time": [
+		"ときのほうこう",
+		"Hurle-Temps",
+		"Fragortempo",
+		"Zeitenlärm",
+		"Distorsión"
+	],
+	"Rock Blast": [
+		"ロックブラスト",
+		"Boule Roc",
+		"Cadutamassi",
+		"Felswurf",
+		"Pedrada"
+	],
+	"Rock Climb": [
+		"ロッククライム",
+		"Escalade",
+		"Scalaroccia",
+		"Kraxler",
+		"Treparrocas"
+	],
+	"Rock Polish": [
+		"ロックカット",
+		"Poliroche",
+		"Lucidatura",
+		"Steinpolitur",
+		"Pulimento"
+	],
+	"Rock Slide": [
+		"いわなだれ",
+		"Éboulement",
+		"Frana",
+		"Steinhagel",
+		"Avalancha"
+	],
+	"Rock Smash": [
+		"いわくだき",
+		"Éclate-Roc",
+		"Spaccaroccia",
+		"Zertrümmerer",
+		"Golpe Roca"
+	],
+	"Rock Throw": [
+		"いわおとし",
+		"Jet-Pierres",
+		"Sassata",
+		"Steinwurf",
+		"Lanzarrocas"
+	],
+	"Rock Tomb": [
+		"がんせきふうじ",
+		"Tomberoche",
+		"Rocciotomba",
+		"Felsgrab",
+		"Tumba Rocas"
+	],
+	"Rock Wrecker": [
+		"がんせきほう",
+		"Roc-Boulet",
+		"Devastomasso",
+		"Felswerfer",
+		"Romperrocas"
+	],
+	"Role Play": [
+		"なりきり",
+		"Imitation",
+		"Giocodiruolo",
+		"Rollentausch",
+		"Imitación"
+	],
+	"Rolling Kick": [
+		"まわしげり",
+		"Mawashi Geri",
+		"Calciorullo",
+		"Fegekick",
+		"Patada Giro"
+	],
+	"Rollout": [
+		"ころがる",
+		"Roulade",
+		"Rotolamento",
+		"Walzer",
+		"Desenrollar"
+	],
+	"Roost": [
+		"はねやすめ",
+		"Atterrissage",
+		"Trespolo",
+		"Ruheort",
+		"Respiro"
+	],
+	"Round": [
+		"りんしょう",
+		"Chant Canon",
+		"Coro",
+		"Kanon",
+		"Canon"
+	],
+	"Sacred Fire": [
+		"せいなるほのお",
+		"Feu Sacré",
+		"Magifuoco",
+		"Läuterfeuer",
+		"Fuegosagrado"
+	],
+	"Sacred Sword": [
+		"せいなるつるぎ",
+		"Lame Sainte",
+		"Spadasolenne",
+		"Sanctoklinge",
+		"Espadasanta"
+	],
+	"Safeguard": [
+		"しんぴのまもり",
+		"Rune Protect",
+		"Salvaguardia",
+		"Bodyguard",
+		"Velo Sagrado"
+	],
+	"Sand Tomb": [
+		"すなじごく",
+		"Tourbi-Sable",
+		"Sabbiotomba",
+		"Sandgrab",
+		"Bucle Arena"
+	],
+	"Sand-Attack": [
+		"すなかけ",
+		"Jet de Sable",
+		"Turbosabbia",
+		"Sandwirbel",
+		"Ataque Arena"
+	],
+	"Sandstorm": [
+		"すなあらし",
+		"Tempêtesable",
+		"Terrempesta",
+		"Sandsturm",
+		"Torm. Arena"
+	],
+	"Scald": [
+		"ねっとう",
+		"Ébullition",
+		"Idrovampata",
+		"Siedewasser",
+		"Escaldar"
+	],
+	"Scary Face": [
+		"こわいかお",
+		"Grimace",
+		"Visotruce",
+		"Grimasse",
+		"Cara Susto"
+	],
+	"Scratch": [
+		"ひっかく",
+		"Griffe",
+		"Graffio",
+		"Kratzer",
+		"Arañazo"
+	],
+	"Screech": [
+		"いやなおと",
+		"Grincement",
+		"Stridio",
+		"Kreideschrei",
+		"Chirrido"
+	],
+	"Searing Shot": [
+		"かえんだん",
+		"Incendie",
+		"Sparafuoco",
+		"Flammenball",
+		"Bomba Ígnea"
+	],
+	"Secret Power": [
+		"ひみつのちから",
+		"Force Cachée",
+		"Forzasegreta",
+		"Geheimpower",
+		"Daño Secreto"
+	],
+	"Secret Sword": [
+		"しんぴのつるぎ",
+		"Lame Ointe",
+		"Spadamistica",
+		"Mystoschwert",
+		"Sablemístico"
+	],
+	"Seed Bomb": [
+		"タネばくだん",
+		"Canon Graine",
+		"Semebomba",
+		"Samenbomben",
+		"Bomba Germen"
+	],
+	"Seed Flare": [
+		"シードフレア",
+		"Fulmigraine",
+		"Infuriaseme",
+		"Schocksamen",
+		"Fogonazo"
+	],
+	"Seismic Toss": [
+		"ちきゅうなげ",
+		"Frappe Atlas",
+		"Mov. Sismico",
+		"Geowurf",
+		"Mov. Sísmico"
+	],
+	"Selfdestruct": [
+		"じばく",
+		"Destruction",
+		"Autodistruz.",
+		"Finale",
+		"Autodestruc"
+	],
+	"Shadow Ball": [
+		"シャドーボール",
+		"Ball'Ombre",
+		"Palla Ombra",
+		"Spukball",
+		"Bola Sombra"
+	],
+	"Shadow Claw": [
+		"シャドークロー",
+		"Griffe Ombre",
+		"Ombrartigli",
+		"Dunkelklaue",
+		"Garra Umbría"
+	],
+	"Shadow Force": [
+		"シャドーダイブ",
+		"Revenant",
+		"Oscurotuffo",
+		"Schemenkraft",
+		"Golpe Umbrío"
+	],
+	"Shadow Punch": [
+		"シャドーパンチ",
+		"Poing Ombre",
+		"Pugnodombra",
+		"Finsterfaust",
+		"Puño Sombra"
+	],
+	"Shadow Sneak": [
+		"かげうち",
+		"Ombre Portée",
+		"Furtivombra",
+		"Schattenstoß",
+		"Sombra Vil"
+	],
+	"Sharpen": [
+		"かくばる",
+		"Affûtage",
+		"Affilatore",
+		"Schärfer",
+		"Afilar"
+	],
+	"Sheer Cold": [
+		"ぜったいれいど",
+		"Glaciation",
+		"Purogelo",
+		"Eiseskälte",
+		"Frío Polar"
+	],
+	"Shell Smash": [
+		"からをやぶる",
+		"Exuviation",
+		"Gettaguscio",
+		"Hausbruch",
+		"Rompecoraza"
+	],
+	"Shift Gear": [
+		"ギアチェンジ",
+		"Chgt Vitesse",
+		"Cambiomarcia",
+		"Gangwechsel",
+		"Cambiomarcha"
+	],
+	"Shock Wave": [
+		"でんげきは",
+		"Onde de Choc",
+		"Ondashock",
+		"Schockwelle",
+		"Onda Voltio"
+	],
+	"Signal Beam": [
+		"シグナルビーム",
+		"Rayon Signal",
+		"Segnoraggio",
+		"Ampelleuchte",
+		"Doble Rayo"
+	],
+	"Silver Wind": [
+		"ぎんいろのかぜ",
+		"Vent Argenté",
+		"Ventargenteo",
+		"Silberhauch",
+		"Viento Plata"
+	],
+	"Simple Beam": [
+		"シンプルビーム",
+		"Rayon Simple",
+		"Ondisinvolta",
+		"Wankelstrahl",
+		"Onda Simple"
+	],
+	"Sing": [
+		"うたう",
+		"Berceuse",
+		"Canto",
+		"Gesang",
+		"Canto"
+	],
+	"Sketch": [
+		"スケッチ",
+		"Gribouille",
+		"Schizzo",
+		"Nachahmer",
+		"Esquema"
+	],
+	"Skill Swap": [
+		"スキルスワップ",
+		"Échange",
+		"Baratto",
+		"Wertewechsel",
+		"Intercambio"
+	],
+	"Skull Bash": [
+		"ロケットずつき",
+		"Coud'Krâne",
+		"Capocciata",
+		"Schädelwumme",
+		"Cabezazo"
+	],
+	"Sky Attack": [
+		"ゴッドバード",
+		"Pique",
+		"Aeroattacco",
+		"Himmelsfeger",
+		"Ataque Aéreo"
+	],
+	"Sky Drop": [
+		"フリーフォール",
+		"Chute Libre",
+		"Cadutalibera",
+		"Freier Fall",
+		"Caída Libre"
+	],
+	"Sky Uppercut": [
+		"スカイアッパー",
+		"Stratopercut",
+		"Stramontante",
+		"Himmelhieb",
+		"Gancho Alto"
+	],
+	"Slack Off": [
+		"なまける",
+		"Paresse",
+		"Pigro",
+		"Tagedieb",
+		"Relajo"
+	],
+	"Slam": [
+		"たたきつける",
+		"Souplesse",
+		"Schianto",
+		"Slam",
+		"Portazo"
+	],
+	"Slash": [
+		"きりさく",
+		"Tranche",
+		"Lacerazione",
+		"Schlitzer",
+		"Cuchillada"
+	],
+	"Sleep Powder": [
+		"ねむりごな",
+		"Poudre Dodo",
+		"Sonnifero",
+		"Schlafpuder",
+		"Somnífero"
+	],
+	"Sleep Talk": [
+		"ねごと",
+		"Blabla Dodo",
+		"Sonnolalia",
+		"Schlafrede",
+		"Sonámbulo"
+	],
+	"Sludge": [
+		"ヘドロこうげき",
+		"Détritus",
+		"Fango",
+		"Schlammbad",
+		"Residuos"
+	],
+	"Sludge Bomb": [
+		"ヘドロばくだん",
+		"Bomb-Beurk",
+		"Fangobomba",
+		"Matschbombe",
+		"Bomba Lodo"
+	],
+	"Sludge Wave": [
+		"ヘドロウェーブ",
+		"Cradovague",
+		"Fangonda",
+		"Schlammwoge",
+		"Onda Tóxica"
+	],
+	"Smack Down": [
+		"うちおとす",
+		"Anti-Air",
+		"Abbattimento",
+		"Katapult",
+		"Antiaéreo"
+	],
+	"SmellingSalt": [
+		"きつけ",
+		"Stimulant",
+		"Maniereforti",
+		"Riechsalz",
+		"Estímulo"
+	],
+	"Smog": [
+		"スモッグ",
+		"Purédpois",
+		"Smog",
+		"Smog",
+		"Polución"
+	],
+	"SmokeScreen": [
+		"えんまく",
+		"Brouillard",
+		"Muro di Fumo",
+		"Rauchwolke",
+		"Pantallahumo"
+	],
+	"Snarl": [
+		"バークアウト",
+		"Aboiement",
+		"Urlorabbia",
+		"Standpauke",
+		"Alarido"
+	],
+	"Snatch": [
+		"よこどり",
+		"Saisie",
+		"Scippo",
+		"Übernahme",
+		"Robo"
+	],
+	"Snore": [
+		"いびき",
+		"Ronflement",
+		"Russare",
+		"Schnarcher",
+		"Ronquido"
+	],
+	"Soak": [
+		"みずびたし",
+		"Détrempage",
+		"Inondazione",
+		"Überflutung",
+		"Anegar"
+	],
+	"Softboiled": [
+		"タマゴうみ",
+		"E-Coque",
+		"Covauova",
+		"Weichei",
+		"Amortiguador"
+	],
+	"SolarBeam": [
+		"ソーラービーム",
+		"Lance-Soleil",
+		"Solarraggio",
+		"Solarstrahl",
+		"Rayo Solar"
+	],
+	"SonicBoom": [
+		"ソニックブーム",
+		"Sonicboom",
+		"Sonicboom",
+		"Ultraschall",
+		"Bomba Sónica"
+	],
+	"Spacial Rend": [
+		"あくうせつだん",
+		"Spatio-Rift",
+		"Fendispazio",
+		"Raumschlag",
+		"Corte Vacío"
+	],
+	"Spark": [
+		"スパーク",
+		"Étincelle",
+		"Scintilla",
+		"Funkensprung",
+		"Chispa"
+	],
+	"Spider Web": [
+		"クモのす",
+		"Toile",
+		"Ragnatela",
+		"Spinnennetz",
+		"Telaraña"
+	],
+	"Spike Cannon": [
+		"とげキャノン",
+		"Picanon",
+		"Sparalance",
+		"Dornkanone",
+		"Clavo Cañón"
+	],
+	"Spikes": [
+		"まきびし",
+		"Picots",
+		"Punte",
+		"Stachler",
+		"Púas"
+	],
+	"Spit Up": [
+		"はきだす",
+		"Relâche",
+		"Sfoghenergia",
+		"Entfessler",
+		"Escupir"
+	],
+	"Spite": [
+		"うらみ",
+		"Dépit",
+		"Dispetto",
+		"Groll",
+		"Rencor"
+	],
+	"Splash": [
+		"はねる",
+		"Trempette",
+		"Splash",
+		"Platscher",
+		"Salpicadura"
+	],
+	"Spore": [
+		"キノコのほうし",
+		"Spore",
+		"Spora",
+		"Pilzspore",
+		"Espora"
+	],
+	"Stealth Rock": [
+		"ステルスロック",
+		"Piège de Roc",
+		"Levitoroccia",
+		"Tarnsteine",
+		"Trampa Rocas"
+	],
+	"Steamroller": [
+		"ハードローラー",
+		"Bulldoboule",
+		"Rulloduro",
+		"Quetschwalze",
+		"Rodillo Púas"
+	],
+	"Steel Wing": [
+		"はがねのつばさ",
+		"Aile d'Acier",
+		"Alacciaio",
+		"Stahlflügel",
+		"Ala de Acero"
+	],
+	"Stockpile": [
+		"たくわえる",
+		"Stockage",
+		"Accumulo",
+		"Horter",
+		"Reserva"
+	],
+	"Stomp": [
+		"ふみつけ",
+		"Écrasement",
+		"Pestone",
+		"Stampfer",
+		"Pisotón"
+	],
+	"Stone Edge": [
+		"ストーンエッジ",
+		"Lame de Roc",
+		"Pietrataglio",
+		"Steinkante",
+		"Roca Afilada"
+	],
+	"Stored Power": [
+		"アシストパワー",
+		"ForceAjoutée",
+		"Veicolaforza",
+		"Kraftvorrat",
+		"Poderreserva"
+	],
+	"Storm Throw": [
+		"やまあらし",
+		"Yama Arashi",
+		"Tempestretta",
+		"Bergsturm",
+		"Llave Corsé"
+	],
+	"Strength": [
+		"かいりき",
+		"Force",
+		"Forza",
+		"Stärke",
+		"Fuerza"
+	],
+	"String Shot": [
+		"いとをはく",
+		"Sécrétion",
+		"Millebave",
+		"Fadenschuss",
+		"Disp. Demora"
+	],
+	"Struggle": [
+		"わるあがき",
+		"Lutte",
+		"Scontro",
+		"Verzweifler",
+		"Combate"
+	],
+	"Struggle Bug": [
+		"むしのていこう",
+		"Survinsecte",
+		"Entomoblocco",
+		"Käfertrutz",
+		"Estoicismo"
+	],
+	"Stun Spore": [
+		"しびれごな",
+		"Para-Spore",
+		"Paralizzante",
+		"Stachelspore",
+		"Paralizador"
+	],
+	"Submission": [
+		"じごくぐるま",
+		"Sacrifice",
+		"Sottomiss.",
+		"Überroller",
+		"Sumisión"
+	],
+	"Substitute": [
+		"みがわり",
+		"Clonage",
+		"Sostituto",
+		"Delegator",
+		"Sustituto"
+	],
+	"Sucker Punch": [
+		"ふいうち",
+		"Coup Bas",
+		"Sbigoattacco",
+		"Tiefschlag",
+		"Golpe Bajo"
+	],
+	"Sunny Day": [
+		"にほんばれ",
+		"Zénith",
+		"Giornodisole",
+		"Sonnentag",
+		"Día Soleado"
+	],
+	"Super Fang": [
+		"いかりのまえば",
+		"Croc Fatal",
+		"Superzanna",
+		"Superzahn",
+		"Superdiente"
+	],
+	"Superpower": [
+		"ばかぢから",
+		"Surpuissance",
+		"Troppoforte",
+		"Kraftkoloss",
+		"Fuerza Bruta"
+	],
+	"Supersonic": [
+		"ちょうおんぱ",
+		"Ultrason",
+		"Supersuono",
+		"Superschall",
+		"Supersónico"
+	],
+	"Surf": [
+		"なみのり",
+		"Surf",
+		"Surf",
+		"Surfer",
+		"Surf"
+	],
+	"Swagger": [
+		"いばる",
+		"Vantardise",
+		"Bullo",
+		"Angeberei",
+		"Contoneo"
+	],
+	"Swallow": [
+		"のみこむ",
+		"Avale",
+		"Introenergia",
+		"Verzehrer",
+		"Tragar"
+	],
+	"Sweet Kiss": [
+		"てんしのキッス",
+		"Doux Baiser",
+		"Dolcebacio",
+		"Bitterkuss",
+		"Beso Dulce"
+	],
+	"Sweet Scent": [
+		"あまいかおり",
+		"Doux Parfum",
+		"Profumino",
+		"Lockduft",
+		"Dulce Aroma"
+	],
+	"Swift": [
+		"スピードスター",
+		"Météores",
+		"Comete",
+		"Sternschauer",
+		"Rapidez"
+	],
+	"Switcheroo": [
+		"すりかえ",
+		"Passe-Passe",
+		"Rapidscambio",
+		"Wechseldich",
+		"Trapicheo"
+	],
+	"Swords Dance": [
+		"つるぎのまい",
+		"Danse-Lames",
+		"Danzaspada",
+		"Schwerttanz",
+		"Danza Espada"
+	],
+	"Synchronoise": [
+		"シンクロノイズ",
+		"Synchropeine",
+		"Sincrumore",
+		"Synchrolärm",
+		"Sincrorruido"
+	],
+	"Synthesis": [
+		"こうごうせい",
+		"Synthèse",
+		"Sintesi",
+		"Synthese",
+		"Síntesis"
+	],
+	"Tackle": [
+		"たいあたり",
+		"Charge",
+		"Azione",
+		"Tackle",
+		"Placaje"
+	],
+	"Tail Glow": [
+		"ほたるび",
+		"Lumiqueue",
+		"Codadiluce",
+		"Schweifglanz",
+		"Ráfaga"
+	],
+	"Tail Slap": [
+		"スイープビンタ",
+		"Plumo-Queue",
+		"Spazzasberla",
+		"Kehrschelle",
+		"Plumerazo"
+	],
+	"Tail Whip": [
+		"しっぽをふる",
+		"Mimi-Queue",
+		"Colpocoda",
+		"Rutenschlag",
+		"Látigo"
+	],
+	"Tailwind": [
+		"おいかぜ",
+		"Vent Arrière",
+		"Ventoincoda",
+		"Rückenwind",
+		"Viento Afín"
+	],
+	"Take Down": [
+		"とっしん",
+		"Bélier",
+		"Riduttore",
+		"Bodycheck",
+		"Derribo"
+	],
+	"Taunt": [
+		"ちょうはつ",
+		"Provoc",
+		"Provocazione",
+		"Verhöhner",
+		"Mofa"
+	],
+	"Techno Blast": [
+		"テクノバスター",
+		"TechnoBuster",
+		"Tecnobotto",
+		"Techblaster",
+		"Tecno Shock"
+	],
+	"Teeter Dance": [
+		"フラフラダンス",
+		"Danse-Folle",
+		"Strampadanza",
+		"Taumeltanz",
+		"Danza Caos"
+	],
+	"Telekinesis": [
+		"テレキネシス",
+		"Lévikinésie",
+		"Telecinesi",
+		"Telekinese",
+		"Telequinesis"
+	],
+	"Teleport": [
+		"テレポート",
+		"Téléport",
+		"Teletraspor.",
+		"Teleport",
+		"Teletransp"
+	],
+	"Thief": [
+		"どろぼう",
+		"Larcin",
+		"Furto",
+		"Raub",
+		"Ladrón"
+	],
+	"Thrash": [
+		"あばれる",
+		"Mania",
+		"Colpo",
+		"Fuchtler",
+		"Golpe"
+	],
+	"Thunder": [
+		"かみなり",
+		"Fatal-Foudre",
+		"Tuono",
+		"Donner",
+		"Trueno"
+	],
+	"Thunder Fang": [
+		"かみなりのキバ",
+		"Crocs Éclair",
+		"Fulmindenti",
+		"Donnerzahn",
+		"Colm. Rayo"
+	],
+	"Thunder Wave": [
+		"でんじは",
+		"Cage-Éclair",
+		"Tuononda",
+		"Donnerwelle",
+		"Onda Trueno"
+	],
+	"Thunderbolt": [
+		"１０まんボルト",
+		"Tonnerre",
+		"Fulmine",
+		"Donnerblitz",
+		"Rayo"
+	],
+	"ThunderPunch": [
+		"かみなりパンチ",
+		"Poing-Éclair",
+		"Tuonopugno",
+		"Donnerschlag",
+		"Puño Trueno"
+	],
+	"ThunderShock": [
+		"でんきショック",
+		"Éclair",
+		"Tuonoshock",
+		"Donnerschock",
+		"Impactrueno"
+	],
+	"Tickle": [
+		"くすぐる",
+		"Chatouille",
+		"Solletico",
+		"Spaßkanone",
+		"Cosquillas"
+	],
+	"Torment": [
+		"いちゃもん",
+		"Tourmente",
+		"Attaccalite",
+		"Folterknecht",
+		"Tormento"
+	],
+	"Toxic": [
+		"どくどく",
+		"Toxik",
+		"Tossina",
+		"Toxin",
+		"Tóxico"
+	],
+	"Toxic Spikes": [
+		"どくびし",
+		"Pics Toxik",
+		"Fielepunte",
+		"Giftspitzen",
+		"Púas Tóxicas"
+	],
+	"Transform": [
+		"へんしん",
+		"Morphing",
+		"Trasformaz.",
+		"Wandler",
+		"Transform"
+	],
+	"Tri Attack": [
+		"トライアタック",
+		"Triplattaque",
+		"Tripletta",
+		"Triplette",
+		"Triataque"
+	],
+	"Trick": [
+		"トリック",
+		"Tourmagik",
+		"Raggiro",
+		"Trickbetrug",
+		"Truco"
+	],
+	"Trick Room": [
+		"トリックルーム",
+		"Distorsion",
+		"Distortozona",
+		"Bizarroraum",
+		"Espacio Raro"
+	],
+	"Triple Kick": [
+		"トリプルキック",
+		"Triple Pied",
+		"Triplocalcio",
+		"Dreifachkick",
+		"Triplepatada"
+	],
+	"Trump Card": [
+		"きりふだ",
+		"Atout",
+		"Asso",
+		"Trumpfkarte",
+		"As Oculto"
+	],
+	"Twineedle": [
+		"ダブルニードル",
+		"Double-Dard",
+		"Doppio Ago",
+		"Duonadel",
+		"Dobleataque"
+	],
+	"Twister": [
+		"たつまき",
+		"Ouragan",
+		"Tornado",
+		"Windhose",
+		"Ciclón"
+	],
+	"U-turn": [
+		"とんぼがえり",
+		"Demi-Tour",
+		"Retromarcia",
+		"Kehrtwende",
+		"Ida y Vuelta"
+	],
+	"Uproar": [
+		"さわぐ",
+		"Brouhaha",
+		"Baraonda",
+		"Aufruhr",
+		"Alboroto"
+	],
+	"V-create": [
+		"Ｖジェネレート",
+		"CoupVictoire",
+		"Generatore V",
+		"V-Generator",
+		"V de Fuego"
+	],
+	"Vacuum Wave": [
+		"しんくうは",
+		"Onde Vide",
+		"Vuotonda",
+		"Vakuumwelle",
+		"Onda Vacío"
+	],
+	"Venoshock": [
+		"ベノムショック",
+		"Choc Venin",
+		"Velenoshock",
+		"Giftschock",
+		"Cargatóxica"
+	],
+	"ViceGrip": [
+		"はさむ",
+		"Force Poigne",
+		"Presa",
+		"Klammer",
+		"Agarre"
+	],
+	"Vine Whip": [
+		"つるのムチ",
+		"Fouet Lianes",
+		"Frustata",
+		"Rankenhieb",
+		"Látigo Cepa"
+	],
+	"Vital Throw": [
+		"あてみなげ",
+		"Corps Perdu",
+		"Vitaltiro",
+		"Überwurf",
+		"Tiro Vital"
+	],
+	"Volt Switch": [
+		"ボルトチェンジ",
+		"ChangeÉclair",
+		"Invertivolt",
+		"Voltwechsel",
+		"Voltiocambio"
+	],
+	"Volt Tackle": [
+		"ボルテッカー",
+		"Électacle",
+		"Locomovolt",
+		"Volttackle",
+		"Placaje Eléc"
+	],
+	"Wake-Up Slap": [
+		"めざましビンタ",
+		"Réveil Forcé",
+		"Svegliopacca",
+		"Weckruf",
+		"Espabila"
+	],
+	"Water Gun": [
+		"みずでっぽう",
+		"Pistolet à O",
+		"Pistolacqua",
+		"Aquaknarre",
+		"Pistola Agua"
+	],
+	"Water Pledge": [
+		"みずのちかい",
+		"Aire d'Eau",
+		"Acquapatto",
+		"Wassersäulen",
+		"Voto Agua"
+	],
+	"Water Pulse": [
+		"みずのはどう",
+		"Vibraqua",
+		"Idropulsar",
+		"Aquawelle",
+		"Hidropulso"
+	],
+	"Water Sport": [
+		"みずあそび",
+		"Tourniquet",
+		"Docciascudo",
+		"Nassmacher",
+		"Hidrochorro"
+	],
+	"Water Spout": [
+		"しおふき",
+		"Giclédo",
+		"Zampillo",
+		"Fontränen",
+		"Salpicar"
+	],
+	"Waterfall": [
+		"たきのぼり",
+		"Cascade",
+		"Cascata",
+		"Kaskade",
+		"Cascada"
+	],
+	"Weather Ball": [
+		"ウェザーボール",
+		"Ball'Météo",
+		"Palla Clima",
+		"Meteorologe",
+		"Meteorobola"
+	],
+	"Whirlpool": [
+		"うずしお",
+		"Siphon",
+		"Mulinello",
+		"Whirlpool",
+		"Torbellino"
+	],
+	"Whirlwind": [
+		"ふきとばし",
+		"Cyclone",
+		"Turbine",
+		"Wirbelwind",
+		"Remolino"
+	],
+	"Wide Guard": [
+		"ワイドガード",
+		"Garde Large",
+		"Bodyguard",
+		"Rundumschutz",
+		"Vastaguardia"
+	],
+	"Wild Charge": [
+		"ワイルドボルト",
+		"Éclair Fou",
+		"Sprizzalampo",
+		"Stromstoß",
+		"Voltio Cruel"
+	],
+	"Will-O-Wisp": [
+		"おにび",
+		"Feu Follet",
+		"Fuocofatuo",
+		"Irrlicht",
+		"Fuego Fatuo"
+	],
+	"Wing Attack": [
+		"つばさでうつ",
+		"Cru-Aile",
+		"Att. d'Ala",
+		"Flügelschlag",
+		"Ataque Ala"
+	],
+	"Wish": [
+		"ねがいごと",
+		"Vœu",
+		"Desiderio",
+		"Wunschtraum",
+		"Deseo"
+	],
+	"Withdraw": [
+		"からにこもる",
+		"Repli",
+		"Ritirata",
+		"Panzerschutz",
+		"Refugio"
+	],
+	"Wonder Room": [
+		"ワンダールーム",
+		"Zone Étrange",
+		"Mirabilzona",
+		"Wunderraum",
+		"Zona Extraña"
+	],
+	"Wood Hammer": [
+		"ウッドハンマー",
+		"Martobois",
+		"Mazzuolegno",
+		"Holzhammer",
+		"Mazazo"
+	],
+	"Work Up": [
+		"ふるいたてる",
+		"Rengorgement",
+		"Cuordileone",
+		"Kraftschub",
+		"Avivar"
+	],
+	"Worry Seed": [
+		"なやみのタネ",
+		"Soucigraine",
+		"Affannoseme",
+		"Sorgensamen",
+		"Abatidoras"
+	],
+	"Wrap": [
+		"まきつく",
+		"Ligotage",
+		"Avvolgibotta",
+		"Wickel",
+		"Repetición"
+	],
+	"Wring Out": [
+		"しぼりとる",
+		"Essorage",
+		"Strizzata",
+		"Auswringen",
+		"Estrujón"
+	],
+	"X-Scissor": [
+		"シザークロス",
+		"Plaie-Croix",
+		"Forbice X",
+		"Kreuzschere",
+		"Tijera X"
+	],
+	"Yawn": [
+		"あくび",
+		"Bâillement",
+		"Sbadiglio",
+		"Gähner",
+		"Bostezo"
+	],
+	"Zap Cannon": [
+		"でんじほう",
+		"Élecanon",
+		"Falcecannone",
+		"Blitzkanone",
+		"Electrocañón"
+	],
+	"Zen Headbutt": [
+		"しねんのずつき",
+		"Psykoud'Boul",
+		"Cozzata Zen",
+		"Zen-Kopfstoß",
+		"Cabezazo Zen"
+	],
+	/* Item translations */
+	"Absorb Bulb": [
+		"きゅうこん",
+		"Bulbe",
+		"Bulbo",
+		"Knolle",
+		"Tubérculo"
+	],
+	"Adamant Orb": [
+		"こんごうだま",
+		"Orbe Adamant",
+		"Adamasfera",
+		"Adamant-Orb",
+		"Diamansfera"
+	],
+	"Aguav Berry": [
+		"バンジのみ",
+		"Baie Gowav",
+		"Baccaguava",
+		"Gauvebeere",
+		"Baya Guaya"
+	],
+	"Air Balloon": [
+		"ふうせん",
+		"Ballon",
+		"Palloncino",
+		"Luftballon",
+		"Globo Helio"
+	],
+	"Apicot Berry": [
+		"ズアのみ",
+		"Baie Abriko",
+		"Baccacocca",
+		"Apikobeere",
+		"Baya Aricoc"
+	],
+	"Armor Fossil": [
+		"たてのカセキ",
+		"Foss. Armure",
+		"Fossilscudo",
+		"Panzerfossil",
+		"Fósil Coraza"
+	],
+	"Aspear Berry": [
+		"ナナシのみ",
+		"Baie Willia",
+		"Baccaperina",
+		"Wilbirbeere",
+		"Baya Perasi"
+	],
+	"Babiri Berry": [
+		"リリバのみ",
+		"Baie Babiri",
+		"Baccababiri",
+		"Babiribeere",
+		"Baya Baribá"
+	],
+	"Belue Berry": [
+		"ベリブのみ",
+		"Baie Myrte",
+		"Baccartillo",
+		"Myrtilbeere",
+		"Baya Andano"
+	],
+	"Berry Juice": [
+		"きのみジュース",
+		"Jus de Baie",
+		"Succodibacca",
+		"Beerensaft",
+		"Zumo de Baya"
+	],
+	"Big Root": [
+		"おおきなねっこ",
+		"Grosseracine",
+		"Granradice",
+		"Großwurzel",
+		"Raíz Grande"
+	],
+	"Binding Band": [
+		"しめつけバンド",
+		"B. Étreinte",
+		"Legafascia",
+		"Klammerband",
+		"Ban. Atadura"
+	],
+	"Black Belt": [
+		"くろおび",
+		"Ceint.Noire",
+		"Cinturanera",
+		"Schwarzgurt",
+		"Cint. Negro"
+	],
+	"Black Sludge": [
+		"くろいヘドロ",
+		"Boue Noire",
+		"Fangopece",
+		"Giftschleim",
+		"Lodo Negro"
+	],
+	"BlackGlasses": [
+		"くろいメガネ",
+		"Lunet.Noires",
+		"Occhialineri",
+		"Schattenglas",
+		"Gafas de Sol"
+	],
+	"Bluk Berry": [
+		"ブリーのみ",
+		"Baie Remu",
+		"Baccamora",
+		"Morbbeere",
+		"Baya Oram"
+	],
+	"BrightPowder": [
+		"ひかりのこな",
+		"Poudreclaire",
+		"Luminpolvere",
+		"Blendpuder",
+		"Polvo Brillo"
+	],
+	"Bug Gem": [
+		"むしのジュエル",
+		"Joyau Insect",
+		"Bijoucoleot.",
+		"Käferjuwel",
+		"G. Bicho"
+	],
+	"Burn Drive": [
+		"ブレイズカセット",
+		"Module Pyro",
+		"Piromodulo",
+		"Flammenmodul",
+		"PiroROM"
+	],
+	"Cell Battery": [
+		"じゅうでんち",
+		"Pile",
+		"Ricaripila",
+		"Akku",
+		"Pila"
+	],
+	"Charcoal": [
+		"もくたん",
+		"Charbon",
+		"Carbonella",
+		"Holzkohle",
+		"Carbón"
+	],
+	"Charti Berry": [
+		"ヨロギのみ",
+		"Baie Charti",
+		"Baccaciofo",
+		"Chiaribeere",
+		"Baya Alcho"
+	],
+	"Cheri Berry": [
+		"クラボのみ",
+		"Baie Ceriz",
+		"Baccaliegia",
+		"Amrenabeere",
+		"Baya Zreza"
+	],
+	"Cherish Ball": [
+		"プレシャスボール",
+		"Mémoire Ball",
+		"Pregio Ball",
+		"Jubelball",
+		"Gloria Ball"
+	],
+	"Chesto Berry": [
+		"カゴのみ",
+		"Baie Maron",
+		"Baccastagna",
+		"Maronbeere",
+		"Baya Atania"
+	],
+	"Chilan Berry": [
+		"ホズのみ",
+		"Baie Zalis",
+		"Baccacinlan",
+		"Latchibeere",
+		"Baya Chilan"
+	],
+	"Chill Drive": [
+		"フリーズカセット",
+		"Module Cryo",
+		"Gelomodulo",
+		"Gefriermodul",
+		"CrioROM"
+	],
+	"Choice Band": [
+		"こだわりハチマキ",
+		"Band. Choix",
+		"Bendascelta",
+		"Wahlband",
+		"Cin. Elegida"
+	],
+	"Choice Scarf": [
+		"こだわりスカーフ",
+		"Mouch. Choix",
+		"Stolascelta",
+		"Wahlschal",
+		"Pañ. Elegido"
+	],
+	"Choice Specs": [
+		"こだわりメガネ",
+		"Lunet. Choix",
+		"Lentiscelta",
+		"Wahlglas",
+		"Gafas Elegid"
+	],
+	"Chople Berry": [
+		"ヨプのみ",
+		"Baie Pomroz",
+		"Baccarosmel",
+		"Rospelbeere",
+		"Baya Pomaro"
+	],
+	"Claw Fossil": [
+		"ツメのカセキ",
+		"Foss. Griffe",
+		"Fossilunghia",
+		"Klauenfossil",
+		"Fósil Garra"
+	],
+	"Coba Berry": [
+		"バコウのみ",
+		"Baie Cobaba",
+		"Baccababa",
+		"Kobabeere",
+		"Baya Kouba"
+	],
+	"Colbur Berry": [
+		"ナモのみ",
+		"Baie Lampou",
+		"Baccaxan",
+		"Burleobeere",
+		"Baya Dillo"
+	],
+	"Cornn Berry": [
+		"モコシのみ",
+		"Baie Siam",
+		"Baccavena",
+		"Saimbeere",
+		"Baya Mais"
+	],
+	"Cover Fossil": [
+		"ふたのカセキ",
+		"Foss. Plaque",
+		"Fossiltappo",
+		"Schildfossil",
+		"Fósil Tapa"
+	],
+	"Custap Berry": [
+		"イバンのみ",
+		"Baie Chérim",
+		"Baccacrela",
+		"Eipfelbeere",
+		"Baya Chiri"
+	],
+	"Damp Rock": [
+		"しめったいわ",
+		"Roche Humide",
+		"Rocciaumida",
+		"Nassbrocken",
+		"Roca Lluvia"
+	],
+	"Dark Gem": [
+		"あくのジュエル",
+		"Joyau Ténèbr",
+		"Bijoubuio",
+		"Unlichtjuwel",
+		"G. Siniestra"
+	],
+	"DeepSeaScale": [
+		"しんかいのウロコ",
+		"Écailleocéan",
+		"Squamabissi",
+		"Abyssplatte",
+		"Escama Mar."
+	],
+	"DeepSeaTooth": [
+		"しんかいのキバ",
+		"Dent Océan",
+		"Dente Abissi",
+		"Abysszahn",
+		"Diente Mar."
+	],
+	"Destiny Knot": [
+		"あかいいと",
+		"Nœud Destin",
+		"Destincomune",
+		"Fatumknoten",
+		"Lazo Destino"
+	],
+	"Dive Ball": [
+		"ダイブボール",
+		"Scuba Ball",
+		"Sub Ball",
+		"Tauchball",
+		"Buceo Ball"
+	],
+	"Dome Fossil": [
+		"こうらのカセキ",
+		"Fossile Dôme",
+		"Domofossile",
+		"Domfossil",
+		"Fósil Domo"
+	],
+	"Douse Drive": [
+		"アクアカセット",
+		"Module Aqua",
+		"Idromodulo",
+		"Aquamodul",
+		"HidroROM"
+	],
+	"Draco Plate": [
+		"りゅうのプレート",
+		"Plaque Draco",
+		"Lastradrakon",
+		"Dracotafel",
+		"Tabla Draco"
+	],
+	"Dragon Fang": [
+		"りゅうのキバ",
+		"Croc Dragon",
+		"Dentedidrago",
+		"Drachenzahn",
+		"Colmillodrag"
+	],
+	"Dragon Gem": [
+		"ドラゴンジュエル",
+		"Joyau Dragon",
+		"Bijoudrago",
+		"Drakojuwel",
+		"G. Dragón"
+	],
+	"Dread Plate": [
+		"こわもてプレート",
+		"Plaque Ombre",
+		"Lastratimore",
+		"Furchttafel",
+		"Tabla Oscura"
+	],
+	"Dream Ball": [
+		"ドリームボール",
+		"Rêve Ball",
+		"Dream Ball",
+		"Traumball",
+		"Ensueño Ball"
+	],
+	"Durin Berry": [
+		"ドリのみ",
+		"Baie Durin",
+		"Baccadurian",
+		"Durinbeere",
+		"Baya Rudion"
+	],
+	"Dusk Ball": [
+		"ダークボール",
+		"Sombre Ball",
+		"Scuro Ball",
+		"Finsterball",
+		"Ocaso Ball"
+	],
+	"Earth Plate": [
+		"だいちのプレート",
+		"Plaque Terre",
+		"Lastrageo",
+		"Erdtafel",
+		"Tabla Terrax"
+	],
+	"Eject Button": [
+		"だっしゅつボタン",
+		"Bouton Fuite",
+		"Pulsantefuga",
+		"Fluchtknopf",
+		"Botón Escape"
+	],
+	"Electirizer": [
+		"エレキブースター",
+		"Électiriseur",
+		"Elettritore",
+		"Stromisierer",
+		"Electrizador"
+	],
+	"Electric Gem": [
+		"でんきのジュエル",
+		"Joyau Électr",
+		"Bijouelettro",
+		"Elektrojuwel",
+		"G. Eléctrica"
+	],
+	"EnergyPowder": [
+		"ちからのこな",
+		"Poudrénergie",
+		"Polvenergia",
+		"Energiestaub",
+		"Polvoenergía"
+	],
+	"Enigma Berry": [
+		"ナゾのみ",
+		"Baie Enigma",
+		"Baccaenigma",
+		"Enigmabeere",
+		"Baya Enigma"
+	],
+	"Eviolite": [
+		"しんかのきせき",
+		"Évoluroc",
+		"Evolcondensa",
+		"Evolith",
+		"Mineral Evol"
+	],
+	"Expert Belt": [
+		"たつじんのおび",
+		"Ceinture Pro",
+		"Abilcintura",
+		"Expertengurt",
+		"Cinta Xperto"
+	],
+	"Fast Ball": [
+		"スピードボール",
+		"Speed Ball",
+		"Rapid Ball",
+		"Turboball",
+		"Rapid Ball"
+	],
+	"Fighting Gem": [
+		"かくとうジュエル",
+		"Joyau Combat",
+		"Bijoulotta",
+		"Kampfjuwel",
+		"G. Lucha"
+	],
+	"Figy Berry": [
+		"フィラのみ",
+		"Baie Figuy",
+		"Baccafico",
+		"Giefebeere",
+		"Baya Higog"
+	],
+	"Fire Gem": [
+		"ほのおのジュエル",
+		"Joyau Feu",
+		"Bijoufuoco",
+		"Feuerjuwel",
+		"G. Fuego"
+	],
+	"Fist Plate": [
+		"こぶしのプレート",
+		"Plaque Poing",
+		"Lastrapugno",
+		"Fausttafel",
+		"Tabla Fuerte"
+	],
+	"Flame Orb": [
+		"かえんだま",
+		"Orbe Flamme",
+		"Fiammosfera",
+		"Heiß-Orb",
+		"Llamasfera"
+	],
+	"Flame Plate": [
+		"ひのたまプレート",
+		"Plaque Flam",
+		"Lastrarogo",
+		"Feuertafel",
+		"Tabla Llama"
+	],
+	"Float Stone": [
+		"かるいし",
+		"Pierrallégée",
+		"Pietralieve",
+		"Leichtstein",
+		"Piedra Pómez"
+	],
+	"Flying Gem": [
+		"ひこうのジュエル",
+		"Joyau Vol",
+		"Bijouvolante",
+		"Flugjuwel",
+		"G. Voladora"
+	],
+	"Focus Band": [
+		"きあいのハチマキ",
+		"Bandeau",
+		"Bandana",
+		"Fokus-Band",
+		"Cinta Focus"
+	],
+	"Focus Sash": [
+		"きあいのタスキ",
+		"Ceint. Force",
+		"Focalnastro",
+		"Fokusgurt",
+		"Banda Focus"
+	],
+	"Full Incense": [
+		"まんぷくおこう",
+		"Encens Plein",
+		"Gonfioaroma",
+		"Lahmrauch",
+		"Incie. Lento"
+	],
+	"Ganlon Berry": [
+		"リュガのみ",
+		"Baie Lingan",
+		"Baccalongan",
+		"Linganbeere",
+		"Baya Gonlan"
+	],
+	"Ghost Gem": [
+		"ゴーストジュエル",
+		"Joyau Spectr",
+		"Bijouspettro",
+		"Geistjuwel",
+		"G. Fantasma"
+	],
+	"Grass Gem": [
+		"くさのジュエル",
+		"Joyau Plante",
+		"Bijouerba",
+		"Pflanzjuwel",
+		"G. Planta"
+	],
+	"Great Ball": [
+		"スーパーボール",
+		"Super Ball",
+		"Mega Ball",
+		"Superball",
+		"Superball"
+	],
+	"Grepa Berry": [
+		"ウブのみ",
+		"Baie Résin",
+		"Baccauva",
+		"Labrusbeere",
+		"Baya Uvav"
+	],
+	"Grip Claw": [
+		"ねばりのかぎづめ",
+		"Accro Griffe",
+		"Presartigli",
+		"Griffklaue",
+		"Garra Garfio"
+	],
+	"Griseous Orb": [
+		"はっきんだま",
+		"Orbe Platiné",
+		"Grigiosfera",
+		"Platinum-Orb",
+		"Griseosfera"
+	],
+	"Ground Gem": [
+		"じめんのジュエル",
+		"Joyau Sol",
+		"Bijouterra",
+		"Bodenjuwel",
+		"G. Tierra"
+	],
+	"Haban Berry": [
+		"ハバンのみ",
+		"Baie Fraigo",
+		"Baccahaban",
+		"Terirobeere",
+		"Baya Anjiro"
+	],
+	"Hard Stone": [
+		"かたいいし",
+		"Pierre Dure",
+		"Pietradura",
+		"Granitstein",
+		"Piedra Dura"
+	],
+	"Heal Ball": [
+		"ヒールボール",
+		"Soin Ball",
+		"Cura Ball",
+		"Heilball",
+		"Sana Ball"
+	],
+	"Heat Rock": [
+		"あついいわ",
+		"Roche Chaude",
+		"Rocciacalda",
+		"Heißbrocken",
+		"Roca Calor"
+	],
+	"Heavy Ball": [
+		"ヘビーボール",
+		"Masse Ball",
+		"Peso Ball",
+		"Schwerball",
+		"Peso Ball"
+	],
+	"Helix Fossil": [
+		"かいのカセキ",
+		"Nautile",
+		"Helixfossile",
+		"Helixfossil",
+		"Fósil Helix"
+	],
+	"Hondew Berry": [
+		"ロメのみ",
+		"Baie Lonme",
+		"Baccamelon",
+		"Honmelbeere",
+		"Baya Meluce"
+	],
+	"Iapapa Berry": [
+		"イアのみ",
+		"Baie Papaya",
+		"Baccapaia",
+		"Yapabeere",
+		"Baya Pabaya"
+	],
+	"Ice Gem": [
+		"こおりのジュエル",
+		"Joyau Glace",
+		"Bijoughiac.",
+		"Eisjuwel",
+		"G. Hielo"
+	],
+	"Icicle Plate": [
+		"つららのプレート",
+		"Plaque Glace",
+		"Lastragelo",
+		"Frosttafel",
+		"Tabla Helada"
+	],
+	"Icy Rock": [
+		"つめたいいわ",
+		"Roche Glace",
+		"Rocciafredda",
+		"Eisbrocken",
+		"Roca Helada"
+	],
+	"Insect Plate": [
+		"たまむしプレート",
+		"Plaquinsect",
+		"Lastrabaco",
+		"Käfertafel",
+		"Tabla Bicho"
+	],
+	"Iron Ball": [
+		"くろいてっきゅう",
+		"Balle Fer",
+		"Ferropalla",
+		"Eisenkugel",
+		"Bola Férrea"
+	],
+	"Iron Plate": [
+		"こうてつプレート",
+		"Plaque Fer",
+		"Lastraferro",
+		"Eisentafel",
+		"Tabla Acero"
+	],
+	"Jaboca Berry": [
+		"ジャポのみ",
+		"Baie Jaboca",
+		"Baccajaba",
+		"Jabocabeere",
+		"Baya Jaboca"
+	],
+	"Kasib Berry": [
+		"カシブのみ",
+		"Baie Sédra",
+		"Baccacitrus",
+		"Zitarzbeere",
+		"Baya Drasi"
+	],
+	"Kebia Berry": [
+		"ビアーのみ",
+		"Baie Kébia",
+		"Baccakebia",
+		"Grarzbeere",
+		"Baya Kebia"
+	],
+	"Kelpsy Berry": [
+		"ネコブのみ",
+		"Baie Alga",
+		"Baccalga",
+		"Setangbeere",
+		"Baya Algama"
+	],
+	"King's Rock": [
+		"おうじゃのしるし",
+		"Roche Royale",
+		"Roccia Di Re",
+		"King-Stein",
+		"Roca del Rey"
+	],
+	"Lagging Tail": [
+		"こうこうのしっぽ",
+		"Ralentiqueue",
+		"Rallentocoda",
+		"Schwerschwf.",
+		"Cola Plúmbea"
+	],
+	"Lansat Berry": [
+		"サンのみ",
+		"Baie Lansat",
+		"Baccalangsa",
+		"Lansatbeere",
+		"Baya Zonlan"
+	],
+	"Lax Incense": [
+		"のんきのおこう",
+		"Encens Doux",
+		"Distraroma",
+		"Laxrauch",
+		"Incie. Suave"
+	],
+	"Leftovers": [
+		"たべのこし",
+		"Restes",
+		"Avanzi",
+		"Überreste",
+		"Restos"
+	],
+	"Leppa Berry": [
+		"ヒメリのみ",
+		"Baie Mepo",
+		"Baccamela",
+		"Jonagobeere",
+		"Baya Zanama"
+	],
+	"Level Ball": [
+		"レベルボール",
+		"Niveau Ball",
+		"Level Ball",
+		"Levelball",
+		"Nivel Ball"
+	],
+	"Liechi Berry": [
+		"チイラのみ",
+		"Baie Lichii",
+		"Baccalici",
+		"Lydzibeere",
+		"Baya Lichi"
+	],
+	"Life Orb": [
+		"いのちのたま",
+		"Orbe Vie",
+		"Assorbisfera",
+		"Leben-Orb",
+		"Vidasfera"
+	],
+	"Light Ball": [
+		"でんきだま",
+		"Ballelumière",
+		"Elettropalla",
+		"Kugelblitz",
+		"Bolaluminosa"
+	],
+	"Light Clay": [
+		"ひかりのねんど",
+		"Lumargile",
+		"Creta Luce",
+		"Lichtlehm",
+		"Refleluz"
+	],
+	"Love Ball": [
+		"ラブラブボール",
+		"Love Ball",
+		"Love Ball",
+		"Sympaball",
+		"Amor Ball"
+	],
+	"Lucky Punch": [
+		"ラッキーパンチ",
+		"Poing Chance",
+		"Fortunpugno",
+		"Lucky Punch",
+		"Puño Suerte"
+	],
+	"Lum Berry": [
+		"ラムのみ",
+		"Baie Prine",
+		"Baccaprugna",
+		"Prunusbeere",
+		"Baya Ziuela"
+	],
+	"Lure Ball": [
+		"ルアーボール",
+		"Appât Ball",
+		"Esca Ball",
+		"Köderball",
+		"Cebo Ball"
+	],
+	"Lustrous Orb": [
+		"しらたま",
+		"Orbe Perlé",
+		"Splendisfera",
+		"Weiß-Orb",
+		"Lustresfera"
+	],
+	"Luxury Ball": [
+		"ゴージャスボール",
+		"Luxe Ball",
+		"Chic Ball",
+		"Luxusball",
+		"Lujo Ball"
+	],
+	"Macho Brace": [
+		"きょうせいギプス",
+		"Brac. Macho",
+		"Crescicappa",
+		"Machoband",
+		"Brazal Firme"
+	],
+	"Magnet": [
+		"じしゃく",
+		"Aimant",
+		"Calamita",
+		"Magnet",
+		"Imán"
+	],
+	"Mago Berry": [
+		"マゴのみ",
+		"Baie Mago",
+		"Baccamango",
+		"Magobeere",
+		"Baya Ango"
+	],
+	"Magost Berry": [
+		"ゴスのみ",
+		"Baie Mangou",
+		"Baccagostan",
+		"Magostbeere",
+		"Baya Aostan"
+	],
+	"Master Ball": [
+		"マスターボール",
+		"Master Ball",
+		"Master Ball",
+		"Meisterball",
+		"Master Ball"
+	],
+	"Meadow Plate": [
+		"みどりのプレート",
+		"Plaque Herbe",
+		"Lastraprato",
+		"Wiesentafel",
+		"Tabla Pradal"
+	],
+	"Mental Herb": [
+		"メンタルハーブ",
+		"Herbe Mental",
+		"Mentalerba",
+		"Mentalkraut",
+		"Hier. Mental"
+	],
+	"Metal Coat": [
+		"メタルコート",
+		"Peau Métal",
+		"Metalcoperta",
+		"Metallmantel",
+		"Rev.metálico"
+	],
+	"Metal Powder": [
+		"メタルパウダー",
+		"Poudre Métal",
+		"Metalpolvere",
+		"Metallstaub",
+		"Pol.metálico"
+	],
+	"Metronome": [
+		"メトロノーム",
+		"Métronome",
+		"Plessimetro",
+		"Metronom",
+		"Metrónomo"
+	],
+	"Micle Berry": [
+		"ミクルのみ",
+		"Baie Micle",
+		"Baccaracolo",
+		"Wunfrubeere",
+		"Baya Lagro"
+	],
+	"Moon Ball": [
+		"ムーンボール",
+		"Lune Ball",
+		"Luna Ball",
+		"Mondball",
+		"Luna Ball"
+	],
+	"Mind Plate": [
+		"ふしぎのプレート",
+		"Plaquesprit",
+		"Lastramente",
+		"Hirntafel",
+		"Tabla Mental"
+	],
+	"Miracle Seed": [
+		"きせきのタネ",
+		"Grain Miracl",
+		"Miracolseme",
+		"Wundersaat",
+		"Sem. Milagro"
+	],
+	"Muscle Band": [
+		"ちからのハチマキ",
+		"Band. Muscle",
+		"Muscolbanda",
+		"Muskelband",
+		"Cinta Fuerte"
+	],
+	"Mystic Water": [
+		"しんぴのしずく",
+		"Eau Mystique",
+		"Acqua Magica",
+		"Zauberwasser",
+		"Agua Mística"
+	],
+	"Nanab Berry": [
+		"ナナのみ",
+		"Baie Nanab",
+		"Baccabana",
+		"Nanabbeere",
+		"Baya Latano"
+	],
+	"Nest Ball": [
+		"ネストボール",
+		"Faiblo Ball",
+		"Minor Ball",
+		"Nestball",
+		"Nido Ball"
+	],
+	"Net Ball": [
+		"ネットボール",
+		"Filet Ball",
+		"Rete Ball",
+		"Netzball",
+		"Malla Ball"
+	],
+	"NeverMeltIce": [
+		"とけないこおり",
+		"Glacéternel",
+		"Gelomai",
+		"Ewiges Eis",
+		"Antiderretir"
+	],
+	"Nomel Berry": [
+		"ノメルのみ",
+		"Baie Tronci",
+		"Baccalemon",
+		"Tronzibeere",
+		"Baya Monli"
+	],
+	"Normal Gem": [
+		"ノーマルジュエル",
+		"Joyau Normal",
+		"Bijounormale",
+		"Normaljuwel",
+		"G. Normal"
+	],
+	"Occa Berry": [
+		"オッカのみ",
+		"Baie Chocco",
+		"Baccacao",
+		"Koakobeere",
+		"Baya Caoca"
+	],
+	"Odd Incense": [
+		"あやしいおこう",
+		"Bizar.Encens",
+		"Bizzoaroma",
+		"Schrägrauch",
+		"Incie. Raro"
+	],
+	"Old Amber": [
+		"ひみつのコハク",
+		"Vieil Ambre",
+		"Ambra Antica",
+		"Altbernstein",
+		"Ámbar Viejo"
+	],
+	"Oran Berry": [
+		"オレンのみ",
+		"Baie Oran",
+		"Baccarancia",
+		"Sinelbeere",
+		"Baya Aranja"
+	],
+	"Pamtre Berry": [
+		"シーヤのみ",
+		"Baie Palma",
+		"Baccapalma",
+		"Pallmbeere",
+		"Baya Plama"
+	],
+	"Park Ball": [
+		"パークボール",
+		"Parc Ball",
+		"Parco Ball",
+		"Parkball",
+		"Parque Ball"
+	],
+	"Passho Berry": [
+		"イトケのみ",
+		"Baie Pocpoc",
+		"Baccapasflo",
+		"Foepasbeere",
+		"Baya Pasio"
+	],
+	"Payapa Berry": [
+		"ウタンのみ",
+		"Baie Yapap",
+		"Baccapayapa",
+		"Pyapabeere",
+		"Baya Payapa"
+	],
+	"Pecha Berry": [
+		"モモンのみ",
+		"Baie Pêcha",
+		"Baccapesca",
+		"Pirsifbeere",
+		"Baya Meloc"
+	],
+	"Persim Berry": [
+		"キーのみ",
+		"Baie Kika",
+		"Baccaki",
+		"Persimbeere",
+		"Baya Caquic"
+	],
+	"Petaya Berry": [
+		"ヤタピのみ",
+		"Baie Pitaye",
+		"Baccapitaya",
+		"Tahaybeere",
+		"Baya Yapati"
+	],
+	"Pinap Berry": [
+		"パイルのみ",
+		"Baie Nanana",
+		"Baccananas",
+		"Sananabeere",
+		"Baya Pinia"
+	],
+	"Plume Fossil": [
+		"はねのカセキ",
+		"Foss. Plume",
+		"Fossilpiuma",
+		"Federfossil",
+		"Fósil Pluma"
+	],
+	"Poison Barb": [
+		"どくバリ",
+		"Pic Venin",
+		"Velenaculeo",
+		"Giftstich",
+		"Flecha Ven."
+	],
+	"Poison Gem": [
+		"どくのジュエル",
+		"Joyau Poison",
+		"Bijouveleno",
+		"Giftjuwel",
+		"G. Veneno"
+	],
+	"Poke Ball": [
+		"モンスターボール",
+		"Poké Ball",
+		"Poké Ball",
+		"Pokéball",
+		"Poké Ball"
+	],
+	"Pomeg Berry": [
+		"ザロクのみ",
+		"Baie Grena",
+		"Baccagrana",
+		"Granabeere",
+		"Baya Grana"
+	],
+	"Power Herb": [
+		"パワフルハーブ",
+		"Herbe Pouv.",
+		"Vigorerba",
+		"Energiekraut",
+		"Hierba Única"
+	],
+	"Premier Ball": [
+		"プレミアボール",
+		"Honor Ball",
+		"Premier Ball",
+		"Premierball",
+		"Honor Ball"
+	],
+	"Psychic Gem": [
+		"エスパージュエル",
+		"Joyau Psy",
+		"Bijoupsico",
+		"Psychojuwel",
+		"G. Psíquica"
+	],
+	"Qualot Berry": [
+		"タポルのみ",
+		"Baie Qualot",
+		"Baccaloquat",
+		"Qualotbeere",
+		"Baya Ispero"
+	],
+	"Quick Ball": [
+		"クイックボール",
+		"Rapide Ball",
+		"Velox Ball",
+		"Flottball",
+		"Veloz Ball"
+	],
+	"Quick Claw": [
+		"せんせいのツメ",
+		"Vive Griffe",
+		"Rapidartigli",
+		"Flinkklaue",
+		"Garra Rápida"
+	],
+	"Quick Powder": [
+		"スピードパウダー",
+		"Poudre Vite",
+		"Velopolvere",
+		"Flottstaub",
+		"Polvo Veloz"
+	],
+	"Rabuta Berry": [
+		"ラブタのみ",
+		"Baie Rabuta",
+		"Baccambutan",
+		"Rabutabeere",
+		"Baya Rautan"
+	],
+	"Rare Bone": [
+		"きちょうなホネ",
+		"Os Rare",
+		"Osso Raro",
+		"Steinknochen",
+		"Hueso Raro"
+	],
+	"Rawst Berry": [
+		"チーゴのみ",
+		"Baie Fraive",
+		"Baccafrago",
+		"Fragiabeere",
+		"Baya Safre"
+	],
+	"Razor Claw": [
+		"するどいツメ",
+		"Grif. Rasoir",
+		"Affilartigli",
+		"Scharfklaue",
+		"Garrafilada"
+	],
+	"Razor Fang": [
+		"するどいキバ",
+		"Croc Rasoir",
+		"Affilodente",
+		"Scharfzahn",
+		"Colmillagudo"
+	],
+	"Razz Berry": [
+		"ズリのみ",
+		"Baie Framby",
+		"Baccalampon",
+		"Himmihbeere",
+		"Baya Frambu"
+	],
+	"Red Card": [
+		"レッドカード",
+		"Carton Rouge",
+		"Cartelrosso",
+		"Rote Karte",
+		"Tarjeta Roja"
+	],
+	"Repeat Ball": [
+		"リピートボール",
+		"Bis Ball",
+		"Bis Ball",
+		"Wiederball",
+		"Acopio Ball"
+	],
+	"Rindo Berry": [
+		"リンドのみ",
+		"Baie Ratam",
+		"Baccarindo",
+		"Grindobeere",
+		"Baya Tamar"
+	],
+	"Ring Target": [
+		"ねらいのまと",
+		"Pt de Mire",
+		"Facilsaglio",
+		"Zielscheibe",
+		"Blanco"
+	],
+	"Rock Gem": [
+		"いわのジュエル",
+		"Joyau Roche",
+		"Bijouroccia",
+		"Gesteinjuwel",
+		"G. Roca"
+	],
+	"Rock Incense": [
+		"がんせきおこう",
+		"Encens Roc",
+		"Roccioaroma",
+		"Steinrauch",
+		"Incie. Roca"
+	],
+	"Rocky Helmet": [
+		"ゴツゴツメット",
+		"Casque Brut",
+		"Bitorzolelmo",
+		"Beulenhelm",
+		"Cas. Dentado"
+	],
+	"Root Fossil": [
+		"ねっこのカセキ",
+		"Foss. Racine",
+		"Radifossile",
+		"Wurzelfossil",
+		"Fósil Raíz"
+	],
+	"Rose Incense": [
+		"おはなのおこう",
+		"Encens Fleur",
+		"Rosaroma",
+		"Rosenrauch",
+		"Inc. Floral"
+	],
+	"Rowap Berry": [
+		"レンブのみ",
+		"Baie Pommo",
+		"Baccaroam",
+		"Roselbeere",
+		"Baya Magua"
+	],
+	"Safari Ball": [
+		"サファリボール",
+		"Safari Ball",
+		"Safari Ball",
+		"Safariball",
+		"Safari Ball"
+	],
+	"Salac Berry": [
+		"カムラのみ",
+		"Baie Sailak",
+		"Baccasalak",
+		"Salkabeere",
+		"Baya Aslac"
+	],
+	"Scope Lens": [
+		"ピントレンズ",
+		"Lentilscope",
+		"Mirino",
+		"Scope-Linse",
+		"Periscopio"
+	],
+	"Sea Incense": [
+		"うしおのおこう",
+		"Encens Mer",
+		"Marearoma",
+		"Seerauch",
+		"Incie. Mar."
+	],
+	"Sharp Beak": [
+		"するどいくちばし",
+		"Bec Pointu",
+		"Beccaffilato",
+		"Hackattack",
+		"Pico Afilado"
+	],
+	"Shed Shell": [
+		"きれいなぬけがら",
+		"Carapace Mue",
+		"Disfoguscio",
+		"Wechselhülle",
+		"Muda Concha"
+	],
+	"Shell Bell": [
+		"かいがらのすず",
+		"Grelot Coque",
+		"Conchinella",
+		"Seegesang",
+		"Camp. Concha"
+	],
+	"Shock Drive": [
+		"イナズマカセット",
+		"Module Choc",
+		"Voltmodulo",
+		"Blitzmodul",
+		"FulgoROM"
+	],
+	"Shuca Berry": [
+		"シュカのみ",
+		"Baie Jouca",
+		"Baccanaca",
+		"Schukebeere",
+		"Baya Acardo"
+	],
+	"Silk Scarf": [
+		"シルクのスカーフ",
+		"Mouch. Soie",
+		"Sciarpa Seta",
+		"Seidenschal",
+		"Pañuelo Seda"
+	],
+	"SilverPowder": [
+		"ぎんのこな",
+		"Poudre Arg.",
+		"Argenpolvere",
+		"Silberstaub",
+		"Polvo Plata"
+	],
+	"Sitrus Berry": [
+		"オボンのみ",
+		"Baie Sitrus",
+		"Baccacedro",
+		"Tsitrubeere",
+		"Baya Zidra"
+	],
+	"Skull Fossil": [
+		"ずがいのカセキ",
+		"Foss. Crâne",
+		"Fossilcranio",
+		"Kopffossil",
+		"Fósil Cráneo"
+	],
+	"Sky Plate": [
+		"あおぞらプレート",
+		"Plaque Ciel",
+		"Lastracielo",
+		"Wolkentafel",
+		"Tabla Cielo"
+	],
+	"Smooth Rock": [
+		"さらさらいわ",
+		"Roche Lisse",
+		"Roccialiscia",
+		"Glattbrocken",
+		"Roca Suave"
+	],
+	"Soft Sand": [
+		"やわらかいすな",
+		"Sable Doux",
+		"Sabbia Soff.",
+		"Pudersand",
+		"Arena Fina"
+	],
+	"Soul Dew": [
+		"こころのしずく",
+		"Rosée Âme",
+		"Cuorugiada",
+		"Seelentau",
+		"Rocío Bondad"
+	],
+	"Spell Tag": [
+		"のろいのおふだ",
+		"Rune Sort",
+		"Spettrotarga",
+		"Bannsticker",
+		"Hechizo"
+	],
+	"Spelon Berry": [
+		"ノワキのみ",
+		"Baie Kiwan",
+		"Baccamelos",
+		"Kiwanbeere",
+		"Baya Wikano"
+	],
+	"Splash Plate": [
+		"しずくプレート",
+		"Plaque Hydro",
+		"Lastraidro",
+		"Wassertafel",
+		"Tabla Linfa"
+	],
+	"Spooky Plate": [
+		"もののけプレート",
+		"Plaque Fantô",
+		"Lastratetra",
+		"Spuktafel",
+		"Tabla Terror"
+	],
+	"Sport Ball": [
+		"コンペボール",
+		"Compét'Ball",
+		"Gara Ball",
+		"Turnierball",
+		"Competi Ball"
+	],
+	"Starf Berry": [
+		"スターのみ",
+		"Baie Frista",
+		"Baccambola",
+		"Krambobeere",
+		"Baya Arabol"
+	],
+	"Steel Gem": [
+		"はがねのジュエル",
+		"Joyau Acier",
+		"Bijouacciaio",
+		"Stahljuwel",
+		"G. Acero"
+	],
+	"Stick": [
+		"ながねぎ",
+		"Bâton",
+		"Gambo",
+		"Lauchstange",
+		"Palo"
+	],
+	"Sticky Barb": [
+		"くっつきバリ",
+		"Piquants",
+		"Vischiopunta",
+		"Klettdorn",
+		"Toxiestrella"
+	],
+	"Stone Plate": [
+		"がんせきプレート",
+		"Plaque Roc",
+		"Lastrapietra",
+		"Steintafel",
+		"Tabla Pétrea"
+	],
+	"Tamato Berry": [
+		"マトマのみ",
+		"Baie Tamato",
+		"Baccamodoro",
+		"Tamotbeere",
+		"Baya Tamate"
+	],
+	"Tanga Berry": [
+		"タンガのみ",
+		"Baie Panga",
+		"Baccaitan",
+		"Tanigabeere",
+		"Baya Yecana"
+	],
+	"Thick Club": [
+		"ふといホネ",
+		"Masse Os",
+		"Ossospesso",
+		"Kampfknochen",
+		"Hueso Grueso"
+	],
+	"Timer Ball": [
+		"タイマーボール",
+		"Chrono Ball",
+		"Timer Ball",
+		"Timerball",
+		"Turno Ball"
+	],
+	"Toxic Orb": [
+		"どくどくだま",
+		"Orbe Toxique",
+		"Tossicsfera",
+		"Toxik-Orb",
+		"Toxisfera"
+	],
+	"Toxic Plate": [
+		"もうどくプレート",
+		"Plaque Toxic",
+		"Lastrafiele",
+		"Gifttafel",
+		"Tabla Tóxica"
+	],
+	"TwistedSpoon": [
+		"まがったスプーン",
+		"Cuillertordu",
+		"Cucch. Torto",
+		"Krummlöffel",
+		"Cuchara Tor"
+	],
+	"Ultra Ball": [
+		"ハイパーボール",
+		"Hyper Ball",
+		"Ultra Ball",
+		"Hyperball",
+		"Ultraball"
+	],
+	"Wacan Berry": [
+		"ソクノのみ",
+		"Baie Parma",
+		"Baccaparmen",
+		"Kerzalbeere",
+		"Baya Gualot"
+	],
+	"Water Gem": [
+		"みずのジュエル",
+		"Joyau Eau",
+		"Bijouacqua",
+		"Wasserjuwel",
+		"G. Agua"
+	],
+	"Watmel Berry": [
+		"カイスのみ",
+		"Baie Stekpa",
+		"Baccacomero",
+		"Wasmelbeere",
+		"Baya Sambia"
+	],
+	"Wave Incense": [
+		"さざなみのおこう",
+		"Encens Vague",
+		"Ondaroma",
+		"Wellenrauch",
+		"Incie. Aqua"
+	],
+	"Wepear Berry": [
+		"セシナのみ",
+		"Baie Repoi",
+		"Baccapera",
+		"Nirbebeere",
+		"Baya Peragu"
+	],
+	"White Herb": [
+		"しろいハーブ",
+		"Herbeblanche",
+		"Erbachiara",
+		"Schlohkraut",
+		"Hier. Blanca"
+	],
+	"Wide Lens": [
+		"こうかくレンズ",
+		"Loupe",
+		"Grandelente",
+		"Großlinse",
+		"Lupa"
+	],
+	"Wiki Berry": [
+		"ウイのみ",
+		"Baie Wiki",
+		"Baccakiwi",
+		"Wikibeere",
+		"Baya Wiki"
+	],
+	"Wise Glasses": [
+		"ものしりメガネ",
+		"Lunet. Sages",
+		"Saviocchiali",
+		"Schlauglas",
+		"Gafas Esp."
+	],
+	"Yache Berry": [
+		"ヤチェのみ",
+		"Baie Nanone",
+		"Baccamoya",
+		"Kiroyabeere",
+		"Baya Rimoya"
+	],
+	"Zap Plate": [
+		"いかずちプレート",
+		"Plaque Volt",
+		"Lastrasaetta",
+		"Blitztafel",
+		"Tabla Trueno"
+	],
+	"Zoom Lens": [
+		"フォーカスレンズ",
+		"Lentil. Zoom",
+		"Zoomlente",
+		"Zoomlinse",
+		"Telescopio"
+	],
+	/* Ability translations */
+	"Adaptability": [
+		"てきおうりょく",
+		"Adaptabilité",
+		"Adattabilità",
+		"Anpassung",
+		"Adaptable"
+	],
+	"Aftermath": [
+		"ゆうばく",
+		"Boom Final",
+		"Scoppio",
+		"Finalschlag",
+		"Resquicio"
+	],
+	"Air Lock": [
+		"エアロック",
+		"Air Lock",
+		"Riparo",
+		"Klimaschutz",
+		"Bucle Aire"
+	],
+	"Analytic": [
+		"アナライズ",
+		"Analyste",
+		"Ponderazione",
+		"Analyse",
+		"Cálc. Final"
+	],
+	"Anger Point": [
+		"いかりのつぼ",
+		"Colérique",
+		"Grancollera",
+		"Kurzschluss",
+		"Irascible"
+	],
+	"Anticipation": [
+		"きけんよち",
+		"Anticipation",
+		"Presagio",
+		"Vorahnung",
+		"Anticipación"
+	],
+	"Arena Trap": [
+		"ありじごく",
+		"Piège",
+		"Trappoarena",
+		"Ausweglos",
+		"Trampa Arena"
+	],
+	"Bad Dreams": [
+		"ナイトメア",
+		"Mauvais Rêve",
+		"Sogniamari",
+		"Alptraum",
+		"Mal Sueño"
+	],
+	"Battle Armor": [
+		"カブトアーマー",
+		"Armurbaston",
+		"Lottascudo",
+		"Kampfpanzer",
+		"Armad. Bat."
+	],
+	"Big Pecks": [
+		"はとむね",
+		"Cœur de Coq",
+		"Pettinfuori",
+		"Brustbieter",
+		"Sacapecho"
+	],
+	"Blaze": [
+		"もうか",
+		"Brasier",
+		"Aiutofuoco",
+		"Großbrand",
+		"Mar Llamas"
+	],
+	"Chlorophyll": [
+		"ようりょくそ",
+		"Chlorophyle",
+		"Clorofilla",
+		"Chlorophyll",
+		"Clorofila"
+	],
+	"Clear Body": [
+		"クリアボディ",
+		"Corps Sain",
+		"Corpochiaro",
+		"Neutraltorso",
+		"Cuerpo Puro"
+	],
+	"Cloud Nine": [
+		"ノーてんき",
+		"Ciel Gris",
+		"Antimeteo",
+		"Wolke Sieben",
+		"Aclimatación"
+	],
+	"Color Change": [
+		"へんしょく",
+		"Déguisement",
+		"Cambiacolore",
+		"Farbwechsel",
+		"Cambio Color"
+	],
+	"Compoundeyes": [
+		"ふくがん",
+		"Œil Composé",
+		"Insettocchi",
+		"Facettenauge",
+		"Ojocompuesto"
+	],
+	"Contrary": [
+		"あまのじゃく",
+		"Contestation",
+		"Inversione",
+		"Umkehrung",
+		"Respondón"
+	],
+	"Cursed Body": [
+		"のろわれボディ",
+		"Corps Maudit",
+		"Corpofunesto",
+		"Tastfluch",
+		"Cue. Maldito"
+	],
+	"Cute Charm": [
+		"メロメロボディ",
+		"Joli Sourire",
+		"Incantevole",
+		"Charmebolzen",
+		"Gran Encanto"
+	],
+	"Damp": [
+		"しめりけ",
+		"Moiteur",
+		"Umidità",
+		"Feuchtigkeit",
+		"Humedad"
+	],
+	"Defeatist": [
+		"よわき",
+		"Défaitiste",
+		"Sconforto",
+		"Schwächling",
+		"Flaqueza"
+	],
+	"Defiant": [
+		"まけんき",
+		"Acharné",
+		"Agonismo",
+		"Siegeswille",
+		"Competitivo"
+	],
+	"Download": [
+		"ダウンロード",
+		"Télécharge",
+		"Download",
+		"Download",
+		"Descarga"
+	],
+	"Drizzle": [
+		"あめふらし",
+		"Crachin",
+		"Piovischio",
+		"Niesel",
+		"Llovizna"
+	],
+	"Drought": [
+		"ひでり",
+		"Sécheresse",
+		"Siccità",
+		"Dürre",
+		"Sequía"
+	],
+	"Dry Skin": [
+		"かんそうはだ",
+		"Peau Sèche",
+		"Pellearsa",
+		"Trockenheit",
+		"Piel Seca"
+	],
+	"Early Bird": [
+		"はやおき",
+		"Matinal",
+		"Sveglialampo",
+		"Frühwecker",
+		"Madrugar"
+	],
+	"Effect Spore": [
+		"ほうし",
+		"Pose Spore",
+		"Spargispora",
+		"Sporenwirt",
+		"Efec. Espora"
+	],
+	"Filter": [
+		"フィルター",
+		"Filtre",
+		"Filtro",
+		"Filter",
+		"Filtro"
+	],
+	"Flame Body": [
+		"ほのおのからだ",
+		"Corps Ardent",
+		"Corpodifuoco",
+		"Flammkörper",
+		"Cuerpo Llama"
+	],
+	"Flare Boost": [
+		"ねつぼうそう",
+		"Rage Brûlure",
+		"Bruciaimpeto",
+		"Hitzewahn",
+		"Ím. Ardiente"
+	],
+	"Flash Fire": [
+		"もらいび",
+		"Torche",
+		"Fuocardore",
+		"Feuerfänger",
+		"Absor. Fuego"
+	],
+	"Flower Gift": [
+		"フラワーギフト",
+		"Don Floral",
+		"Regalfiore",
+		"Pflanzengabe",
+		"Don Floral"
+	],
+	"Forecast": [
+		"てんきや",
+		"Météo",
+		"Previsioni",
+		"Prognose",
+		"Predicción"
+	],
+	"Forewarn": [
+		"よちむ",
+		"Prédiction",
+		"Premonizione",
+		"Vorwarnung",
+		"Alerta"
+	],
+	"Friend Guard": [
+		"フレンドガード",
+		"Garde Amie",
+		"Amicoscudo",
+		"Freundeshut",
+		"Compiescolta"
+	],
+	"Frisk": [
+		"おみとおし",
+		"Fouille",
+		"Indagine",
+		"Schnüffler",
+		"Cacheo"
+	],
+	"Gluttony": [
+		"くいしんぼう",
+		"Gloutonnerie",
+		"Voracità",
+		"Völlerei",
+		"Gula"
+	],
+	"Guts": [
+		"こんじょう",
+		"Cran",
+		"Dentistretti",
+		"Adrenalin",
+		"Agallas"
+	],
+	"Harvest": [
+		"しゅうかく",
+		"Récolte",
+		"Coglibacche",
+		"Reiche Ernte",
+		"Cosecha"
+	],
+	"Healer": [
+		"いやしのこころ",
+		"Cœur Soin",
+		"Curacuore",
+		"Heilherz",
+		"Alma Cura"
+	],
+	"Heatproof": [
+		"たいねつ",
+		"Ignifuge",
+		"Antifuoco",
+		"Hitzeschutz",
+		"Ignífugo"
+	],
+	"Heavy Metal": [
+		"ヘヴィメタル",
+		"Heavy Metal",
+		"Metalpesante",
+		"Schwermetall",
+		"Met. Pesado"
+	],
+	"Honey Gather": [
+		"みつあつめ",
+		"Cherche Miel",
+		"Mielincetta",
+		"Honigmaul",
+		"Recogemiel"
+	],
+	"Huge Power": [
+		"ちからもち",
+		"Coloforce",
+		"Macroforza",
+		"Kraftkoloss",
+		"Potencia"
+	],
+	"Hustle": [
+		"はりきり",
+		"Agitation",
+		"Tuttafretta",
+		"Übereifer",
+		"Entusiasmo"
+	],
+	"Hydration": [
+		"うるおいボディ",
+		"Hydratation",
+		"Idratazione",
+		"Hydration",
+		"Hidratación"
+	],
+	"Hyper Cutter": [
+		"かいりきバサミ",
+		"Hyper Cutter",
+		"Ipertaglio",
+		"Scherenmacht",
+		"Corte Fuerte"
+	],
+	"Ice Body": [
+		"アイスボディ",
+		"Corps Gel",
+		"Corpogelo",
+		"Eishaut",
+		"Gélido"
+	],
+	"Illuminate": [
+		"はっこう",
+		"Lumiatirance",
+		"Risplendi",
+		"Erleuchtung",
+		"Iluminación"
+	],
+	"Illusion": [
+		"イリュージョン",
+		"Illusion",
+		"Illusione",
+		"Trugbild",
+		"Ilusión"
+	],
+	"Immunity": [
+		"めんえき",
+		"Vaccin",
+		"Immunità",
+		"Immunität",
+		"Inmunidad"
+	],
+	"Imposter": [
+		"かわりもの",
+		"Imposteur",
+		"Sosia",
+		"Doppelgänger",
+		"Impostor"
+	],
+	"Infiltrator": [
+		"すりぬけ",
+		"Infiltration",
+		"Intrapasso",
+		"Schwebedurch",
+		"Allanamiento"
+	],
+	"Inner Focus": [
+		"せいしんりょく",
+		"Attention",
+		"Fuocodentro",
+		"Konzentrator",
+		"Foco Interno"
+	],
+	"Insomnia": [
+		"ふみん",
+		"Insomnia",
+		"Insonnia",
+		"Insomnia",
+		"Insomnio"
+	],
+	"Intimidate": [
+		"いかく",
+		"Intimidation",
+		"Prepotenza",
+		"Bedroher",
+		"Intimidación"
+	],
+	"Iron Barbs": [
+		"てつのトゲ",
+		"Épine de Fer",
+		"Spineferrate",
+		"Eisenstachel",
+		"Punta Acero"
+	],
+	"Iron Fist": [
+		"てつのこぶし",
+		"Poing de Fer",
+		"Ferropugno",
+		"Eisenfaust",
+		"Puño Férreo"
+	],
+	"Justified": [
+		"せいぎのこころ",
+		"Cœur Noble",
+		"Giustizia",
+		"Redlichkeit",
+		"Justiciero"
+	],
+	"Keen Eye": [
+		"するどいめ",
+		"Regard Vif",
+		"Sguardofermo",
+		"Adlerauge",
+		"Vista Lince"
+	],
+	"Klutz": [
+		"ぶきよう",
+		"Maladresse",
+		"Impaccio",
+		"Tollpatsch",
+		"Zoquete"
+	],
+	"Leaf Guard": [
+		"リーフガード",
+		"Feuil. Garde",
+		"Fogliamanto",
+		"Floraschild",
+		"Defensa Hoja"
+	],
+	"Levitate": [
+		"ふゆう",
+		"Lévitation",
+		"Levitazione",
+		"Schwebe",
+		"Levitación"
+	],
+	"Light Metal": [
+		"ライトメタル",
+		"Light Metal",
+		"Metalleggero",
+		"Leichtmetall",
+		"Met. Liviano"
+	],
+	"Lightningrod": [
+		"ひらいしん",
+		"Paratonnerre",
+		"Parafulmine",
+		"Blitzfänger",
+		"Pararrayos"
+	],
+	"Limber": [
+		"じゅうなん",
+		"Échauffement",
+		"Scioltezza",
+		"Flexibilität",
+		"Flexibilidad"
+	],
+	"Liquid Ooze": [
+		"ヘドロえき",
+		"Suintement",
+		"Melma",
+		"Kloakensoße",
+		"Lodo Líquido"
+	],
+	"Magic Bounce": [
+		"マジックミラー",
+		"Miroir Magik",
+		"Magispecchio",
+		"Magiespiegel",
+		"Espejomágico"
+	],
+	"Magic Guard": [
+		"マジックガード",
+		"Garde Magik",
+		"Magicscudo",
+		"Magieschild",
+		"Muro Mágico"
+	],
+	"Magma Armor": [
+		"マグマのよろい",
+		"Armumagma",
+		"Magmascudo",
+		"Magmapanzer",
+		"Escudo Magma"
+	],
+	"Magnet Pull": [
+		"じりょく",
+		"Magnépiège",
+		"Magnetismo",
+		"Magnetfalle",
+		"Imán"
+	],
+	"Marvel Scale": [
+		"ふしぎなうろこ",
+		"Écaille Spé.",
+		"Pelledura",
+		"Notschutz",
+		"Escama Esp."
+	],
+	"Minus": [
+		"マイナス",
+		"Minus",
+		"Meno",
+		"Minus",
+		"Menos"
+	],
+	"Mold Breaker": [
+		"かたやぶり",
+		"Brise Moule",
+		"Rompiforma",
+		"Überbrückung",
+		"Rompemoldes"
+	],
+	"Moody": [
+		"ムラっけ",
+		"Lunatique",
+		"Altalena",
+		"Gefühlswippe",
+		"Veleta"
+	],
+	"Motor Drive": [
+		"でんきエンジン",
+		"Motorisé",
+		"Elettrorapid",
+		"Starthilfe",
+		"Electromotor"
+	],
+	"Moxie": [
+		"じしんかじょう",
+		"Impudence",
+		"Arroganza",
+		"Hochmut",
+		"Autoestima"
+	],
+	"Multiscale": [
+		"マルチスケイル",
+		"Multiécaille",
+		"Multisquame",
+		"Multischuppe",
+		"Compensación"
+	],
+	"Multitype": [
+		"マルチタイプ",
+		"Multi-Type",
+		"Multitipo",
+		"Variabilität",
+		"Multitipo"
+	],
+	"Mummy": [
+		"ミイラ",
+		"Momie",
+		"Mummia",
+		"Mumie",
+		"Momia"
+	],
+	"Natural Cure": [
+		"しぜんかいふく",
+		"Médic Nature",
+		"Alternacura",
+		"Innere Kraft",
+		"Cura Natural"
+	],
+	"No Guard": [
+		"ノーガード",
+		"Annule Garde",
+		"Nullodifesa",
+		"Schildlos",
+		"Indefenso"
+	],
+	"Normalize": [
+		"ノーマルスキン",
+		"Normalise",
+		"Normalità",
+		"Regulierung",
+		"Normalidad"
+	],
+	"Oblivious": [
+		"どんかん",
+		"Benêt",
+		"Indifferenza",
+		"Dösigkeit",
+		"Despiste"
+	],
+	"Overcoat": [
+		"ぼうじん",
+		"Envelocape",
+		"Copricapo",
+		"Wetterfest",
+		"Funda"
+	],
+	"Overgrow": [
+		"しんりょく",
+		"Engrais",
+		"Erbaiuto",
+		"Notdünger",
+		"Espesura"
+	],
+	"Own Tempo": [
+		"マイペース",
+		"Tempo Perso",
+		"Mente Locale",
+		"Tempomacher",
+		"Ritmo Propio"
+	],
+	"Pickpocket": [
+		"わるいてぐせ",
+		"Pickpocket",
+		"Arraffalesto",
+		"Langfinger",
+		"Hurto"
+	],
+	"Pickup": [
+		"ものひろい",
+		"Ramassage",
+		"Raccolta",
+		"Mitnahme",
+		"Recogida"
+	],
+	"Plus": [
+		"プラス",
+		"Plus",
+		"Più",
+		"Plus",
+		"Más"
+	],
+	"Poison Heal": [
+		"ポイズンヒール",
+		"Soin Poison",
+		"Velencura",
+		"Aufheber",
+		"Antídoto"
+	],
+	"Poison Point": [
+		"どくのトゲ",
+		"Point Poison",
+		"Velenopunto",
+		"Giftdorn",
+		"Punto Tóxico"
+	],
+	"Poison Touch": [
+		"どくしゅ",
+		"Toxitouche",
+		"Velentocco",
+		"Giftgriff",
+		"Toque Tóxico"
+	],
+	"Prankster": [
+		"いたずらごころ",
+		"Farceur",
+		"Burla",
+		"Strolch",
+		"Bromista"
+	],
+	"Pressure": [
+		"プレッシャー",
+		"Pression",
+		"Pressione",
+		"Erzwinger",
+		"Presión"
+	],
+	"Pure Power": [
+		"ヨガパワー",
+		"Force Pure",
+		"Forzapura",
+		"Mentalkraft",
+		"Energía Pura"
+	],
+	"Quick Feet": [
+		"はやあし",
+		"Pied Véloce",
+		"Piedisvelti",
+		"Rasanz",
+		"Pies Rápidos"
+	],
+	"Rain Dish": [
+		"あめうけざら",
+		"Cuvette",
+		"Copripioggia",
+		"Regengenuss",
+		"Cura Lluvia"
+	],
+	"Rattled": [
+		"びびり",
+		"Phobique",
+		"Paura",
+		"Hasenfuß",
+		"Cobardía"
+	],
+	"Reckless": [
+		"すてみ",
+		"Téméraire",
+		"Temerarietà",
+		"Achtlos",
+		"Audaz"
+	],
+	"Regenerator": [
+		"さいせいりょく",
+		"Régé-Force",
+		"Rigenergia",
+		"Belebekraft",
+		"Regeneración"
+	],
+	"Rivalry": [
+		"とうそうしん",
+		"Rivalité",
+		"Antagonismo",
+		"Rivalität",
+		"Rivalidad"
+	],
+	"Rock Head": [
+		"いしあたま",
+		"Tête de Roc",
+		"Testadura",
+		"Steinhaupt",
+		"Cabeza Roca"
+	],
+	"Rough Skin": [
+		"さめはだ",
+		"Peau Dure",
+		"Cartavetro",
+		"Rauhaut",
+		"Piel Tosca"
+	],
+	"Run Away": [
+		"にげあし",
+		"Fuite",
+		"Fugafacile",
+		"Angsthase",
+		"Fuga"
+	],
+	"Sand Force": [
+		"すなのちから",
+		"Force Sable",
+		"Silicoforza",
+		"Sandgewalt",
+		"Poder Arena"
+	],
+	"Sand Rush": [
+		"すなかき",
+		"Baigne Sable",
+		"Remasabbia",
+		"Sandscharrer",
+		"Ímpetu Arena"
+	],
+	"Sand Stream": [
+		"すなおこし",
+		"Sable Volant",
+		"Sabbiafiume",
+		"Sandsturm",
+		"Chorro Arena"
+	],
+	"Sand Veil": [
+		"すながくれ",
+		"Voile Sable",
+		"Sabbiavelo",
+		"Sandschleier",
+		"Velo Arena"
+	],
+	"Sap Sipper": [
+		"そうしょく",
+		"Herbivore",
+		"Mangiaerba",
+		"Vegetarier",
+		"Herbívoro"
+	],
+	"Scrappy": [
+		"きもったま",
+		"Querelleur",
+		"Nervisaldi",
+		"Rauflust",
+		"Intrépido"
+	],
+	"Serene Grace": [
+		"てんのめぐみ",
+		"Sérénité",
+		"Leggiadro",
+		"Edelmut",
+		"Dicha"
+	],
+	"Shadow Tag": [
+		"かげふみ",
+		"Marque Ombre",
+		"Pedinombra",
+		"Wegsperre",
+		"Sombratrampa"
+	],
+	"Shed Skin": [
+		"だっぴ",
+		"Mue",
+		"Muta",
+		"Expidermis",
+		"Mudar"
+	],
+	"Sheer Force": [
+		"ちからずく",
+		"Sans Limite",
+		"Forzabruta",
+		"Rohe Gewalt",
+		"Pot. Bruta"
+	],
+	"Shell Armor": [
+		"シェルアーマー",
+		"Coque Armure",
+		"Guscioscudo",
+		"Panzerhaut",
+		"Caparazón"
+	],
+	"Shield Dust": [
+		"りんぷん",
+		"Écran Poudre",
+		"Polvoscudo",
+		"Puderabwehr",
+		"Polvo Escudo"
+	],
+	"Simple": [
+		"たんじゅん",
+		"Simple",
+		"Disinvoltura",
+		"Wankelmut",
+		"Simple"
+	],
+	"Skill Link": [
+		"スキルリンク",
+		"Multi-Coups",
+		"Abillegame",
+		"Wertelink",
+		"Encadenado"
+	],
+	"Slow Start": [
+		"スロースタート",
+		"Début Calme",
+		"Lentoinizio",
+		"Saumselig",
+		"Inicio Lento"
+	],
+	"Sniper": [
+		"スナイパー",
+		"Sniper",
+		"Cecchino",
+		"Superschütze",
+		"Francotirad."
+	],
+	"Snow Cloak": [
+		"ゆきがくれ",
+		"Rideau Neige",
+		"Mantelneve",
+		"Schneemantel",
+		"Manto Níveo"
+	],
+	"Snow Warning": [
+		"ゆきふらし",
+		"Alerte Neige",
+		"Scendineve",
+		"Hagelalarm",
+		"Nevada"
+	],
+	"Solar Power": [
+		"サンパワー",
+		"Force Soleil",
+		"Solarpotere",
+		"Solarkraft",
+		"Poder Solar"
+	],
+	"Solid Rock": [
+		"ハードロック",
+		"Solide Roc",
+		"Solidroccia",
+		"Felskern",
+		"Roca Sólida"
+	],
+	"Soundproof": [
+		"ぼうおん",
+		"Anti-Bruit",
+		"Antisuono",
+		"Lärmschutz",
+		"Insonorizar"
+	],
+	"Speed Boost": [
+		"かそく",
+		"Turbo",
+		"Acceleratore",
+		"Temposchub",
+		"Impulso"
+	],
+	"Stall": [
+		"あとだし",
+		"Frein",
+		"Rallentatore",
+		"Zeitspiel",
+		"Rezagado"
+	],
+	"Static": [
+		"せいでんき",
+		"Statik",
+		"Statico",
+		"Statik",
+		"Elec. Estát."
+	],
+	"Steadfast": [
+		"ふくつのこころ",
+		"Impassible",
+		"Cuordeciso",
+		"Felsenfest",
+		"Impasible"
+	],
+	"Stench": [
+		"あくしゅう",
+		"Puanteur",
+		"Tanfo",
+		"Duftnote",
+		"Hedor"
+	],
+	"Sticky Hold": [
+		"ねんちゃく",
+		"Glue",
+		"Antifurto",
+		"Wertehalter",
+		"Viscosidad"
+	],
+	"Storm Drain": [
+		"よびみず",
+		"Lavabo",
+		"Acquascolo",
+		"Sturmsog",
+		"Colector"
+	],
+	"Sturdy": [
+		"がんじょう",
+		"Fermeté",
+		"Vigore",
+		"Robustheit",
+		"Robustez"
+	],
+	"Suction Cups": [
+		"きゅうばん",
+		"Ventouse",
+		"Ventose",
+		"Saugnapf",
+		"Ventosas"
+	],
+	"Super Luck": [
+		"きょううん",
+		"Chanceux",
+		"Supersorte",
+		"Glückspilz",
+		"Afortunado"
+	],
+	"Swarm": [
+		"むしのしらせ",
+		"Essaim",
+		"Aiutinsetto",
+		"Hexaplaga",
+		"Enjambre"
+	],
+	"Swift Swim": [
+		"すいすい",
+		"Glissade",
+		"Nuotovelox",
+		"Wassertempo",
+		"Nado Rápido"
+	],
+	"Synchronize": [
+		"シンクロ",
+		"Synchro",
+		"Sincronismo",
+		"Synchro",
+		"Sincronía"
+	],
+	"Tangled Feet": [
+		"ちどりあし",
+		"Pieds Confus",
+		"Intricopiedi",
+		"Fußangel",
+		"Tumbos"
+	],
+	"Technician": [
+		"テクニシャン",
+		"Technicien",
+		"Tecnico",
+		"Techniker",
+		"Experto"
+	],
+	"Telepathy": [
+		"テレパシー",
+		"Télépathe",
+		"Telepatia",
+		"Telepathie",
+		"Telepatía"
+	],
+	"Teravolt": [
+		"テラボルテージ",
+		"Téra-Voltage",
+		"Teravolt",
+		"Teravolt",
+		"Terravoltaje"
+	],
+	"Thick Fat": [
+		"あついしぼう",
+		"Isograisse",
+		"Grassospesso",
+		"Speckschicht",
+		"Sebo"
+	],
+	"Tinted Lens": [
+		"いろめがね",
+		"Lentiteintée",
+		"Lentifumé",
+		"Aufwertung",
+		"Cromolente"
+	],
+	"Torrent": [
+		"げきりゅう",
+		"Torrent",
+		"Acquaiuto",
+		"Sturzbach",
+		"Torrente"
+	],
+	"Toxic Boost": [
+		"どくぼうそう",
+		"Rage Poison",
+		"Velenimpeto",
+		"Giftwahn",
+		"Ím. Tóxico"
+	],
+	"Trace": [
+		"トレース",
+		"Calque",
+		"Traccia",
+		"Fährte",
+		"Rastro"
+	],
+	"Truant": [
+		"なまけ",
+		"Absentéisme",
+		"Pigrone",
+		"Schnarchnase",
+		"Ausente"
+	],
+	"Turboblaze": [
+		"ターボブレイズ",
+		"TurboBrasier",
+		"Piroturbina",
+		"Turbobrand",
+		"Turbollama"
+	],
+	"Unaware": [
+		"てんねん",
+		"Inconscient",
+		"Imprudenza",
+		"Unkenntnis",
+		"Ignorante"
+	],
+	"Unburden": [
+		"かるわざ",
+		"Délestage",
+		"Agiltecnica",
+		"Entlastung",
+		"Liviano"
+	],
+	"Unnerve": [
+		"きんちょうかん",
+		"Tension",
+		"Agitazione",
+		"Anspannung",
+		"Nerviosismo"
+	],
+	"Victory Star": [
+		"しょうりのほし",
+		"Victorieux",
+		"Vittorstella",
+		"Triumphstern",
+		"Tinovictoria"
+	],
+	"Vital Spirit": [
+		"やるき",
+		"Esprit Vital",
+		"Spiritovivo",
+		"Munterkeit",
+		"Espír. Vital"
+	],
+	"Volt Absorb": [
+		"ちくでん",
+		"Absorb Volt",
+		"Assorbivolt",
+		"Voltabsorber",
+		"Absor. Elec."
+	],
+	"Water Absorb": [
+		"ちょすい",
+		"Absorb Eau",
+		"Assorbacqua",
+		"H2O-Absorber",
+		"Absor. Agua"
+	],
+	"Water Veil": [
+		"みずのベール",
+		"Ignifu-Voile",
+		"Idrovelo",
+		"Aquahülle",
+		"Velo Agua"
+	],
+	"Weak Armor": [
+		"くだけるよろい",
+		"Armurouillée",
+		"Sottilguscio",
+		"Bruchrüstung",
+		"Arm. Frágil"
+	],
+	"White Smoke": [
+		"しろいけむり",
+		"Écran Fumée",
+		"Fumochiaro",
+		"Pulverrauch",
+		"Humo Blanco"
+	],
+	"Wonder Guard": [
+		"ふしぎなまもり",
+		"Garde Mystik",
+		"Magidifesa",
+		"Wunderwache",
+		"Superguarda"
+	],
+	"Wonder Skin": [
+		"ミラクルスキン",
+		"Peau Miracle",
+		"Splendicute",
+		"Wunderhaut",
+		"Piel Milagro"
+	],
+	"Zen Mode": [
+		"ダルマモード",
+		"Mode Transe",
+		"Stato Zen",
+		"Trance-Modus",
+		"Modo Daruma"
+	],
+	/* Type translations */
+	"Bug": [
+		"むし",
+		"Insecte",
+		"Coleottero",
+		"Käfer",
+		"Bicho"
+	],
+	"Dark": [
+		"あく",
+		"Ténèbres",
+		"Buio",
+		"Unlicht",
+		"Siniestro"
+	],
+	"Dragon": [
+		"ドラゴン",
+		"Dragon",
+		"Drago",
+		"Drachen",
+		"Dragón"
+	],
+	"Electric": [
+		"でんき",
+		"Electrik",
+		"Elettro",
+		"Electro",
+		"Eléctrico"
+	],
+	"Fighting": [
+		"かくとう",
+		"Combat",
+		"Lotta",
+		"Kampf",
+		"Lucha"
+	],
+	"Fire": [
+		"ほのお",
+		"Feu",
+		"Fuoco",
+		"Feuer",
+		"Fuego"
+	],
+	"Flying": [
+		"ひこう",
+		"Vol",
+		"Volante",
+		"Flug",
+		"Volador"
+	],
+	"Ghost": [
+		"ゴースト",
+		"Spectre",
+		"Spettro",
+		"Geist",
+		"Fantasma"
+	],
+	"Grass": [
+		"くさ",
+		"Plante",
+		"Erba",
+		"Pflanze",
+		"Planta"
+	],
+	"Ground": [
+		"じめん",
+		"Sol",
+		"Terra",
+		"Boden",
+		"Tierra"
+	],
+	"Ice": [
+		"こおり",
+		"Glace",
+		"Ghiaccio",
+		"Eis",
+		"Hielo"
+	],
+	"Normal": [
+		"ノーマル",
+		"Normal",
+		"Normale",
+		"Normal",
+		"Normal"
+	],
+	"Poison": [
+		"どく",
+		"Poison",
+		"Veleno",
+		"Gift",
+		"Veneno"
+	],
+	"Psychic": [
+		"エスパー",
+		"Psy",
+		"Psico",
+		"Psycho",
+		"Psíquico"
+	],
+	"Rock": [
+		"いわ",
+		"Roche",
+		"Roccia",
+		"Gestein",
+		"Roca"
+	],
+	"Steel": [
+		"はがね",
+		"Acier",
+		"Acciaio",
+		"Stahl",
+		"Acero"
+	],
+	"Water": [
+		"みず",
+		"Eau",
+		"Acqua",
+		"Wasser",
+		"Agua"
+	]
+};

--- a/js/battledata.js
+++ b/js/battledata.js
@@ -101,6 +101,25 @@ function hashColor(name) {
 	return colorCache[name];
 }
 
+// Translation function
+var _ = (function() {
+	var re = /@[0-9]+/g;
+	var args = {};
+	var callback = function (args) { return function(i) { return args[+i.substr(1)+1] || ""; }; };
+	var lt = {en: 0, jp: 1, fr: 2, it: 3, de: 4, es: 5};
+	var lang = (window.Config && Config.language && lt[Config.language]) ? lt[Config.language] : 0;
+
+	if(lang && window.exports && exports.Translations)
+	{
+		return function f (message) {
+			var m = exports.Translations.hasOwnProperty(message) ? exports.Translations[message][lang-1] : message;
+			return m.replace(re, callback(f.arguments));
+		};
+	} else {
+		return function f (message) { return m.replace(re, callback(f.arguments)); };
+	}
+})();
+
 function messageSanitize(str) {
 	str = Tools.escapeHTML(str);
 	// Don't format console commands (>>).


### PR DESCRIPTION
Extracted translations from the Japanese, French, Italian, German and Spanish ROMS.
Messages have been reformatted to use @ for formatting (similar to how it is handled in-game). A demo translation function _ is also provided, but not made use of in battle.js. To actually enable translations, in addition to loading the big translation file and setting a language in Config, every game message in battle.js must be refactored to use translation, e.g. "Pointed stones dug into " + poke.getLowerName() + "!" should be rewritten to _("Pointed stones dug into @0!", poke.getLowerName());