### PR TITLE
Properly display type changes

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -807,10 +807,7 @@
 					types = pokemon.volatiles.typechange[2].split(', ');
 				}
 				if (types) {
-					text += Tools.getTypeIcon(types[0]);
-					if (types[1]) {
-						text += ' '+Tools.getTypeIcon(types[1]);
-					}
+					text += types.map(Tools.getTypeIcon).join(' ');
 				} else {
 					text += 'Types unknown';
 				}


### PR DESCRIPTION
A Pokemon can have their type changed to be multiple types. This possible through usage of Reflect Type, Trick-or-Treat, or Forest's Curse.
