### PR TITLE
Display desktop notification on disconnect

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -429,6 +429,11 @@
 			});
 
 			this.on('init:socketclosed', function () {
+				// Display a desktop notification if the user won't immediately see the popup.
+				if ((self.popups.length || !self.focused) && window.Notification) {
+					self.rooms[''].requestNotifications();
+					new Notification("Reconnect to Showdown!", {lang: 'en', body: "You have been disconnected \u2014 possibly because the server was restarted."});
+				}
 				self.reconnectPending = true;
 				if (!self.popups.length) self.addPopup(ReconnectPopup);
 			});


### PR DESCRIPTION
I'm sure I saw this requested in one of the forums somewhere but I can't find it now. (I may have even Liked the post but I don't know how to search the forums for my own Likes.) Basically the idea is that until you see the reconnect popup you might not realise that you've been disconnected, which is bad if you're doing something else in another tab or window while waiting for a tournament battle to become available.

To avoid annoying the user the desktop notification is not shown if the popup is visible to the user i.e. if the app is focused and no other popup is currently showing.

Clicking on the desktop notification will helpfully reload showdown for the user.

The desktop notification permission is also requested just in case the user has never opened any PMs.