### PR TITLE
Implement Special text for gen 1 on stats tooltip

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1035,7 +1035,13 @@
 					text += '<p>Item: ' + Tools.getItem(pokemon.item).name + '</p>';
 				}
 				if (pokemon.stats) {
-					text += '<p>' + pokemon.stats['atk'] + '&nbsp;Atk /&nbsp;' + pokemon.stats['def'] + '&nbsp;Def /&nbsp;' + pokemon.stats['spa'] + '&nbsp;SpA /&nbsp;' + pokemon.stats['spd'] + '&nbsp;SpD /&nbsp;' + pokemon.stats['spe'] + '&nbsp;Spe</p>';
+					text += '<p>' + pokemon.stats['atk'] + '&nbsp;Atk /&nbsp;' + pokemon.stats['def'] + '&nbsp;Def /&nbsp;' + pokemon.stats['spa'];
+					if (this.battle.gen === 1) {
+						text += '&nbsp;Spc /&nbsp;';
+					} else {
+						text += '&nbsp;SpA /&nbsp;' + pokemon.stats['spd'] + '&nbsp;SpD /&nbsp;';
+					}
+					text += pokemon.stats['spe'] + '&nbsp;Spe</p>';
 				} else if (template.baseStats) {
 					var minSpe;
 					var maxSpe;


### PR DESCRIPTION
Didn't see this when doing https://github.com/Zarel/Pokemon-Showdown-Client/commit/1055c196fd93a991655cad9ef8d341465d69b311, noticed recently playing gen 1 randbats.