### PR TITLE
Rewrite URL parsing.

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -278,6 +278,42 @@ var baseSpeciesChart = {
 	// others are hardcoded by ending with 'mega'
 };
 
+// Precompile often used regular expression for links.
+var domainRegex = '[a-z0-9\\-]+(?:[.][a-z0-9\\-]+)*';
+var parenthesisRegex = '[(][^\\s()<>]*[)]';
+var linkRegex = new RegExp(
+	'\\b' +
+	'(?:' +
+		'(?:' +
+			// When using www. or http://, allow any-length TLD (like .museum)
+			'(?:https?://|www[.])' + domainRegex +
+			'|' + domainRegex + '[.]' +
+				// Allow a common TLD, or any 2-3 letter TLD followed by : or /
+				'(?:com?|org|net|edu|info|us|jp|[a-z]{2,3}(?=[:/]))' +
+		')' +
+		'(?:[:][0-9]+)?' +
+		'\\b' +
+		'(?:' +
+			'/' +
+			'(?:' +
+				'(?:' +
+					'[^\\s()<>]' +
+					'|' + parenthesisRegex +
+				')*' +
+				// URLs usually don't end with punctuation, so don't allow
+				// punctuation symbols that probably aren't related to URL.
+				'(?:' +
+					'[^\\s`()<>\\[\\]{}\'".,!?;:]' +
+					'|' + parenthesisRegex +
+				')' +
+			')?' +
+		')?' +
+		'|[a-z0-9.]+\\b@' + domainRegex + '[.][a-z]{2,3}' +
+	')'
+,
+	'ig'
+);
+
 var Tools = {
 
 	resourcePrefix: (function() {
@@ -330,8 +366,8 @@ var Tools = {
 				options.hidestrikethrough ? '$1' : '<s>$1</s>');
 		// linking of URIs
 		if (!options.hidelinks) {
-			str = str.replace(/https?\:\/\/[a-z0-9-.]+(?:\:[0-9]+)?(?:\/(?:[^\s]*[^\s?.,])?)?|[a-z0-9.]+\@[a-z0-9.]+\.[a-z0-9]{2,3}|(?:[a-z0-9](?:[a-z0-9-\.]*[a-z0-9])?\.(?:com|org|net|edu|us|jp)(?:\:[0-9]+)?|qmark\.tk)(?:(?:\/(?:[^\s]*[^\s?.,])?)?)\b/ig, function(uri) {
-				if (/[a-z0-9.]+\@[a-z0-9.]+\.[a-z0-9]{2,3}/ig.test(uri)) {
+			str = str.replace(linkRegex, function(uri) {
+				if (/^[a-z0-9.]+\@/ig.test(uri)) {
 					return '<a href="mailto:'+uri+'" target="_blank">'+uri+'</a>';
 				}
 				// Insert http:// before URIs without a URI scheme specified.


### PR DESCRIPTION
Regular expression is now written using new RegExp constructor to make a more readable regular expression (even if I admit it's not that great because of `+` everywhere, but this is JavaScript, so no neat `/x` flag for regular expressions).

This heavily changes behaviour of auto-linking, in particular.

-   URLs can be in parenthesis, see 6b8b68d for more details and justification of a change.

-   More top level domains are allowed in URLs without http:// prefix. Anything that is two letter is allowed, as long followed by slash or colon.

-   Allow auto-linking URLs starting with `www.`, even with unrecognized TLD. Chances are if a domain has this particular subdomain, it's a website address.

-   Removed qmark.tk special case, this site is dead anyway.

-   Added support for `.co` TLD. This domain gets a lot of popularity, and it doesn't look like it could harm anything.

-   Added support for `.info` TLD. This is because the special case of handling 2-3 letter TLD doesn't handle `.info`.