### PR TITLE
Update |unlink|hide| message

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5466,6 +5466,7 @@ var Battle = (function () {
 		case 'unlink':
 			var user = toId(args[2]) || toId(args[1]);
 			var $messages = $('.chatmessage-' + user);
+			if (!$messages.length) break;
 			$messages.find('a').contents().unwrap();
 			if (args[2]) {
 				$messages.hide();

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -995,10 +995,11 @@
 					// so that it can be included in the scrollback buffer.
 					var user = toId(row[2]) || toId(row[1]);
 					var $messages = $('.chatmessage-' + user);
+					if (!$messages.length) break;
 					$messages.find('a').contents().unwrap();
 					if (row[2]) {
 						$messages.hide();
-						if (this.$chat.find('.chatmessage-' + user).length) this.$chat.append('<div class="chatmessage-' + user + '"><button name="revealMessages" value="' + user + '"><small>Some messages were hidden, click here to restore them.</small></button></div>');
+						this.$chat.append('<div class="chatmessage-' + user + '"><button name="revealMessages" value="' + user + '"><small>Some messages were hidden, click here to restore them.</small></button></div>');
 					}
 					break;
 


### PR DESCRIPTION
Display the reveal button based on each user's screen instead of the current room's chat for cases such as a user being locked/banned for a PM offense without having any messages in the room.