### PR TITLE
Keep the sound playing when switching sides

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5878,7 +5878,7 @@ var Battle = (function () {
 		}
 		this.soundPause();
 	};
-	Battle.prototype.play = function () {
+	Battle.prototype.play = function (dontResetSound) {
 		if (this.fastForward) {
 			this.paused = false;
 			this.playbackState = 5;
@@ -5888,7 +5888,7 @@ var Battle = (function () {
 				this.soundStop();
 			}
 			this.playbackState = 2;
-			if (!this.done) {
+			if (!dontResetSound && !this.done) {
 				this.soundStart();
 			}
 			this.nextActivity();

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -711,10 +711,10 @@
 				this.battle.fastForwardTo(-1);
 			} else {
 				var turn = this.battle.turn;
-				this.battle.reset();
+				this.battle.reset(true);
 				this.battle.switchSides();
 				if (turn) this.battle.fastForwardTo(turn);
-				this.battle.play();
+				this.battle.play(true);
 			}
 		},
 		instantReplay: function () {


### PR DESCRIPTION
`battle.reset` already has a `dontResetSound` flag so I thought I might as well give `battle.play` the flag too.