### PR TITLE
Support for disabling move buttons on invalid decisions

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -369,7 +369,6 @@ var Pokemon = (function () {
 		return (details === this.details.replace(/-[A-Za-z0-9*]+(, |$)/, '$1'));
 	};
 	Pokemon.prototype.getIdent = function () {
-		if (this.side.active.length === 1) return this.ident;
 		var slots = ['a','b','c','d','e','f'];
 		return this.ident.substr(0,2) + slots[this.slot] + this.ident.substr(2);	
 	};


### PR DESCRIPTION
- Added |callback|cant, similar to |callback|trapped, to handle the fact that a player may not know which moves are disabled at a certain time (relevant to Imprison).
- Both messages can now parse a pokémon identity, rather than only an active index.
