### PR TITLE
Pyroar-f shiny fix

### DIFF
--- a/data/pokedex-mini.js
+++ b/data/pokedex-mini.js
@@ -759,7 +759,7 @@ BattlePokemonSprites = {
 	"spewpa":{num:665, front:{ani:{w:44,h:43}}, back:{ani:{w:42,h:43}}},
 	"vivillon":{num:666, front:{ani:{w:104,h:104}}, back:{ani:{w:96,h:113}}},
 	"litleo":{num:667, front:{ani:{w:51,h:61}}, back:{ani:{w:61,h:59}}},
-	"pyroar":{num:668, front:{ani:{w:79, h:99}, anif:{w:192, h:192}},back:{ani:{w:127, h:100}, anif:{w:112, h:100}}},
+	"pyroar":{num:668, front:{ani:{w:79, h:99}, anif:{w:68, h:95}},back:{ani:{w:127, h:100}, anif:{w:112, h:100}}},
 	"flabebe":{num:669, front:{ani:{w:76,h:78}}, back:{ani:{w:75,h:79}}},
 	"floette":{num:670, front:{ani:{w:61,h:95}}, back:{ani:{w:62,h:97}}},
 	"floetteeternalflower":{num:670, front:{ani:{w:81,h:90}}, back:{ani:{w:86,h:99}}},	


### PR DESCRIPTION
Matches size between both pyroar regular and shiny. Push with April 25 sprite update.
