### PR TITLE
Display battle formats in groups

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -853,12 +853,20 @@
 
 			buf += '<p><label>Format:</label><select name="format"><option value="">(All formats)</option>';
 			if (window.BattleFormats) {
+				var curSection = '';
 				for (var i in BattleFormats) {
-					if (BattleFormats[i].searchShow) {
+					var format = BattleFormats[i];
+					if (format.searchShow) {
+						if (format.section !== curSection) {
+							if (curSection) buf += '</optgroup>';
+							curSection = format.section;
+							if (curSection) buf += '<optgroup label="' + Tools.escapeHTML(curSection) + '">';
+						}
 						var activeFormat = (this.format === i ? ' selected=' : '');
-						buf += '<option value="' + i + '"' + activeFormat + '>' + BattleFormats[i].name + '</option>';
+						buf += '<option value="' + i + '"' + activeFormat + '>' + format.name + '</option>';
 					}
 				}
+				if (curSection) buf += '</optgroup>';
 			}
 			buf += '</select></p>';
 			buf += '<div class="list"><p>Loading...</p></div>';

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -494,12 +494,20 @@
 				}
 				if (exports.BattleFormats) {
 					buf += '<li class="format-select"><label>Format:</label><select name="format"><option value="">(None)</option>';
+					var curSection = '';
 					for (var i in BattleFormats) {
-						if (BattleFormats[i].isTeambuilderFormat) {
+						var format = BattleFormats[i];
+						if (format.isTeambuilderFormat) {
+							if (format.section !== curSection) {
+								if (curSection) buf += '</optgroup>';
+								curSection = format.section;
+								if (curSection) buf += '<optgroup label="' + Tools.escapeHTML(curSection) + '">';
+							}
 							var activeFormat = (this.curTeam.format === i ? ' selected="selected"' : '');
-							buf += '<option value="' + i + '"' + activeFormat + '>' + BattleFormats[i].name + '</option>';
+							buf += '<option value="' + i + '"' + activeFormat + '>' + format.name + '</option>';
 						}
 					}
+					if (curSection) buf += '</optgroup>';
 					buf += '</select></li>';
 				}
 				if (!this.curSetList.length) {


### PR DESCRIPTION
When teambuilding or searching for a battle you are currently presented with a plain list, unlike when challenging or laddering. This improves the display of those lists to include all the same sections.