### PR TITLE
Allow negative attack nature for U-turn and Volt Switch

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1843,9 +1843,9 @@
 				if (evTotal < 508) {
 					var remaining = 508 - evTotal;
 					if (remaining > 252) remaining = 252;
-					if (!evs['atk'] && moveCount['PhysicalAttack']) {
+					if (!evs['atk'] && moveCount['PhysicalAttack'] >= 1) {
 						evs['atk'] = remaining;
-					} else if (!evs['spa'] && moveCount['SpecialAttack']) {
+					} else if (!evs['spa'] && moveCount['SpecialAttack'] >= 1) {
 						evs['spa'] = remaining;
 					} else if (stats.hp == 1 && !evs['def']) {
 						evs['def'] = remaining;
@@ -1864,8 +1864,10 @@
 				minusStat = 'spe';
 			} else if (!moveCount['PhysicalAttack']) {
 				minusStat = 'atk';
-			} else if (!moveCount['SpecialAttack']) {
+			} else if (moveCount['SpecialAttack'] < 1) {
 				minusStat = 'spa';
+			} else if (moveCount['PhysicalAttack'] < 1) {
+				minusStat = 'atk';
 			} else if (stats.def > stats.spd) {
 				minusStat = 'spd';
 			} else {


### PR DESCRIPTION
U-turn and Volt Switch are unusual in an aspect that they are dual purpose moves. Sometimes they are used as damaging moves (main attacking move even, like with Mega Beedrill or Genesect). In other cases, they are used to preserve momentum, and the damage from them doesn't exactly matter (see Cobalion, Xatu, Mega Pidgeot or Hydreigon).

This change allows giving a negative attacking nature to an user of U-turn or Volt Switch if it appears to be used in a momentum-sort of way, as opposed to an usage as a damaging move.