### PR TITLE
Allow spectators to switch sides

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -2647,6 +2647,7 @@ var Battle = (function () {
 			if (this.turnCallback) this.turnCallback(this);
 			if (this.fastForward > -1 && turnnum >= this.fastForward) {
 				this.fastForwardOff();
+				if (this.endCallback) this.endCallback(this);
 			}
 			return;
 		}

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -189,7 +189,12 @@
 			} else if (this.battle.playbackState === 2 || this.battle.playbackState === 3) {
 
 				// battle is playing or paused
-				this.$controls.html('<p><button name="skipTurn">Skip turn <i class="fa fa-step-forward"></i></button><button name="goToEnd">Go to last turn <i class="fa fa-fast-forward"></i></button></p>');
+				if (this.side) {
+					// is a player
+					this.$controls.html('<p><button name="skipTurn">Skip turn <i class="fa fa-step-forward"></i></button><button name="goToEnd">Go to last turn <i class="fa fa-fast-forward"></i></button></p>');
+				} else {
+					this.$controls.html('<p><button name="switchSides">Switch sides <i class="fa fa-random"></i></button> <button name="skipTurn">Skip turn <i class="fa fa-step-forward"></i></button> <button name="goToEnd">Go to last turn <i class="fa fa-fast-forward"></i></button></p>');
+				}
 				return;
 
 			}
@@ -225,7 +230,7 @@
 					// was a player
 					this.$controls.html('<div class="controls"><p><em><button name="instantReplay"><i class="fa fa-undo"></i> Instant Replay</button> <button name="saveReplay"><i class="fa fa-upload"></i> Share replay</button></p><p><button name="closeAndMainMenu"><strong>Main menu</strong><br /><small>(closes this battle)</small></button> <button name="closeAndRematch"><strong>Rematch</strong><br /><small>(closes this battle)</small></button></p></div>');
 				} else {
-					this.$controls.html('<div class="controls"><p><em><button name="instantReplay"><i class="fa fa-undo"></i> Instant Replay</button> <button name="saveReplay"><i class="fa fa-upload"></i> Share replay</button></p></div>');
+					this.$controls.html('<div class="controls"><p><em><button name="switchSides">Switch sides <i class="fa fa-random"></i></button> <button name="instantReplay"><i class="fa fa-undo"></i> Instant Replay</button> <button name="saveReplay"><i class="fa fa-upload"></i> Share replay</button></p></div>');
 				}
 
 			} else if (!this.battle.mySide.initialized || !this.battle.yourSide.initialized) {
@@ -264,7 +269,7 @@
 			} else {
 
 				// full battle
-				this.$controls.html('<p><em>Waiting for players...</em></p>');
+				this.$controls.html('<p><em><button name="switchSides">Switch sides <i class="fa fa-random"></i></button> Waiting for players...</em></p>');
 
 			}
 
@@ -703,6 +708,19 @@
 		},
 		saveReplay: function () {
 			this.send('/savereplay');
+		},
+		switchSides: function () {
+			if (this.battle.done) {
+				this.battle.reset(true);
+				this.battle.switchSides();
+				this.battle.fastForwardTo(-1);
+			} else {
+				var turn = this.battle.turn;
+				this.battle.reset();
+				this.battle.switchSides();
+				if (turn) this.battle.fastForwardTo(turn);
+				this.battle.play();
+			}
 		},
 		instantReplay: function () {
 			this.hideTooltip();


### PR DESCRIPTION
Apparently it's been suggested before, and it's definitely been suggested since, but the suggestion I found was http://www.smogon.com/forums/posts/5343275

Note that if you switch side while the battle is animating it will skip to the end; I couldn't work out how to skip to the current turn without restarting the background music.