### PR TITLE
Make tooltips work in instant replays

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -15,7 +15,26 @@
 			this.$chatFrame = this.$el.find('.battle-log');
 			this.$chatAdd = this.$el.find('.battle-log-add');
 			this.$join = null;
+
+			// tooltips
+			var buf = '';
+			var tooltips = {
+				your2: { top: 70, left: 250, width: 80, height: 100 },
+				your1: { top: 85, left: 320, width: 90, height: 100 },
+				your0: { top: 90, left: 390, width: 100, height: 100 },
+				my2: { top: 210, left: 410, width: 140, height: 160 },
+				my1: { top: 210, left: 270, width: 160, height: 160 },
+				my0: { top: 210, left: 130, width: 180, height: 160 }
+			};
+			for (var active in tooltips) {
+				buf += '<div style="position:absolute;';
+				for (var css in tooltips[active]) {
+					buf += css + ':' + tooltips[active][css] + 'px;';
+				}
+				buf += '"' + this.tooltipAttrs(active, 'pokemon', true, true) + '></div>';
+			}
 			this.$foeHint = this.$el.find('.foehint');
+			this.$foeHint.html(buf);
 
 			BattleSound.setMute(Tools.prefs('mute'));
 			this.battle = new Battle(this.$battle, this.$chatFrame);
@@ -194,30 +213,6 @@
 
 			}
 
-			// tooltips
-			var myActive = this.battle.mySide.active;
-			var yourActive = this.battle.yourSide.active;
-			var buf = '';
-			if (yourActive[2]) {
-				buf += '<div style="position:absolute;top:70px;left:250px;width:80px;height:100px;"' + this.tooltipAttrs(yourActive[2].getIdent(), 'pokemon', true, 'foe') + '></div>';
-			}
-			if (yourActive[1]) {
-				buf += '<div style="position:absolute;top:85px;left:320px;width:90px;height:100px;"' + this.tooltipAttrs(yourActive[1].getIdent(), 'pokemon', true, 'foe') + '></div>';
-			}
-			if (yourActive[0]) {
-				buf += '<div style="position:absolute;top:90px;left:390px;width:100px;height:100px;"' + this.tooltipAttrs(yourActive[0].getIdent(), 'pokemon', true, 'foe') + '></div>';
-			}
-			if (myActive[0]) {
-				buf += '<div style="position:absolute;top:210px;left:130px;width:180px;height:160px;"' + this.tooltipAttrs(myActive[0].getIdent(), 'pokemon', true, true) + '></div>';
-			}
-			if (myActive[1]) {
-				buf += '<div style="position:absolute;top:210px;left:270px;width:160px;height:160px;"' + this.tooltipAttrs(myActive[1].getIdent(), 'pokemon', true, true) + '></div>';
-			}
-			if (myActive[2]) {
-				buf += '<div style="position:absolute;top:210px;left:410px;width:140px;height:160px;"' + this.tooltipAttrs(myActive[2].getIdent(), 'pokemon', true, true) + '></div>';
-			}
-			this.$foeHint.html(buf);
-
 			if (this.battle.done) {
 
 				// battle has ended
@@ -373,7 +368,7 @@
 						} else if (!pokemon || pokemon.zerohp) {
 							controls += '<button class="disabled" name="chooseMoveTarget" value="' + (i + 1) + '"><span class="pokemonicon" style="display:inline-block;vertical-align:middle;' + Tools.getIcon('missingno') + '"></span></button> ';
 						} else {
-							controls += '<button name="chooseMoveTarget" value="' + (i + 1) + '"' + this.tooltipAttrs(pokemon.getIdent(), 'pokemon', true, 'foe') + '><span class="pokemonicon" style="display:inline-block;vertical-align:middle;' + Tools.getIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') + '</button> ';
+							controls += '<button name="chooseMoveTarget" value="' + (i + 1) + '"' + this.tooltipAttrs("your" + i, 'pokemon', true, true) + '><span class="pokemonicon" style="display:inline-block;vertical-align:middle;' + Tools.getIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') + '</button> ';
 						}
 					}
 					controls += '<div style="clear:both"></div> </div><div class="switchmenu" style="display:block">';
@@ -1003,7 +998,8 @@
 				break;
 
 			case 'pokemon':
-				var pokemon = this.battle.getPokemon(thing);
+				var side = this.battle[thing.slice(0, -1) + "Side"];
+				var pokemon = side.active[thing.slice(-1)];
 				if (!pokemon) return;
 				/* falls through */
 			case 'sidepokemon':

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1009,7 +1009,7 @@
 					if (!pokemon) {
 						pokemon = this.myPokemon[parseInt(thing)];
 						battlePokemon = this.battle.getPokemon('other: old: ' + pokemon.ident, pokemon.details);
-					} else if (pokemon.side === this.battle.mySide) {
+					} else if (this.controlsShown && pokemon.side === this.battle.mySide) {
 						myPokemon = this.myPokemon[pokemon.slot];
 					}
 				}
@@ -1052,11 +1052,15 @@
 				if (pokemon.maxhp == 48 && isActive) exacthp = ' <small>(' + pokemon.hp + '/' + pokemon.maxhp + ' pixels)</small>';
 				text += '<p>HP: ' + pokemon.hpDisplay() + exacthp + (pokemon.status ? ' <span class="status ' + pokemon.status + '">' + pokemon.status.toUpperCase() + '</span>' : '') + '</p>';
 				if (myPokemon) {
-					text += '<p>';
 					if (this.battle.gen > 2) {
-						text += 'Ability: ' + Tools.getAbility(pokemon.ability || myPokemon.baseAbility).name + ' / ';
+						text += '<p>Ability: ' + Tools.getAbility(myPokemon.baseAbility).name;
+						if (myPokemon.item) {
+							text += ' / Item: ' + Tools.getItem(myPokemon.item).name;
+						}
+						text += '</p>';
+					} else if (myPokemon.item) {
+						text += '<p> / Item: ' + Tools.getItem(myPokemon.item).name + '</p>';
 					}
-					text += 'Item: ' + Tools.getItem(myPokemon.item).name + '</p>';
 					text += '<p>' + myPokemon.stats['atk'] + '&nbsp;Atk /&nbsp;' + myPokemon.stats['def'] + '&nbsp;Def /&nbsp;' + myPokemon.stats['spa'];
 					if (this.battle.gen === 1) {
 						text += '&nbsp;Spc /&nbsp;';


### PR DESCRIPTION
During an instant replay the controls are not updated and therefore the tooltips don't work, unless you are lucky and the battle was forfeited with all the Pokémon still playing.

By setting up the tooltips prior to the start we can ensure that they will always work. I had to change the way the Pokémon is selected as `Battle.getPokemon` works on the logical rather than the visual sides and also if you give it a fainted Pokémon it will happily substitute another Pokémon for you. The new code will automatically ignore fainted Pokémon or Pokémon that are out of range (e.g. position 2 in singles).

The `thing` for the `'pokemon'` tooltip is now a concatenation of either `'my'` or `'your'` depending on the visual side and the integer offset in the active array, thus in doubles the possible values are `my0`, `my1`, `your0` and `your1`.

The tooltips are created with a loop to make it easier to see what's going on, rather than using a large unreadable block of HTML.

There is one other place that field tooltips are used and that is when selecting the target of a move in doubles or triples, so I have adapted that case accordingly.