### PR TITLE
Auto-link URLs without closing parenthesis at end

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -330,7 +330,7 @@ var Tools = {
 				options.hidestrikethrough ? '$1' : '<s>$1</s>');
 		// linking of URIs
 		if (!options.hidelinks) {
-			str = str.replace(/https?\:\/\/[a-z0-9-.]+(?:\:[0-9]+)?(?:\/(?:[^\s]*[^\s?.,])?)?|[a-z0-9.]+\@[a-z0-9.]+\.[a-z0-9]{2,3}|(?:[a-z0-9](?:[a-z0-9-\.]*[a-z0-9])?\.(?:com|org|net|edu|us|jp)(?:\:[0-9]+)?|qmark\.tk)(?:(?:\/(?:[^\s]*[^\s?.,])?)?)\b/ig, function(uri) {
+			str = str.replace(/https?\:\/\/[a-z0-9-.]+(?:\:[0-9]+)?(?:\/(?:\([^\s()]*\)|[^\s?.,()])*)?|[a-z0-9.]+\@[a-z0-9.]+\.[a-z0-9]{2,3}|(?:[a-z0-9](?:[a-z0-9-\.]*[a-z0-9])?\.(?:com|org|net|edu|us|jp)(?:\:[0-9]+)?|qmark\.tk)\b(?:(?:\/(?:\([^\s()]*\)|[^\s?.,()])*)?)/ig, function(uri) {
 				if (/[a-z0-9.]+\@[a-z0-9.]+\.[a-z0-9]{2,3}/ig.test(uri)) {
 					return '<a href="mailto:'+uri+'" target="_blank">'+uri+'</a>';
 				}


### PR DESCRIPTION
Currently Pokémon Showdown doesn't auto-link URLs properly in the following form.

    (Check out http://play.pokemonshowdown.com/)

In this case, it's obvious that `)` not part of an URL, but the current auto-linker believes that it is. Making `)` illegal character at end of URL doesn't solve the problem, as sometimes URLs actually do contain parenthesis. The new URL regex supports one level of parenthesis (regexes don't support recursion, but if you have more than one layer of parenthesis in an URL, you are doing something wrong). This is a case with URLs on Wikipedia.

    https://en.wikipedia.org/wiki/Pokémon_(disambiguation)

(it also bothers me a lot, because I like writing less important stuff in parenthesis)