### PR TITLE
Update the window title as the fragment changes

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -98,6 +98,7 @@
 			if (log.length && log[0].substr(0, 7) === '|title|') {
 				this.title = log[0].substr(7);
 				log.shift();
+				app.roomTitleChanged(this);
 			}
 			if (this.battle.activityQueue.length) return;
 			this.battle.activityQueue = log;
@@ -150,6 +151,7 @@
 					}
 				} else if (logLine.substr(0, 7) === '|title|') {
 					this.title = logLine.substr(7);
+					app.roomTitleChanged(this);
 				} else if (logLine.substr(0, 6) === '|chat|' || logLine.substr(0, 3) === '|c|' || logLine.substr(0, 9) === '|chatmsg|' || logLine.substr(0, 10) === '|inactive|') {
 					this.battle.instantAdd(logLine);
 				} else {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1105,6 +1105,7 @@
 
 				case 'title':
 					this.title = row[1];
+					app.roomTitleChanged(this);
 					app.topbar.updateTabbar();
 					break;
 

--- a/js/client.js
+++ b/js/client.js
@@ -859,9 +859,10 @@
 			if (location.search && window.history) {
 				history.replaceState(null, null, '/');
 			}
-			fragment = toRoomid(fragment || '');
+			this.fragment = fragment = toRoomid(fragment || '');
 			if (this.initialFragment === undefined) this.initialFragment = fragment;
 			this.tryJoinRoom(fragment);
+			this.updateTitle(this.rooms[fragment]);
 		},
 		/**
 		 * Send to sim server
@@ -1389,7 +1390,11 @@
 				}
 				this.curRoom = window.room = room;
 				this.updateLayout();
-				if (this.curRoom.id === id) this.navigate(id);
+				if (this.curRoom.id === id) {
+					this.fragment = id;
+					this.navigate(id);
+					this.updateTitle(this.curRoom);
+				}
 			}
 
 			room.focus();
@@ -1529,6 +1534,12 @@
 				gui.Shell.openExternal(e.target.href);
 				return false;
 			}
+		},
+		roomTitleChanged: function (room) {
+			if (room.id === this.fragment) updateTitle(room);
+		},
+		updateTitle: function (room) {
+			document.title = room.title ? room.title + " - Showdown!" : "Showdown!";
 		},
 		updateAutojoin: function () {
 			if (Config.server.id !== 'showdown') return;


### PR DESCRIPTION
Currently the browser's history (both from the back button but also global history) just shows "Showdown!" for any page under http://play.pokemonshowdown.com/. On the other hand, all replays get nice titles e.g. "Challenge Cup 1-vs-1 replay: conbeef vs. urkerab - Pokémon Showdown". I've gone for a slightly simpler "conbeef vs. urkerab - Showdown!" to show up during an actual battle.

The title is refreshed when the fragment changes as this is what the browser stores in its history, so this not only includes the teambuilder and ladder rooms but also chat rooms if your window is small enough, or if you joined by loading a direct link.

The case of switching to a room whose title has not been read from the server yet is also handled.