### PR TITLE
Alias hl for highlight

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -540,6 +540,7 @@
 				Tools.prefs('timestamps', timestamps);
 				return false;
 
+			case 'hl':
 			case 'highlight':
 				var highlights = Tools.prefs('highlights') || [];
 				if (target.indexOf(',') > -1) {


### PR DESCRIPTION
Lots of people are referring to "hl" as shorthand for "highlight" already, so maybe we should let it be an alias.
