### PR TITLE
Disable Chrome Frame

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -57,7 +57,7 @@ Also feel free to visit us at #showdown on irc.synirc.net
 		<link rel="stylesheet" href="//play.pokemonshowdown.com/style/jquery.slider.min.css?" />
 		<meta id="viewport" name="viewport" content="width=640" />
 		<meta name="robots" content="noindex" />
-		<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+		<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 		<script>
 			var Config = {};
 		</script>

--- a/testclient.html
+++ b/testclient.html
@@ -12,7 +12,7 @@
 		<link rel="stylesheet" href="style/jquery.slider.min.css" />
 		<meta id="viewport" name="viewport" content="width=640" />
 		<meta name="robots" content="noindex" />
-		<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+		<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 		<script>
 			var Config = {testclient: true};
 			(function() {
@@ -35,24 +35,6 @@
 		</script><![endif]-->
 	</head>
 	<body>
-
-		<!-- Chrome Frame -->
-		<!--[if lte IE 8]>
-		<script src="http://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js"></script>
-		<style>
-		/*
-		CSS rules to use for styling the overlay:
-		.chromeFrameOverlayContent
-		.chromeFrameOverlayContent iframe
-		.chromeFrameOverlayCloseBar
-		.chromeFrameOverlayUnderlay
-		*/
-		</style>
-		<script>
-			CFInstall.check({mode: "overlay"});
-		</script>
-		<![endif]-->
-
 		<div id="header" class="header">
 			<img class="logo" src="pokemonshowdownbeta.png" alt="Pok&eacute;mon Showdown! (beta)" /><div class="maintabbarbottom"></div>
 		</div>


### PR DESCRIPTION
Chrome Frame is not supported for two years, which means removing support for it on Pokémon Showdown should be safe.