### PR TITLE
Add punctuation onto Symbiosis' activation message

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -4750,7 +4750,6 @@ var Battle = (function () {
 				case 'symbiosis':
 					actions += '' + ofpoke.getName() + ' shared its ' + Tools.getItem(args[3]).name + ' with ' + poke.getLowerName() + '!';
 					break;
-
 				case 'deltastream':
 					actions += "The mysterious air current weakened the attack!";
 					break;

--- a/js/battle.js
+++ b/js/battle.js
@@ -4748,7 +4748,7 @@ var Battle = (function () {
 					actions += '' + poke.getName() + ' anchors itself!';
 					break;
 				case 'symbiosis':
-					actions += '' + ofpoke.getName() + ' shared its ' + Tools.getItem(args[3]).name + ' with ' + poke.getLowerName();
+					actions += '' + ofpoke.getName() + ' shared its ' + Tools.getItem(args[3]).name + ' with ' + poke.getLowerName() + '!';
 					break;
 
 				case 'deltastream':


### PR DESCRIPTION
I also removed a random blank line because it was awkwardly placed and made Delta Stream's activation message code placement inconsistent with the other abilities.