### PR TITLE
Add classes for /weakness command's labels

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -1255,6 +1255,18 @@ div[class^='tournament-message-'], div[class*=' tournament-message-'] {
 	color: #CC2222;
 	text-decoration: underline;
 }
+.message-effect-weak {
+	font-weight: bold;
+	color: #CC2222;
+}
+.message-effect-resist {
+	font-weight: bold;
+	color: #6688AA;
+}
+.message-effect-immune {
+	font-weight: bold;
+	color: #666666;
+}
 .message-learn-list {
 	margin-top: 0;
 	margin-bottom: 0;


### PR DESCRIPTION
This adds in style for the new labels for the /weakness command, so that "Weaknesses:" is coloured red (the same as the red for .message-learn-cannotlearn for consistency reasons), "Resistances" is coloured blue, and "Immunities" is coloured grey. This reflects the changes to the command made in this pull request: https://github.com/Zarel/Pokemon-Showdown/pull/1116

<img src="https://camo.githubusercontent.com/8768153e5fefd282e8dd77dedd1c3417b7a4f3e7/687474703a2f2f692e696d6775722e636f6d2f547371706e714a2e706e67"/>
