### PR TITLE
Show the pretty format name in the battle tab

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -1893,7 +1893,7 @@
 							name = '(empty room)';
 						}
 					}
-					return buf + '<i class="text">' + formatid + '</i><span>' + name + '</span></a><a class="closebutton" href="' + app.root + id + '"><i class="fa fa-times-circle"></i></a></li>';
+					return buf + '<i class="text">' + Tools.escapeFormat(formatid) + '</i><span>' + name + '</span></a><a class="closebutton" href="' + app.root + id + '"><i class="fa fa-times-circle"></i></a></li>';
 				} else {
 					return buf + '<i class="fa fa-comment-o"></i> <span>' + (Tools.escapeHTML(room.title) || (id === 'lobby' ? 'Lobby' : id)) + '</span></a><a class="closebutton" href="' + app.root + id + '"><i class="fa fa-times-circle"></i></a></li>';
 				}


### PR DESCRIPTION
Tabs for battles currently show the format id and the players. I thought it would look slightly nicer if we used the format name instead. Example:

    _______________________
    |      ounomega      X|
    |junzheng5 vs. OVOOHKO|
    _______________________
    |    OU (no Mega)    X|
    |junzheng5 vs. OVOOHKO|