### PR TITLE
Stop users from being able to challenge themselves

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -432,6 +432,7 @@
 				var self = this;
 				var challenge = function(targets) {
 					target = toId(targets[0]);
+					if (toId(targets[0]) === app.user.get('userid')) return;
 					self.challengeData = { userid: target, format: targets[1] || '', team: targets[2] || '' };
 					app.on('response:userdetails', self.challengeUserdetails, self);
 					app.send('/cmd userdetails '+target);


### PR DESCRIPTION
Although this goes along with users not being able to click on their own name and challenging that way,  some counter-arguments have also come with this pull request, for example:

- @xfix: I'm just saying I don't see a point in fixing it, and I actually took advantage of broken `/challenge`.
- @xfix: But seriously, `/challenge xfix` is useful for me to test chat parser. It opens chat window easier than `/open`.

These are both viable points but note:

- You can still do `/pm [username], test` to still open the chat window.

Edit: I decided not to add this to `case 'pm':` for the reason included in the counter-arguments.