### PR TITLE
Testclient was not working when custom server was using port 443

### DIFF
--- a/testclient.html
+++ b/testclient.html
@@ -22,7 +22,7 @@
 						Config.server = {
 							id: m[1],
 							host: m[2],
-							port: (m[3] && m[3].substr(1)) || 8000
+							port: (m[3] && parseInt(m[3].substr(1))) || 8000
 						};
 					} else {
 						alert('Unrecognised query string syntax: ' + location.search);


### PR DESCRIPTION
While i was getting both client and server to run on Cloud9 I found out that testclient won't connect to server if port 443 is used.

The issue was that the port was parsed as a string in `testclient.html` but then compared using triple equals operator with integer in `client.js` which would return false resulting in a use of `http` protocol instead and connection issues:

		client.js:695		var protocol = (Config.server.port === 443) ? 'https' : 'http';

After this small fix it is now possible to develop and test both client and server in cloud :+1:  .