### PR TITLE
Pumpkaboo wasn't included

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -268,6 +268,7 @@ var baseSpeciesChart = {
 	'keldeo': 1,
 	'aegislash': 1,
 	'gourgeist': 1,
+	'pumpkaboo': 1,
 
 	// mega evolutions
 	'charizard': 1,


### PR DESCRIPTION
Even though it was for "April fools," if we're doing it again next year, include poor pumpkaboo.
