### PR TITLE
Add a validate button to the teambuilder

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -509,7 +509,7 @@
 						}
 					}
 					if (curSection) buf += '</optgroup>';
-					buf += '</select></li>';
+					buf += '</select><button name="validate"><i class="icon-check"></i> Validate</button></li>';
 				}
 				if (!this.curSetList.length) {
 					buf += '<li><em>you have no pokemon lol</em></li>';
@@ -656,6 +656,14 @@
 		save: function () {
 			this.saveFlag = true;
 			Storage.saveTeams();
+		},
+		validate: function () {
+			if (!this.curTeam.format) {
+				app.addPopupMessage('You need to pick a format to validate your team.');
+				return;
+			}
+			app.sendTeam(this.curTeam);
+			app.send('/vtm ' + this.curTeam.format);
 		},
 		teamNameChange: function (e) {
 			this.curTeam.name = ($.trim(e.currentTarget.value) || 'Untitled ' + (this.curTeamLoc + 1));

--- a/style/client.css
+++ b/style/client.css
@@ -2018,7 +2018,7 @@ a.ilink:hover {
 }
 .teamchart li.format-select select,
 .teamchart li.format-select option {
-	font: 12pt Verdana, sans-serif;
+	margin-right: 5px;
 }
 
 .majorbutton {


### PR DESCRIPTION
The validate button sends the current team and a validation request to the
server. The server will respond with a positive acknowledgement for valid teams,
or else a list of problems (the same list as when seeking a battle).

NOTE: This PR is dependent on https://github.com/Zarel/Pokemon-Showdown/pull/2150 being pulled in first.
Screenshots: http://imgur.com/a/dVj3F