### PR TITLE
Add Headbutt Animation

### DIFF
--- a/data/graphics.js
+++ b/data/graphics.js
@@ -3351,6 +3351,9 @@ var BattleMoveAnims = {
 	vicegrip: {
 		anim: BattleOtherAnims.contactattack.anim
 	},
+	headbutt: {
+		anim: BattleOtherAnims.contactattack.anim
+	},
 	xscissor: {
 		anim: BattleOtherAnims.xattack.anim
 	},


### PR DESCRIPTION
In which the Python script I was using to search for nonimplemented moves doesn't use regex and therefore doesn't notice the missing instance of "headbutt" because it's contained in "zenheadbutt"