### PR TITLE
Minor Mummy message refactor

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -3821,7 +3821,7 @@ function Battle(frame, logFrame, noPreload) {
 					actions += '' + poke.getName() + ' copied ' + ofpoke.getLowerName() + '\'s ' + ability.name + '!';
 					break;
 				case 'mummy':
-					actions += "" + poke.getName() + "'s Ability became Mummy!";
+					// actions += "" + poke.getName() + "'s Ability became Mummy!";
 					break;
 				case 'desolateland':
 					if (kwargs.fail) {
@@ -3889,7 +3889,7 @@ function Battle(frame, logFrame, noPreload) {
 					// do nothing
 				} else switch (effect.id) {
 				case 'mummy':
-					actions += "(" + poke.getName() + "\'s Ability was previously " + ability.name + ")";
+					actions += "[" + poke.getName() + "\'s " + ability.name + "] " + poke.name + "'s Ability became Mummy!";
 					break;
 				default:
 					actions += "" + poke.getName() + "\'s Ability was suppressed!";


### PR DESCRIPTION
There was a positive response in #263 to combine the messages in Mummy to one line, like so:

`The opposing Golduck's Ability [Cloud Nine] became Mummy.`

This should change the messages to do that. Technically, the `-endability` handler should be replaced with an `-activate` handler, maybe?
