### PR TITLE
Attempt to use set.baseSpecies as name before set.species on the teambui...

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -318,7 +318,7 @@
 			}
 			buf += '<div class="setmenu"><button name="moveSet"><i class="icon-move"></i>Move</button> <button name="deleteSet"><i class="icon-trash"></i>Delete</button></div>';
 			buf += '<div class="setchart-nickname">';
-			buf += '<label>Nickname</label><input type="text" value="'+Tools.escapeHTML(set.name||set.species)+'" name="nickname" />';
+			buf += '<label>Nickname</label><input type="text" value="'+Tools.escapeHTML(set.name||set.baseSpecies||set.species)+'" name="nickname" />';
 			buf += '</div>';
 			buf += '<div class="setchart">';
 


### PR DESCRIPTION
...lder

When adding a new Pokémon to the team, the default name should be 
the same as in-game, thus it should try to use set.baseSpecies if 
existant and then use set.species as a last resort, should there 
be no name and no baseSpecies.