### PR TITLE
Make /join focus a room if it's already joined

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -607,6 +607,14 @@
 				this.send('/kick ' + target + ', ' + reason);
 				return false;
 
+			case 'join':
+				var room = toId(target);
+				if (app.rooms[room]) {
+					app.focusRoom(room);
+					return false;
+				}
+				return text; // Send the /join command through to the server.
+
 			case 'avatar':
 				var parts = target.split(',');
 				var avatar = parseInt(parts[0], 10);


### PR DESCRIPTION
I am probably not the only one who wants to do that when the room's tab is hidden by the other tabs.
