### PR TITLE
Make long usernames not cut off in battle

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -403,7 +403,7 @@ License: GPLv2
 	display: block;
 	font-size: 8pt;
 	margin-bottom: 2px;
-	overflow: hidden;
+	word-wrap: break-word;
 }
 .trainer div
 {


### PR DESCRIPTION
urkerab: so I take it you're a contributor to the showdown client? would you mind giving me your opinion of adding word-wrap: break-word; to the CSS for .trainer strong in battle.css line 401-407? It means that when playing users with very long names (e.g. GoodMorningEspeon) that it doesn't get cut off.

urkerab: would you mind doing that one on my behalf? as yet I don't envisage being a regular contributor, so right now I'm not really fancying setting up the environment just for a one line change