### PR TITLE
Remove support for buttons with "send" name

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -1412,7 +1412,9 @@
 				app.dispatchingButton = target;
 				e.preventDefault();
 				e.stopImmediatePropagation();
-				this[target.name].call(this, target.value, target);
+				if (target.name !== 'send') {
+					this[target.name].call(this, target.value, target);
+				}
 				delete app.dismissingSource;
 				delete app.dispatchingButton;
 			}


### PR DESCRIPTION
They send arbitrary messages or commands to the server, while the user clicking them might be unaware.
