### PR TITLE
Add sorting options for Pokemon and moves in teambuilder

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -42,6 +42,8 @@
 			'keyup .chartinput': 'chartKeyup',
 			'focus .chartinput': 'chartFocus',
 			'change .chartinput': 'chartChange',
+			'change select[name=pokemonsort]': 'sortChart',
+			'change select[name=movesort]': 'sortChart',
 
 			// clipboard
 			'click .teambuilder-clipboard-data .result': 'clipboardResultSelect',
@@ -677,6 +679,12 @@
 			buf += '</ol>';
 			buf += '</div>';
 
+			//sort results
+			buf += '<div class="teambuilder-results-sort">'
+			buf += 'Sort Pokemon by <select name="pokemonsort"><option>Name</option><option>HP</option><option>Attack</option><option>Defense</option><option>Special Attack</option><option>Special Defense</option><option>Speed</option><option>BST</option></select> ';
+			buf += 'Moves by <select name="movesort"><option>Name</option><option>Type</option><option>Category</option><option>Base Power</option></select>';
+			buf += '</div>';
+
 			// results
 			this.chartPrevSearch = '[init]';
 			buf += '<div class="teambuilder-results"></div>';
@@ -793,6 +801,12 @@
 				this.$chart.find('.totalev').html('<b>'+(510-totalev)+'</b>');
 			}
 			this.$chart.find('select[name=nature]').val(set.nature||'Serious');
+		},
+		sortChart: function(e) {
+			var toSort = e.currentTarget.name;
+			Chart.sortBy[toSort.substr(0, toSort.length - 4)] = e.currentTarget.value;
+			if ( (this.curChartType + 'sort') !== toSort) return;
+			this.updateChart();
 		},
 		curChartType: '',
 		curChartName: '',

--- a/js/utilichart.js
+++ b/js/utilichart.js
@@ -5,6 +5,7 @@ function BattleChart()
 	this.firstResult = '';
 	this.exactResult = false;
 	this.lastSearch = '[init]';
+	this.sortBy = { 'pokemon':'Name', 'move':'Name' };
 
 	// I know, I know, lots of memory
 	// but these are arrays of pointers, so it's not _horrible_
@@ -275,6 +276,11 @@ function BattleChart()
 			other: {}
 		};
 		thisArrange = thisArrange || self.defaultArrange;
+		if (type === 'pokemon') {
+			thisSort = this.pokemonSort[this.sortBy[type]];
+		} else if (type === 'move') {
+			thisSort = this.moveSort[this.sortBy[type]];
+		}
 		thisSort = thisSort || self.defaultSort;
 
 		self.firstResult = '';
@@ -553,6 +559,82 @@ function BattleChart()
 			return ['All'];
 		}
 		return 'All';
+	};
+	this.pokemonSort = {
+		"HP": function(a,b) {
+			if (a.baseStats.hp === b.baseStats.hp) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return (a.baseStats.hp > b.baseStats.hp) ? -1 : 1;
+			}
+		},
+		"Attack": function(a,b) {
+			if (a.baseStats.atk === b.baseStats.atk) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return (a.baseStats.atk > b.baseStats.atk) ? -1 : 1;
+			}
+		},
+		"Defense": function(a,b) {
+			if (a.baseStats.def === b.baseStats.def) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return (a.baseStats.def > b.baseStats.def) ? -1 : 1;
+			}
+		},
+		"Special Attack": function(a,b) {
+			if (a.baseStats.spa === b.baseStats.spa) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return (a.baseStats.spa > b.baseStats.spa) ? -1 : 1;
+			}
+		},
+		"Special Defense": function(a,b) {
+			if (a.baseStats.spd === b.baseStats.spd) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return (a.baseStats.spd > b.baseStats.spd) ? -1 : 1;
+			}
+		},
+		"Speed": function(a,b) {
+			if (a.baseStats.spe === b.baseStats.spe) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return (a.baseStats.spe > b.baseStats.spe) ? -1 : 1;
+			}
+		},
+		"BST": function(a,b) {
+			var bstA = 0, bstB = 0;
+			for (i in a.baseStats) { bstA += a.baseStats[i]; bstB += b.baseStats[i]; }
+			if (bstA === bstB) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else { 
+				return (bstA > bstB) ? -1 : 1;
+			}
+		}
+	};
+	this.moveSort = {
+		"Type": function(a,b) {
+			if (a.type === b.type) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return (a.type > b.type) ? 1 : -1;
+			}
+		},
+		"Category": function(a,b) {
+			if (a.category === b.category) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return (a.category > b.category) ? 1 : -1;
+			}
+		},
+		"Base Power": function(a,b) {
+			if (a.basePower === b.basePower) {
+				return (a.name === b.name) ? 0 : ( (a.name > b.name) ? 1 : -1 );
+			} else {
+				return ( (a.basePower > b.basePower) ? -1 : 1);
+			}
+		}
 	};
 	this.defaultSort = function(a,b) {
 		/* if (!a.num) a.num = 1000;

--- a/style/client.css
+++ b/style/client.css
@@ -2207,7 +2207,7 @@ div[class^='tournament-message-'], div[class*=' tournament-message-'] {
 }
 .teambuilder-results {
 	position: absolute;
-	top: 200px;
+	top: 223px;
 	left: 0;
 	bottom: 0;
 	right: 0;
@@ -2223,6 +2223,21 @@ div[class^='tournament-message-'], div[class*=' tournament-message-'] {
 	bottom: 0;
 	right: 0;
 	border-top: 1px solid #AAAAAA;
+
+	overflow: auto;
+	-webkit-overflow-scrolling: touch;
+	overflow-scrolling: touch;
+}
+.teambuilder-results-sort {
+	position: absolute;
+	top: 202px;
+	left: 0px;
+	bottom: 0;
+	right: 0;
+	font-size: 13px;
+	height: 20px;
+	padding-left: 10px;
+	border-bottom: 1px solid #AAAAAA;
 
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
This can sort Pokemon by name or any of their stats. Moves can be sorted by name, base power, category, or type.

Examples: http://puu.sh/hhUjW.jpg http://puu.sh/hijMP.jpg

I tested some things, but I couldn't find if anything required <code>BattleChart.pokemon</code> to be in alphabetical order.
