### PR TITLE
Rematch button: default to the same tier as previous battle

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -728,7 +728,7 @@
 		},
 		closeAndRematch: function () {
 			app.rooms[''].requestNotifications();
-			app.rooms[''].challenge(this.battle.yourSide.name);
+			app.rooms[''].challenge(this.battle.yourSide.name, this.battle.tier);
 			this.close();
 			app.focusRoom('');
 		},


### PR DESCRIPTION
Currently, clicking Rematch when in a different tier always brings up the dialog to challenge the opponent to randombattle.