### PR TITLE
Store teams as "packed" opposed to JSON

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -65,11 +65,11 @@
 				Storage.saveTeams();
 			} else if (this.curSet) {
 				app.clearGlobalListeners();
-				Storage.teams[this.curTeamLoc]=Storage.packTeam(this.curTeam);
+				Storage.teams[this.curTeamLoc] = Storage.packTeam(this.curTeam);
 				Storage.saveTeams();
 				this.curSet = null;
 			} else if (this.curTeam) {
-			    Storage.teams[this.curTeamLoc]=Storage.packTeam(this.curTeam);
+                Storage.teams[this.curTeamLoc] = Storage.packTeam(this.curTeam);
 				Storage.saveTeams();
 				this.curTeam = null;
 			} else {
@@ -2104,9 +2104,9 @@
 					curSet.moves.push(line);
 				}
 			}
-			if (jsonTeams){
-			    for (var i=0;i<jsonTeams.length;i++){
-			        Storage.teams[i]=Storage.packTeam(jsonTeams[i]);
+			if (jsonTeams) {
+			    for (var i=0; i<jsonTeams.length; i++) {
+			        Storage.teams[i] = Storage.packTeam(jsonTeams[i]);
 			    }
 			}
 			return team;

--- a/js/storage.js
+++ b/js/storage.js
@@ -28,27 +28,25 @@ _Storage.prototype.loadTeams = function() {
 	}
 	this.teams = [];
 	if (window.localStorage) {
-		
-		//load in the teamString
 		var teamString = localStorage.getItem('showdown_teams');
 		
-		if(teamString){
-		    //check if the team is stored as JSON
-		    //could also try to use JSON.parse and catch errors? (not sure which is faster)
-		    var isJSON = teamString.substring(0,2)>"[{"?-1:0;
+		if (teamString) {
+		    // check if the teams are stored as JSON
+		    // could also try to use JSON.parse and catch errors? (not sure which is faster)
+		    var isJSON = teamString.substring(0,2)>"[{" ? -1 : 0;
 
-		    //if JSON, parse the JSON, convert to packed format, update localStorage to packed format
-		    if (isJSON==0){
+		    // if JSON, parse the JSON, convert to packed format, update localStorage to packed format
+		    if (isJSON === 0) {
 		        var jsonTeams = JSON.parse(teamString);
 		        var team = '';
-		        for (var i=0; i<jsonTeams.length; i++){
+		        for (var i=0; i<jsonTeams.length; i++) {
 		            team = this.packTeam(jsonTeams[i])
 		            this.teams.push(team)
 		        }
 		        localStorage.setItem('showdown_teams', this.savePackedTeams());
 		    } else {
-		    //if not JSON, bring in all teams and continue normally
-		    //eventually all users will transition over and only use the else path.
+		        // if not JSON, bring in all teams and continue normally
+		        // eventually all users will transition over and only use the else path.
 		        this.loadPackedTeams(teamString)
 		    }
 		}
@@ -96,7 +94,7 @@ _Storage.prototype.savePackedTeams = function() {
 _Storage.prototype.loadPackedTeams = function(teamString) {
     // use } to separate teams
 	var i = 0, j = 0;
-    while(true){
+    while(true) {
         j = teamString.indexOf('}', i);
         if(j<0) break;
         this.teams.push(teamString.substring(i, j));


### PR DESCRIPTION
In response to issue #815 (https://github.com/Zarel/Pokemon-Showdown/issues/815).

Zarel's packed format was implemented such that only the current team is in an object representation when using the teambuilder. It is backwards compatible with users that already have teams stored with JSON.

However, the current changes only work for teams stored in localStorage. 

I'm unsure how to proceed with the crossDomain connection. I chatted briefly w/ Slayer95 on PS!, but any additional advice/pointers would be much appreciated. 

edit: My main problem with the crossDomain connection is the inability to test/experiment with it in the test client. 