### PR TITLE
Move index.template.html character set declaration to HTTP

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,6 +5,7 @@ AddType application/x-web-app-manifest+json .webapp
 
 <filesMatch "^index\.html$">
   FileETag None
+  AddCharset UTF-8 .html
   <ifModule mod_headers.c>
      Header unset ETag
      Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"

--- a/index.template.html
+++ b/index.template.html
@@ -46,7 +46,6 @@ Also feel free to visit us at #showdown on irc.synirc.net
 -->
 <html>
 	<head>
-		<meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
 		<title>Showdown!</title>
 		<link rel="shortcut icon" href="//play.pokemonshowdown.com/favicon.ico" id="dynamic-favicon" />
 		<link rel="stylesheet" href="//play.pokemonshowdown.com/style/client.css?" />


### PR DESCRIPTION
According to [WHATWG specification][1], there are a few of requirements that a character set declaration must meet. One of these is a following one.

> The element containing the character encoding declaration must be serialised completely within the first 1024 bytes of the document.

Beginning of a document contains a **huge** comment (pretty much 2 kilobytes). Either it would have to be moved to be after character set declaration, character set declaration would have to be moved to HTTP layer, or a comment would have to be remove entirely. I decided on a second option, because I couldn't think of a way to move this comment without making it uglier.

[1]: https://html.spec.whatwg.org/multipage/semantics.html#charset