### PR TITLE
Fix empty room on connect

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -625,7 +625,7 @@
 				// Just open the main menu.
 				fragment = '';
 			}
-			if (!fragment) fragment = '';
+			fragment = toRoomid(fragment || '');
 			if (this.initialFragment === undefined) this.initialFragment = fragment;
 			this.tryJoinRoom(fragment);
 		},


### PR DESCRIPTION
If the URL fragment is not in the form of a roomid, but a room with its roomid exists, connecting no longer adds an empty room using it as its roomid.
