### PR TITLE
Make teambuilder more resistant to zoom changes

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -2306,7 +2306,10 @@ a.ilink:hover {
 }
 .setchart .setcell-item input {
 	width: 114px;
-	margin-right: 1px;
+	margin-right: 0px;
+}
+.setchart .setcell-ability input {
+	margin-left: 0px;
 }
 .setchart .setcol-moves input {
 	width: 129px;

--- a/style/client.css
+++ b/style/client.css
@@ -2096,6 +2096,9 @@ a.ilink:hover {
 .setcell-details {
 	float: none;
 }
+.setcell-ability {
+	float: right;
+}
 .setcol-icon .itemicon {
 	display: block;
 	margin-left: 88px;
@@ -2303,6 +2306,7 @@ a.ilink:hover {
 }
 .setchart .setcell-item input {
 	width: 114px;
+	margin-right: 1px;
 }
 .setchart .setcol-moves input {
 	width: 129px;


### PR DESCRIPTION
Changing the zoom level can disrupt the teambuilder display as shown in this screenshot that I [found on the Smogon forums](http://www.smogon.com/forums/threads/bug-reports-v2-0-read-op-before-posting.3469932/page-217#post-6296053):
![Screenshot](http://i.imgur.com/9OefxTC.jpg)
Notice how the Item is slightly larger than the Nickname, Pokemon (sic) or Ability fields. Removing this item-specific style allows the teambuilder to display naturally at other zoom levels.

I didn't remove the style block because there was a similar placeholder style block a few lines above for `.setchart-nickname` but if this is an error then I can simply remove both blocks.