### PR TITLE
Reintroduce auto-linking without closing parenthesis

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -330,7 +330,7 @@ var Tools = {
 				options.hidestrikethrough ? '$1' : '<s>$1</s>');
 		// linking of URIs
 		if (!options.hidelinks) {
-			str = str.replace(/https?\:\/\/[a-z0-9-.]+(?:\:[0-9]+)?(?:\/(?:[^\s]*[^\s?.,])?)?|[a-z0-9.]+\@[a-z0-9.]+\.[a-z0-9]{2,3}|(?:[a-z0-9](?:[a-z0-9-\.]*[a-z0-9])?\.(?:com|org|net|edu|us|jp)(?:\:[0-9]+)?|qmark\.tk)(?:(?:\/(?:[^\s]*[^\s?.,])?)?)\b/ig, function(uri) {
+			str = str.replace(/https?\:\/\/[a-z0-9-.]+(?:\:[0-9]+)?(?:\/(?:(?:[^\s()]*[^\s?.,()]|\([^\s()]*\))*)?)?|[a-z0-9.]+\@[a-z0-9.]+\.[a-z0-9]{2,3}|(?:[a-z0-9](?:[a-z0-9-\.]*[a-z0-9])?\.(?:com|org|net|edu|us|jp)(?:\:[0-9]+)?|qmark\.tk)\b(?:(?:\/(?:(?:[^\s()]*[^\s?.,()]|\([^\s()]*\))*)?)?)/ig, function(uri) {
 				if (/[a-z0-9.]+\@[a-z0-9.]+\.[a-z0-9]{2,3}/ig.test(uri)) {
 					return '<a href="mailto:'+uri+'" target="_blank">'+uri+'</a>';
 				}


### PR DESCRIPTION
This commit reintroduces change in 6b8b68d without regression on links like http://i.imgur.com/rcOnWA2.png.