### PR TITLE
Tone down excessive notifications

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1302,7 +1302,7 @@
 				var notifyTitle = "Mentioned by " + name + (this.id === 'lobby' ? '' : " in " + this.title);
 				var notifyText = $lastMessage.html().indexOf('<span class="spoiler">') >= 0 ? '(spoiler)' : $lastMessage.children().last().text();
 				this.notifyOnce(notifyTitle, "\"" + notifyText + "\"", 'highlight');
-			} else {
+			} else if (name !== '~') { // |c:|~| prefixes a system message
 				this.subtleNotifyOnce();
 			}
 

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1289,7 +1289,21 @@
 				return; // PMs independently notify in the man menu; no need to make them notify again with `inchatpm`.
 			}
 
-			var isHighlighted = userid !== app.user.get('userid') && this.getHighlight(message);
+			var lastMessageDates = Tools.prefs('logtimes') || (Tools.prefs('logtimes', {}), Tools.prefs('logtimes'));
+			if (!lastMessageDates[Config.server.id]) lastMessageDates[Config.server.id] = {};
+			var lastMessageDate = lastMessageDates[Config.server.id][this.id] || 0;
+			var mayNotify = msgTime > lastMessageDate;
+
+			if (app.focused && (this === app.curSideRoom || this === app.curRoom)) {
+				this.lastMessageDate = 0;
+				lastMessageDates[Config.server.id][this.id] = msgTime;
+				Tools.prefs.save();
+			} else {
+				// To be saved on focus
+				this.lastMessageDate = Math.max(this.lastMessageDate || 0, msgTime);
+			}
+
+			var isHighlighted = mayNotify && userid !== app.user.get('userid') && this.getHighlight(message);
 			var parsedMessage = Tools.parseChatMessage(message, name, ChatRoom.getTimestamp('chat', msgTime), isHighlighted);
 			if (!$.isArray(parsedMessage)) parsedMessage = [parsedMessage];
 			for (var i = 0; i < parsedMessage.length; i++) {
@@ -1302,7 +1316,7 @@
 				var notifyTitle = "Mentioned by " + name + (this.id === 'lobby' ? '' : " in " + this.title);
 				var notifyText = $lastMessage.html().indexOf('<span class="spoiler">') >= 0 ? '(spoiler)' : $lastMessage.children().last().text();
 				this.notifyOnce(notifyTitle, "\"" + notifyText + "\"", 'highlight');
-			} else if (name !== '~') { // |c:|~| prefixes a system message
+			} else if (mayNotify && name !== '~') { // |c:|~| prefixes a system message
 				this.subtleNotifyOnce();
 			}
 

--- a/js/client.js
+++ b/js/client.js
@@ -2113,6 +2113,14 @@
 			} else {
 				this.notifications[tag] = {};
 			}
+
+			if (this.lastMessageDate) {
+				// Mark chat messages as read to avoid double-notifying on reload
+				var lastMessageDates = Tools.prefs('logtimes') || (Tools.prefs('logtimes', {}), Tools.prefs('logtimes'));
+				if (!lastMessageDates[Config.server.id]) lastMessageDates[Config.server.id] = {};
+				lastMessageDates[Config.server.id][this.id] = this.lastMessageDate;
+				Tools.prefs.save();
+			}
 		},
 		dismissAllNotifications: function (skipUpdate) {
 			if (!this.notifications && !this.subtleNotification) {
@@ -2134,6 +2142,14 @@
 				this.notificationClass = '';
 				if (skipUpdate) return;
 				app.topbar.updateTabbar();
+			}
+
+			if (this.lastMessageDate) {
+				// Mark chat messages as read to avoid double-notifying on reload
+				var lastMessageDates = Tools.prefs('logtimes') || (Tools.prefs('logtimes', {}), Tools.prefs('logtimes'));
+				if (!lastMessageDates[Config.server.id]) lastMessageDates[Config.server.id] = {};
+				lastMessageDates[Config.server.id][this.id] = this.lastMessageDate;
+				Tools.prefs.save();
 			}
 		},
 		clickNotification: function (tag) {


### PR DESCRIPTION
- System chat messages (|c|~|) no longer arise subtle notifications
- Do not notify again for the same chat messages on reload: last message date is stored in preferences for each room.