### PR TITLE
Make the username in PM headers clickable

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -162,7 +162,8 @@
 				var buf = '<div class="pm-window pm-window-' + userid + '" data-userid="' + userid + '" data-name="' + name + '">';
 				buf += '<h3><button class="closebutton" href="' + app.root + 'teambuilder" tabindex="-1"><i class="icon-remove-sign"></i></button>';
 				buf += '<button class="minimizebutton" href="' + app.root + 'teambuilder" tabindex="-1"><i class="icon-minus-sign"></i></button>';
-				buf += group + Tools.escapeHTML(name.substr(1)) + '</h3>';
+				var clickableName = '<span class="username" data-name="' + Tools.escapeHTML(name) + '">' + Tools.escapeHTML(name.substr(1)) + '</span>';
+				buf += group + clickableName + '</h3>';
 				buf += '<div class="pm-log"><div class="inner"></div></div>';
 				buf += '<div class="pm-log-add"><form class="chatbox nolabel"><textarea class="textbox" type="text" size="70" autocomplete="off" name="message"></textarea></form></div></div>';
 				$pmWindow = $(buf).prependTo(this.$pmBox);


### PR DESCRIPTION
One of the suggestions in http://www.smogon.com/forums/posts/6197110 is to make the username in PM headers clickable.

The code to create the clickableName was shamelessly copied and pasted from `client-chat.js`.