### PR TITLE
Remove article in tournament creation

### DIFF
--- a/js/client-chat-tournament.js
+++ b/js/client-chat-tournament.js
@@ -251,7 +251,7 @@
 				case 'create':
 					var format = Tools.getEffect(data[0]).name;
 					var type = data[1];
-					this.room.$chat.append("<div class=\"notice tournament-message-create\">A " + Tools.escapeHTML(format) + " " + Tools.escapeHTML(type) + " Tournament has been created.</div>");
+					this.room.$chat.append("<div class=\"notice tournament-message-create\">" + Tools.escapeHTML(format) + " " + Tools.escapeHTML(type) + " Tournament created.</div>");
 					this.room.notifyOnce("Tournament created", "Room: " + this.room.title + "\nFormat: " + format + "\nType: " + type, 'tournament-create');
 					break;
 


### PR DESCRIPTION
Add "An" instead of "A" if the format name begins with a vowel.