### PR TITLE
Make it possible to minimise the Latest News box

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -107,7 +107,7 @@ ga('send', 'pageview');
 				<div class="activitymenu">
 					<div class="pmbox">
 						<div class="pm-window news-embed" data-newsid="<!-- newsid -->">
-							<h3><button class="closebutton" tabindex="-1"><i class="icon-remove-sign"></i></button>Latest News</h3>
+							<h3><button class="closebutton" tabindex="-1"><i class="icon-remove-sign"></i></button><button class="minimizebutton" tabindex="-1"><i class="icon-minus-sign"></i></button>Latest News</h3>
 							<div class="pm-log" style="max-height:none">
 								<div style="font-size:9pt;padding:1px 10px"><!-- news --></div>
 							</div>

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -99,11 +99,10 @@
 			if (newsId === '' + Tools.prefs('readnews')) return;
 			this.addPseudoPM({
 				title: 'Latest News',
-				html: '<iframe src="/news-embed.php?news' + (window.nodewebkit || document.location.protocol === 'https:' ? '&amp;https' : '') + '" width="270" height="400" border="0" style="border:0;width:100%;height:400px"></iframe>',
+				html: '<iframe src="/news-embed.php?news' + (window.nodewebkit || document.location.protocol === 'https:' ? '&amp;https' : '') + '" width="270" height="400" border="0" style="border:0;width:100%;height:100%;display:block"></iframe>',
 				attributes: 'data-newsid="' + newsId + '"',
 				cssClass: 'news-embed',
-				height: 400,
-				noMinimize: true
+				height: 400
 			});
 		},
 

--- a/testclient.html
+++ b/testclient.html
@@ -42,6 +42,12 @@
 			<div class="leftmenu">
 				<div class="activitymenu">
 					<div class="pmbox">
+						<div class="pm-window news-embed">
+							<h3><button class="closebutton" tabindex="-1"><i class="icon-remove-sign"></i></button><button class="minimizebutton" tabindex="-1"><i class="icon-minus-sign"></i></button>Latest News</h3>
+							<div class="pm-log" style="overflow:visible;height:400px;max-height:none">
+								<iframe src="http://play.pokemonshowdown.com/news-embed.php" width="270" height="400" border="0" style="border:0;width:100%;height:100%;display:block"></iframe>
+							</div>
+						</div>
 					</div>
 				</div>
 				<div class="mainmenu">


### PR DESCRIPTION
This was inspired by another forum suggestion post that I can no longer find. The original poster noticed that having closed the Latest News there was no UI to recover it. This works around the problem by allowing the news to be minimised instead. While porting the change to the unused addNews function I also fixed a bug in its height calculations by displaying the news iframe as a block. I also added the Latest News to the test client; the DOM I used there is almost identical to that created by the addNews function, the differences being the lack of the news ID, the hardcoded news URL, and the white space formatting is that from the home page.