### PR TITLE
Added message case for -ability when Cloud Nine or Air Lock activate

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -3792,6 +3792,10 @@ function Battle(frame, logFrame, noPreload) {
 				case 'darkaura':
 					actions += "" + poke.getName() + " is radiating a dark aura!";
 					break;
+				case 'airlock':
+				case 'cloudnine':
+					actions += "The effects of weather disappeared.";
+					break;
 				default:
 					actions += "" + poke.getName() + " has " + ability.name + "!";
 					break;


### PR DESCRIPTION
The server-side code is changing soon to have Cloud Nine/Air Lock
broadcast '-ability' instead of '-message', so we need to add the relevant
messages to the client-side as well.
