### PR TITLE
Show the Rooms tab in the test client

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -355,9 +355,6 @@
 
 			// down
 			// if (document.location.hostname === 'play.pokemonshowdown.com') this.down = 'dos';
-			if (document.location.hostname === 'play.pokemonshowdown.com') {
-				app.supports['rooms'] = true;
-			}
 
 			this.topbar = new Topbar({el: $('#header')});
 			this.addRoom('');
@@ -1247,6 +1244,7 @@
 			if (data) {
 				this.roomsData = data;
 			}
+			app.topbar.updateTabbar();
 		},
 		clearGlobalListeners: function () {
 			// jslider doesn't clear these when it should,


### PR DESCRIPTION
The client doesn't update the tab bar when the server sends it the rooms, so you don't see the rooms tab unless you do something else that causes the tab bar to update.

Since the client now updates the tab bar automatically, you don't need to manually support the rooms tab, but I can remove that hunk if you prefer.