### PR TITLE
Clear known Pokémon when resetting battle

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -1238,11 +1238,9 @@ var Side = (function () {
 	};
 
 	Side.prototype.reset = function () {
+		this.pokemon = [];
 		this.updateSprites();
 		this.sideConditions = {};
-		for (var i = 0; i < this.pokemon.length; i++) {
-			this.pokemon[i].reset();
-		}
 	};
 	Side.prototype.updateSprites = function () {
 		this.z = (this.n ? 200 : 0);


### PR DESCRIPTION
The team as displayed at the end of the battle is currently retained for the instant replay. This makes no difference when team preview is active as the act of instant replaying the team preview resets the team display.
However a correctness issue therefore arises for formats without team preview as the team should be revealed during the course of the replay as they would have been during the battle.
Another aspect of the problem arises when one of the Pokémon mega-evolves; the instant replay does not replace it with its base form so the duplicate Mega form remains throughout the instant replay.