### PR TITLE
Automatically select when exporting

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -133,6 +133,7 @@
 				buf = '<div class="pad"><button name="back"><i class="icon-chevron-left"></i> List</button> <button name="saveBackup" class="savebutton"><i class="icon-save"></i> Save</button></div>';
 				buf += '<div class="teamedit"><textarea class="textbox" rows="17">' + Tools.escapeHTML(Storage.exportAllTeams()) + '</textarea></div>';
 				this.$el.html(buf);
+				this.$('.teamedit textarea').focus().select();
 				return;
 			}
 
@@ -532,6 +533,7 @@
 				buf += '</div>';
 			}
 			this.$el.html('<div class="teamwrapper">' + buf + '</div>');
+			this.$(".teamedit textarea").focus().select();
 			if ($(window).width() < 640) this.show();
 		},
 		renderSet: function (set, i) {
@@ -814,7 +816,8 @@
 				.show()
 				.find('textarea')
 				.val(Storage.exportTeam([this.curSet]).trim())
-				.focus();
+				.focus()
+				.select();
 		},
 		closePokemonImport: function (force) {
 			if (!this.wasViewingPokemon) return this.back();


### PR DESCRIPTION
Quoting original forum post: http://www.smogon.com/forums/posts/6295960

> When you open up the Backup/Restore teams page (where you import/export all your teams) can we have everything automatically highlighted? Like how exported sets work on the dex? Most of the time you're never taking only half or anything, and the only use is to copy everything then paste it back after clearing your cookies. This would make that process slightly faster.

This fixes all three cases to focus and select the text. The workflow when importing team(s) is also more staightforward; after clicking Import you can immediately paste.