### PR TITLE
Add pokemon Icons to teambuilder teams list

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -174,6 +174,12 @@
 						if (j!=0) buf += ' / ';
 						buf += ''+Tools.escapeHTML(team.team[j].name);
 					}
+					if (team.team.length) {
+						buf += '<br />';
+						for (var j=0; j<team.team.length; j++) {
+							buf += '<span class="pokemonicon" style="float:inherit;display:inline-block;'+Tools.getIcon(team.team[j])+'"></span>';
+						}
+					}
 					buf += '</small></button> <button name="edit" value="'+i+'"><i class="icon-pencil"></i>Edit</button> <button name="delete" value="'+i+'"><i class="icon-trash"></i>Delete</button></li>';
 				}
 			}


### PR DESCRIPTION
I think adding Pokemon icons to each team in teambuilder teams list improves the appearance of the list. It also makes easier to recognize individual teams when you are looking for one and you have a lot.

An example of how it looks: http://imgur.com/0TQrOrd