### PR TITLE
Firefox has magic button overflow

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -1446,6 +1446,10 @@ a.ilink:hover {
 	text-align: left;
 	cursor: pointer;
 }
+/* Remove Firefox's magic padding */
+.userlist li button::-moz-focus-inner {
+	padding: 0;
+}
 .userlist li button:hover {
 	background: #dce4ec;
 }


### PR DESCRIPTION
Firefox has this deliberately weird behaviour in that its buttons have 2px of magic padding - the padding is only there if it can make room for it.

This means that long names in the user list don't get the padding, thus misaligning them as seen here (line added for clarity):
![screen shot 2015-09-22 at 17 02 35](https://cloud.githubusercontent.com/assets/13849513/10048787/85517ca2-620c-11e5-87e5-d5675d7d5eee.png)

Maybe there was a time when these needed to be buttons but it doesn't seem to be necessary now so I just changed them to be div elements instead as that seemed simplest.