### PR TITLE
When ignoring spectators join/left messages won't be shown

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5394,11 +5394,15 @@ var Battle = (function () {
 			break;
 		case 'join':
 		case 'j':
-			this.log('<div class="chat"><small>' + Tools.escapeHTML(args[1]) + ' joined.</small></div>', preempt);
+			if (!this.ignoreSpects) {
+				this.log('<div class="chat"><small>' + Tools.escapeHTML(args[1]) + ' joined.</small></div>', preempt);
+			}
 			break;
 		case 'leave':
 		case 'l':
-			this.log('<div class="chat"><small>' + Tools.escapeHTML(args[1]) + ' left.</small></div>', preempt);
+			if (!this.ignoreSpects) {
+				this.log('<div class="chat"><small>' + Tools.escapeHTML(args[1]) + ' left.</small></div>', preempt);
+			}
 			break;
 		case 'J':
 		case 'L':


### PR DESCRIPTION
When player clicks on `Ignore Spectators` he won't see their join and left messages anymore.

During the CAP playtest an hour ago this seemed like a good idea to have as there were almost 1000 spectators and the whole chat was unreadable because of join/left messages.

