### PR TITLE
Only check if an address is already registered by hostname, not by IP

### DIFF
--- a/crossdomain.php
+++ b/crossdomain.php
@@ -56,19 +56,14 @@ if (isset($PokemonServers[$config['host']])) {
 
 	// see if this is actually a registered server
 	if ($config['host'] !== 'localhost') {
-		$ip = gethostbyname($config['host']);
 		foreach ($PokemonServers as &$server) {
-			if (!isset($server['ipcache'])) {
-				$server['ipcache'] = gethostbyname($server['server']);
-			}
-			if ($ip === $server['ipcache']) {
-				if (($config['port'] === $server['port']) ||
-						(isset($server['altport']) &&
-							$config['port'] === $server['altport'])) {
-					$path = isset($_REQUEST['path']) ? $_REQUEST['path'] : '';
-					$config['redirect'] = 'http://' . $server['id'] . '.psim.us/' . rawurlencode($path);
-					break;
-				}
+			if ($config['host'] === $server['server'] && (
+					$config['port'] === $server['port'] ||
+					(isset($server['altport']) && $config['port'] === $server['altport'])
+				)) {
+				$path = isset($_REQUEST['path']) ? $_REQUEST['path'] : '';
+				$config['redirect'] = 'http://' . $server['id'] . '.psim.us/' . rawurlencode($path);
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
When attempting to go on an unregistered server when there is already another registered server sharing the same IP/Port pair (such as in virtual hosting), you get redirected to the registered server, which
is undesirable.

This is important for me particularily because due to the recent change in server registration policy (only one server to be registered to a single user, and no registering on the behalf of others), I can't get my clients to register servers themselves due to this issue. (I host multiple servers on a single IP, but all through port 80)

(Code untested for obvious reasons)