### PR TITLE
Remove crossdomain issues on load for testclient over https

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -143,7 +143,7 @@
 		getActionPHP: function() {
 			var ret = '/~~' + Config.server.id + '/action.php';
 			if (Config.testclient) {
-				ret = 'http://' + Config.origindomain + ret;
+				ret = 'https://' + Config.origindomain + ret;
 			}
 			return (this.getActionPHP = function() {
 				return ret;

--- a/testclient.html
+++ b/testclient.html
@@ -74,7 +74,7 @@
 			document.getElementById('loading-message').innerHTML += ' DONE<br />Loading data...';
 		</script>
 
-		<script src="http://play.pokemonshowdown.com/js/config.js"></script>
+		<script src="https://play.pokemonshowdown.com/js/config.js"></script>
 		<script src="js/battledata.js"></script>
 		<script src="data/pokedex-mini.js"></script>
 		<script src="data/typechart.js"></script>


### PR DESCRIPTION
When testclient is run over https browser loves to complain and block mixed content which includes:
* pokemonshowdown's `//play.pokemonshowdown.com/js/config.js`
* calls to `action.php` like `upkeep`

Fix consists of using protocol-relative URL for `config.js` and not hardcoding protocol to `http://` in test mode for `getActionPHP`.