### PR TITLE
Don't use toId for room names while joining a room using popup

### DIFF
--- a/js/client-rooms.js
+++ b/js/client-rooms.js
@@ -39,7 +39,7 @@
 		},
 		joinRoomPopup: function() {
 			app.addPopupPrompt("Room name:", "Join room", function(room) {
-				room = toId(room);
+				room = toRoomId(room);
 				if (!room) return;
 				app.tryJoinRoom(room);
 			});


### PR DESCRIPTION
This fixes the issue that the Join room popup couldn't be used to enter battle rooms.