### PR TITLE
Allow non-HTML5 based fragments in the test client

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -525,7 +525,8 @@
 
 			this.initializeConnection();
 
-			Backbone.history.start({pushState: true});
+			// HTML5 history throws exceptions when running on file://
+			Backbone.history.start({pushState: !Config.testclient});
 		},
 		/**
 		 * Start up the client, including loading teams and preferences,
@@ -849,11 +850,6 @@
 			};
 		},
 		dispatchFragment: function (fragment) {
-			if (Config.testclient) {
-				// Fragment dispatching doesn't work in testclient.html.
-				// Just open the main menu.
-				fragment = '';
-			}
 			if (location.search && window.history) {
 				history.replaceState(null, null, '/');
 			}

--- a/testclient.html
+++ b/testclient.html
@@ -97,9 +97,6 @@
 		<script src="data/graphics.js"></script>
 
 		<script>
-			// HTML5 history throws exceptions when running on file://
-			Backbone.History.prototype.navigate = function() {};
-
 			var app = new App();
 		</script>
 


### PR DESCRIPTION
By disabling pushState we can support fragments in the test client. I moved the comment about HTML5 based history from testclient.html to js/client.js too.