### PR TITLE
Implement old gen sprites for past gens

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -775,7 +775,7 @@ var Sprite = (function () {
 	Sprite.prototype.animTransform = function (species) {
 		if (!this.oldsp) this.oldsp = this.sp;
 		if (species.volatiles && species.volatiles.formechange) species = species.volatiles.formechange[2];
-		sp = Tools.getSpriteData(species, this.isBackSprite ? 0 : 1, {afd: this.battle.tier === "[Seasonal] Fools Festival"});
+		sp = Tools.getSpriteData(species, this.isBackSprite ? 0 : 1, {afd: this.battle.tier === "[Seasonal] Fools Festival", gen: this.battle.gen});
 		this.sp = sp;
 		var self = this;
 		var battle = this.battle;
@@ -1219,7 +1219,7 @@ var Side = (function () {
 		for (var i = 0; i < this.pokemon.length; i++) {
 			var poke = this.pokemon[i];
 			poke.sprite.destroy();
-			poke.sprite = new Sprite(Tools.getSpriteData(poke, this.n, {afd: this.battle.tier === "[Seasonal] Fools Festival"}), this.x, this.y, this.z, this.battle, this.n);
+			poke.sprite = new Sprite(Tools.getSpriteData(poke, this.n, {afd: this.battle.tier === "[Seasonal] Fools Festival", gen: this.battle.gen}), this.x, this.y, this.z, this.battle, this.n);
 		}
 	};
 	Side.prototype.setSprite = function (spriteid) {
@@ -1508,7 +1508,7 @@ var Side = (function () {
 		if (!poke.ability && poke.baseAbility) poke.ability = poke.baseAbility;
 		poke.id = id;
 		poke.reset();
-		poke.sprite = new Sprite(Tools.getSpriteData(poke, this.n, {afd: this.battle.tier === "[Seasonal] Fools Festival"}), this.x, this.y, this.z, this.battle, this.n);
+		poke.sprite = new Sprite(Tools.getSpriteData(poke, this.n, {afd: this.battle.tier === "[Seasonal] Fools Festival", gen: this.battle.gen}), this.x, this.y, this.z, this.battle, this.n);
 
 		if (typeof replaceSlot !== 'undefined') {
 			this.pokemon[replaceSlot] = poke;
@@ -5169,7 +5169,7 @@ var Battle = (function () {
 			for (var i = 0; i < this.sides[k].pokemon.length; i++) {
 				var pokemon = this.sides[k].pokemon[i];
 
-				var spriteData = Tools.getSpriteData(pokemon, k, {afd: this.tier === "[Seasonal] Fools Festival"});
+				var spriteData = Tools.getSpriteData(pokemon, k, {afd: this.tier === "[Seasonal] Fools Festival", gen: this.gen});
 				var y = 0;
 				var x = 0;
 				if (k) {

--- a/js/battledata.js
+++ b/js/battledata.js
@@ -793,6 +793,8 @@ var Tools = {
 		document.getElementsByTagName('body')[0].appendChild(el);
 	},
 	getSpriteData: function(pokemon, siden, options) {
+		if (!options) options = {gen: 6};
+		if (!options.gen) options.gen = 6;
 		pokemon = Tools.getTemplate(pokemon);
 		var spriteData = {
 			w: 96,
@@ -821,19 +823,19 @@ var Tools = {
 			spriteData.cryurl = 'audio/cries/' + num + '.wav';
 		}
 
-		if (pokemon.shiny) dir += '-shiny';
+		if (pokemon.shiny && options.gen > 1) dir += '-shiny';
 
 		// April Fool's 2014
-		if (window.Config && Config.server && Config.server.afd || options && options.afd) {
+		if (window.Config && Config.server && Config.server.afd || options.afd) {
 			dir = 'afd' + dir;
 			spriteData.url += dir + '/' + name + '.png';
 			return spriteData;
 		}
 
-		var gen = 'xy';
-		if (Tools.prefs('bwgfx')) {
-			gen = 'bw';
-		}
+		// Decide what gen sprites to use.
+		var gen = {1:'rby', 2:'gsc', 3:'rse', 4:'dpp', 5:'bw', 6:'xy'}[options.gen];
+		if (Tools.prefs('nopastgens')) gen = 'xy';
+		if (Tools.prefs('bwgfx') && gen === 'xy') gen = 'bw';
 
 		if (animationData && animationData[facing]) {
 			var spriteType = '';
@@ -841,7 +843,7 @@ var Tools = {
 				name += '-f';
 				spriteType += 'f';
 			}
-			if (!Tools.prefs('noanim')) {
+			if (!Tools.prefs('noanim') && gen in {'bw':1, 'xy':1}) {
 				spriteType = 'ani' + spriteType;
 				dir = gen + 'ani' + dir;
 
@@ -851,8 +853,8 @@ var Tools = {
 				return spriteData;
 			}
 		}
-		// if there is no entry or enough data in pokedex-mini.js or the animations are disabled, use BW static sprites
-		gen = 'bw';
+		// if there is no entry or enough data in pokedex-mini.js or the animations are disabled or past gen, use the proper sprites
+		gen = (gen === 'xy')? 'bw' : gen;
 		dir = gen + dir;
 
 		spriteData.url += dir+'/' + name + '.png';

--- a/js/client.js
+++ b/js/client.js
@@ -2293,6 +2293,7 @@
 		events: {
 			'change input[name=noanim]': 'setNoanim',
 			'change input[name=bwgfx]': 'setBwgfx',
+			'change input[name=nopastgens]': 'setNopastgens',
 			'change input[name=notournaments]': 'setNotournaments',
 			'change input[name=nolobbypm]': 'setNolobbypm',
 			'change input[name=temporarynotifications]': 'setTemporaryNotifications',
@@ -2315,7 +2316,8 @@
 			buf += '<hr />';
 			buf += '<p><label class="optlabel">Background: <select name="bg"><option value="">Charizards</option><option value="#344b6c url(/fx/client-bg-horizon.jpg) no-repeat left center fixed">Horizon</option><option value="#546bac url(/fx/client-bg-3.jpg) no-repeat left center fixed">Waterfall</option><option value="#546bac url(/fx/client-bg-ocean.jpg) no-repeat left center fixed">Ocean</option><option value="#344b6c">Solid blue</option>'+(Tools.prefs('bg')?'<option value="" selected></option>':'')+'</select></label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="noanim"'+(Tools.prefs('noanim')?' checked':'')+' /> Disable animations</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="bwgfx"'+(Tools.prefs('bwgfx')?' checked':'')+' /> Enable BW sprites</label></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="bwgfx"'+(Tools.prefs('bwgfx')?' checked':'')+' /> Enable BW sprites for XY</label></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="nopastgens"'+(Tools.prefs('nopastgens')?' checked':'')+' /> Use modern sprites for past generations</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="notournaments"'+(Tools.prefs('notournaments')?' checked':'')+' /> Ignore tournaments</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="nolobbypm"'+(Tools.prefs('nolobbypm')?' checked':'')+' /> Don\'t show PMs in lobby chat</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="selfhighlight"'+(!Tools.prefs('noselfhighlight')?' checked':'')+'> Highlight when your name is said in chat</label></p>';
@@ -2380,6 +2382,10 @@
 			var bwgfx = !!e.currentTarget.checked;
 			Tools.prefs('bwgfx', bwgfx);
 			Tools.loadSpriteData(bwgfx || Tools.prefs('noanim') ? 'bw' : 'xy');
+		},
+		setNopastgens: function(e) {
+			var nopastgens = !!e.currentTarget.checked;
+			Tools.prefs('nopastgens', nopastgens);
 		},
 		setNotournaments: function(e) {
 			var notournaments = !!e.currentTarget.checked;


### PR DESCRIPTION
Implement old gens to use the old sprites as well as an option to disable it that may interact with enable BW sprites.
If old gens are not disallowed, those will be used for past gens (1-5).
If BW sprites are allowed, those will be used for XY and BW.
If old gens are disallowed and BW allowed, all gens will use BW sprites.

Tested all options and gens interactions with testclient.
