### PR TITLE
SyntaxError handling when adding regex highlights

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -570,8 +570,16 @@
 					switch (targets[0]) {
 					case 'add':
 						for (var i=1, len=targets.length; i<len; i++) {
-							highlights.push(targets[i].trim());
+							if (/[\\^$*+?()|{}[\]]/.test(targets[i])) {
+								// Catch any errors thrown by newly added regular expressions so they don't break the entire highlight list
+								try {
+									new RegExp(targets[i]);
+								} catch (e) {
+									return this.add(e.message.substr(0, 28) === 'Invalid regular expression: ' ? e.message : 'Invalid regular expression: /' + targets[i] + '/: ' + e.message);
+								}
+							}
 						}
+						highlights = highlights.concat(targets.slice(1));
 						this.add("Now highlighting on: " + highlights.join(', '));
 						// We update the regex
 						app.highlightRegExp = new RegExp('\\b('+highlights.join('|')+')\\b', 'i');


### PR DESCRIPTION
If the user attempts to add any regular expressions that throw a syntax
error on RegExp object construction, they can see the first pattern that
throws an error along with its error message without breaking their
entire highlight list.