### PR TITLE
Sidebar update for dragIn

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -1629,6 +1629,7 @@ var Side = (function () {
 		this.battle.statElem.append(this.getStatbarHTML(pokemon));
 		pokemon.statbarElem = this.battle.statElem.children().last();
 		this.updateStatbar(pokemon, true);
+		pokemon.side.updateSidebar();
 		if (this.battle.fastForward) {
 			if (oldpokemon) {
 				oldpokemon.statbarElem.remove();


### PR DESCRIPTION
Simple fix for an open issue https://github.com/Zarel/Pokemon-Showdown/issues/1872 

`updateStatbar` is now called in `dragIn` same way as it is called in `switchIn`.