### PR TITLE
Improve old gen sprites functionality

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -836,14 +836,25 @@ var Tools = {
 		// Decide what gen sprites to use.
 		var gen = {1:'rby', 2:'gsc', 3:'rse', 4:'dpp', 5:'bw', 6:'xy'}[options.gen];
 		if (Tools.prefs('nopastgens')) gen = 'xy';
-		if (Tools.prefs('bwgfx') && gen === 'xy') gen = 'bw';
+		if (Tools.prefs('noanim') && gen === 'xy') gen = 'bw';
+		// We load here BW data if the generation is lower than XY.
+		// We do this here in case it's animated BW sprites, will deal with no animations and XY below.
+		if (gen !== 'xy') {
+			Tools.loadSpriteData('bw');
+		} else {
+			// In case BW was loaded earlier, we re-load XY sprite data.
+			Tools.loadSpriteData('xy');
+		}
 
+		// Check if there's animation data.
 		if (animationData && animationData[facing]) {
 			var spriteType = '';
+			// Check if the Pokémon is female and it has a specific female sprite.
 			if (animationData[facing]['anif'] && pokemon.gender === 'F') {
 				name += '-f';
 				spriteType += 'f';
 			}
+			// If animations are enabled and generation is either BW or XY, use their gifs.
 			if (!Tools.prefs('noanim') && gen in {'bw':1, 'xy':1}) {
 				spriteType = 'ani' + spriteType;
 				dir = gen + 'ani' + dir;
@@ -856,8 +867,9 @@ var Tools = {
 		}
 		// if there is no entry or enough data in pokedex-mini.js or the animations are disabled or past gen, use the proper sprites
 		gen = (gen === 'xy')? 'bw' : gen;
+		// Do this here in case gen was XY but animations were disabled.
+		Tools.loadSpriteData('bw');
 		dir = gen + dir;
-
 		spriteData.url += dir+'/' + name + '.png';
 
 		return spriteData;

--- a/js/client.js
+++ b/js/client.js
@@ -278,7 +278,7 @@
 					}
 				}
 
-				if (Tools.prefs('bwgfx') || Tools.prefs('noanim')) {
+				if (Tools.prefs('noanim')) {
 					// since xy data is loaded by default, only call
 					// loadSpriteData if we want bw sprites or if we need bw
 					// sprite data (if animations are disabled)
@@ -2292,7 +2292,6 @@
 		},
 		events: {
 			'change input[name=noanim]': 'setNoanim',
-			'change input[name=bwgfx]': 'setBwgfx',
 			'change input[name=nopastgens]': 'setNopastgens',
 			'change input[name=notournaments]': 'setNotournaments',
 			'change input[name=nolobbypm]': 'setNolobbypm',
@@ -2316,8 +2315,7 @@
 			buf += '<hr />';
 			buf += '<p><label class="optlabel">Background: <select name="bg"><option value="">Charizards</option><option value="#344b6c url(/fx/client-bg-horizon.jpg) no-repeat left center fixed">Horizon</option><option value="#546bac url(/fx/client-bg-3.jpg) no-repeat left center fixed">Waterfall</option><option value="#546bac url(/fx/client-bg-ocean.jpg) no-repeat left center fixed">Ocean</option><option value="#344b6c">Solid blue</option>'+(Tools.prefs('bg')?'<option value="" selected></option>':'')+'</select></label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="noanim"'+(Tools.prefs('noanim')?' checked':'')+' /> Disable animations</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="bwgfx"'+(Tools.prefs('bwgfx')?' checked':'')+' /> Enable BW sprites for XY</label></p>';
-			buf += '<p><label class="optlabel"><input type="checkbox" name="nopastgens"'+(Tools.prefs('nopastgens')?' checked':'')+' /> Use modern sprites for past generations</label></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="nopastgens"'+(Tools.prefs('nopastgens')?' checked':'')+' /> Disable past generations sprites</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="notournaments"'+(Tools.prefs('notournaments')?' checked':'')+' /> Ignore tournaments</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="nolobbypm"'+(Tools.prefs('nolobbypm')?' checked':'')+' /> Don\'t show PMs in lobby chat</label></p>';
 			buf += '<p><label class="optlabel"><input type="checkbox" name="selfhighlight"'+(!Tools.prefs('noselfhighlight')?' checked':'')+'> Highlight when your name is said in chat</label></p>';
@@ -2376,16 +2374,14 @@
 		setNoanim: function(e) {
 			var noanim = !!e.currentTarget.checked;
 			Tools.prefs('noanim', noanim);
-			Tools.loadSpriteData(noanim || Tools.prefs('bwgfx') ? 'bw' : 'xy');
-		},
-		setBwgfx: function(e) {
-			var bwgfx = !!e.currentTarget.checked;
-			Tools.prefs('bwgfx', bwgfx);
-			Tools.loadSpriteData(bwgfx || Tools.prefs('noanim') ? 'bw' : 'xy');
+			Tools.loadSpriteData(noanim ? 'bw' : 'xy');
 		},
 		setNopastgens: function(e) {
 			var nopastgens = !!e.currentTarget.checked;
 			Tools.prefs('nopastgens', nopastgens);
+			// If no past gens allowed, load XY sprite data.
+			// Otherwise, it's dealt with elsewhere (choosing gen for battle).
+			if (nopastgens) Tools.loadSpriteData('xy');
 		},
 		setNotournaments: function(e) {
 			var notournaments = !!e.currentTarget.checked;


### PR DESCRIPTION
Always load mini sprites from bw when no animations or bw.
Delete the now redundant option to enable BW sprites.
You just need no animations option load BW sprites for XY.
Make the option text more fitting to the overall style.
Make sure sprites have the proper size.