### PR TITLE
Don't let room names overflow the tablist popup

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -365,6 +365,9 @@ a.subtle:hover {
 	text-align: left;
 	border-radius: 0;
 	display: block;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .tablist li:first-child .button {
 	border-top-left-radius: 5px;


### PR DESCRIPTION
If you're, for instance, watching an Anything Goes battle between allaboutthatpanda and Sammichinmyhead (I kid you not), you'll find that the text doesn't fit in the tablist popup.