### PR TITLE
Highlight notifications: display the room title

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -972,7 +972,8 @@
 				// PMs already notify in the main menu; no need to make them notify again
 				var isHighlighted = this.getHighlight(message);
 				if (isHighlighted) {
-					this.notifyOnce("Mentioned by "+name, "\""+message+"\"", 'highlight');
+					var notifyTitle = "Mentioned by "+name+(this.id === 'lobby' ? '' : " in "+this.title);
+					this.notifyOnce(notifyTitle, "\""+message+"\"", 'highlight');
 				}
 			}
 			var highlight = isHighlighted ? ' highlighted' : '';


### PR DESCRIPTION
If the room is the lobby, it's omitted to avoid bloating the notification box.

This should be useful for moderators, and in general people that stay in several chat rooms.
