### PR TITLE
Make long trainer names wrap up instead of down

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -421,7 +421,7 @@ License: GPLv2
 	display: block;
 	font-size: 8pt;
 	margin-bottom: 2px;
-	overflow: hidden;
+	word-wrap: break-word;
 }
 .trainer div
 {

--- a/style/battle.css
+++ b/style/battle.css
@@ -407,11 +407,14 @@ License: GPLv2
 .trainer
 {
 	text-align: center;
-	margin-top: 180px;
+	position: absolute;
+	left: 0;
+	right: 0;
+	bottom: 102px;
 }
 .rightbar .trainer
 {
-	margin-top: 50px;
+	bottom: 232px;
 }
 .trainer strong
 {


### PR DESCRIPTION
In pull request #415 Zarel commented that he didn't like the way long trainer names wrapped because they pushed the trainer sprites down.

Positioning the trainer a fixed amount above the bottom of the bar solves this by making the trainer names wrap up instead of down.

This will then remove the objection to merging that pull request.

Before:
![screen shot 2015-08-19 at 14 06 54](https://cloud.githubusercontent.com/assets/13849513/9397799/33bba66c-4798-11e5-8b9e-0c9c648b32fc.png)

After: 
![screen shot 2015-08-19 at 14 30 23](https://cloud.githubusercontent.com/assets/13849513/9397803/4375f986-4798-11e5-9e2f-d00b8bf37b8c.png)

