### PR TITLE
Changed message for Mummy to be more clear

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -3812,7 +3812,7 @@ function Battle(frame, logFrame, noPreload) {
 					// do nothing
 				} else switch (effect.id) {
 				case 'mummy':
-					actions += "" + poke.getName() + "\'s Ability " + ability.name + " was suppressed!";
+					actions += "(" + poke.getName() + "\'s Ability was previously " + ability.name + ")";
 					break;
 				default:
 					actions += "" + poke.getName() + "\'s Ability was suppressed!";


### PR DESCRIPTION
When a Pokemon's ability changes because of Mummy, it only quickly shows
what the ability was formerly in a small box on the screen, instead of an
in-game message. We use parentheses for messages that don't actually
appear in-game, so Mummy's message is changed to use parentheses instead.
