### PR TITLE
Support parsing versions and config from servers

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5447,6 +5447,9 @@ var Battle = (function () {
 	};
 	Battle.prototype.runMajor = function (args, kwargs, preempt) {
 		switch (args[0]) {
+		case 'version':
+			this.version = args[1];
+			break;
 		case 'start':
 			this.teamPreview(false);
 			this.mySide.active[0] = null;

--- a/js/battledata.js
+++ b/js/battledata.js
@@ -931,6 +931,8 @@ var Tools = {
 		return type;
 	},
 
+	loadConfig: function() {},
+
 	loadedSpriteData: {'xy':1, 'bw':0},
 	loadSpriteData: function (gen) {
 		if (this.loadedSpriteData[gen]) return;

--- a/js/client.js
+++ b/js/client.js
@@ -982,6 +982,27 @@
 			}
 
 			switch (parts[0]) {
+			case 'version':
+				var nlIndex = data.indexOf('\n');
+				if (nlIndex > 0) {
+					this.receive(data.substr(nlIndex + 1));
+					parts = data.slice(1, nlIndex).split('|');
+				}
+				Config.server.version = parts[1];
+				break;
+
+			case 'config':
+				var config;
+				try {
+					config = JSON.parse(parts[1]);
+					if (!config || typeof config !== 'object') config = {};
+				} catch (e) {
+					config = {};
+				}
+				Config.server.config = config;
+				Tools.loadConfig(config);
+				break;
+
 			case 'challstr':
 				if (parts[2]) {
 					this.user.receiveChallstr(parts[1] + '|' + parts[2]);
@@ -991,6 +1012,11 @@
 				break;
 
 			case 'formats':
+				var nlIndex = data.indexOf('\n');
+				if (nlIndex > 0) {
+					this.receive(data.substr(nlIndex + 1));
+					parts = data.slice(1, nlIndex).split('|');
+				}
 				this.parseFormats(parts);
 				break;
 

--- a/lib/dispatcher.lib.php
+++ b/lib/dispatcher.lib.php
@@ -332,6 +332,10 @@ class DefaultActionHandler {
 			$reqData['id'] = $server['id'].'-'.$reqData['id'];
 		}
 
+		if (isset($server['version']) {
+			$reqData['version'] = $server['version'];
+		}
+
 		include_once __DIR__.'/../../replay.pokemonshowdown.com/replays.lib.php';
 		$out = $GLOBALS['Replays']->prepUpload($reqData);
 
@@ -356,6 +360,20 @@ class DefaultActionHandler {
 		// No need to sanitise $server['id'] because it should be safe already.
 		$cssfile = dirname(__FILE__) . '/../../pokemonshowdown.com/config/customcss/' . $server['id'] . '.css';
 		@unlink($cssfile);
+	}
+
+	public function updateversion($dispatcher, &$reqData, &$out) {
+		$server =& $dispatcher->findServer();
+		if (!$server) {
+			$out['errorip'] = $dispatcher->getIp();
+			return;
+		}
+		if (!isset($reqData['version']) || mb_strlen($reqData['version']) > 8 || !preg_match('/^[0-9]+\.[0-9]+\.[0-9]+]+$/', $reqData['version'])) {
+			$out = 0;
+			return;
+		}
+
+		$server['version'] = $reqData['version'];
 	}
 
 	/**


### PR DESCRIPTION
Version support client-side and login-server-side.
Config support stubbed only client-side. Possible usage for it includes custom ranks / rank sorting (# vs ~ comes to mind)

(Be harsh in PHP review)
