### PR TITLE
Implement Special visual for gen 1

### DIFF
--- a/data/graphics.js
+++ b/data/graphics.js
@@ -156,7 +156,7 @@ var BattleBackdrops = [
 	'bg-route.png'
 ];
 var BattleStats = {
-	atk: 'Attack', def: 'Defense', spa: 'Special Attack', spd: 'Special Defense', spe: 'Speed', accuracy: 'accuracy', evasion: 'evasiveness'
+	atk: 'Attack', def: 'Defense', spa: 'Special Attack', spd: 'Special Defense', spe: 'Speed', accuracy: 'accuracy', evasion: 'evasiveness', spc: 'Special'
 };
 var BattleItems = {
 };

--- a/js/battle.js
+++ b/js/battle.js
@@ -577,7 +577,8 @@ var Pokemon = (function () {
 			spd: 'SpD',
 			spe: 'Spe',
 			accuracy: 'Accuracy',
-			evasion: 'Evasion'
+			evasion: 'Evasion',
+			spc: 'Spc'
 		};
 		if (!this.boosts[boostStat]) {
 			return '1&times;&nbsp;' + boostStatTable[boostStat];
@@ -3300,6 +3301,8 @@ var Battle = (function () {
 			case '-boost':
 				var poke = this.getPokemon(args[1]);
 				var stat = args[2];
+				if (this.gen === 1 && stat === 'spd') break;
+				if (this.gen === 1 && stat === 'spa') stat = 'spc';
 				var amount = parseInt(args[3]);
 				if (!poke.boosts[stat]) {
 					poke.boosts[stat] = 0;
@@ -3331,6 +3334,8 @@ var Battle = (function () {
 			case '-unboost':
 				var poke = this.getPokemon(args[1]);
 				var stat = args[2];
+				if (this.gen === 1 && stat === 'spd') break;
+				if (this.gen === 1 && stat === 'spa') stat = 'spc';
 				var amount = parseInt(args[3]);
 				if (!poke.boosts[stat]) {
 					poke.boosts[stat] = 0;


### PR DESCRIPTION
This change makes gen 1 show special drops and boosts instead of using both spa and spd at the same time.
This change makes playing faster as boosts and unboost will only show one message and also makes the simulator truer to the game.
