### PR TITLE
Update chatbox focus text to reflect reality

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -59,9 +59,7 @@
 
 		focusText: function () {
 			if (this.$chatbox) {
-				var rooms = app.roomList;
-				if (this === app.curSideRoom) rooms = app.sideRoomList;
-				else if (!app.curSideRoom) rooms = rooms.concat(app.sideRoomList);
+				var rooms = app.roomList.concat(app.sideRoomList);
 				var roomIndex = rooms.indexOf(this);
 				var roomLeft = rooms[roomIndex - 1];
 				var roomRight = rooms[roomIndex + 1];

--- a/js/client.js
+++ b/js/client.js
@@ -1654,47 +1654,20 @@
 		},
 		focusRoomBy: function (room, amount) {
 			this.arrowKeysUsed = true;
+			var rooms = this.roomList.concat(this.sideRoomList);
 			if (room && room.id === 'rooms') {
-				if (amount > 0) return false;
-				if (this.sideRoomList.length) {
-					this.focusRoom(this.sideRoomList[this.sideRoomList.length - 1].id);
-					return true;
-				}
-				if (this.roomList.length) {
-					this.focusRoom(this.roomList[this.roomList.length - 1].id);
-					return true;
-				}
-				return false;
-			}
-			var index = this.roomList.indexOf(room);
-			if (index >= 0) {
-				var newIndex = index + amount;
-				if (newIndex < 0) return false;
-				if (newIndex >= this.roomList.length) {
-					if (!this.sideRoomList.length) {
-						this.joinRoom('rooms');
-						return true;
-					}
-					this.focusRoom(this.sideRoomList[0].id);
-					return true;
-				}
-				if (!this.roomList[newIndex]) return false;
-				this.focusRoom(this.roomList[newIndex].id);
+				if (!rooms.length) return false;
+				this.focusRoom(rooms[amount < 0 ? rooms.length - 1 : 0].id);
 				return true;
 			}
-			index = this.sideRoomList.indexOf(room);
+			var index = rooms.indexOf(room);
 			if (index >= 0) {
 				var newIndex = index + amount;
-				if (newIndex >= this.sideRoomList.length) {
+				if (!rooms[newIndex]) {
 					this.joinRoom('rooms');
 					return true;
 				}
-				if (newIndex < 0) {
-					if (!this.roomList.length) return false;
-					this.focusRoom(this.roomList[this.roomList.length - 1].id);
-				}
-				if (!this.sideRoomList[newIndex]) return false;
-				this.focusRoom(this.sideRoomList[newIndex].id);
+				this.focusRoom(rooms[newIndex].id);
 				return true;
 			}
 			return false;


### PR DESCRIPTION
The Left/Right room navigation was changed so that it always loops through all rooms (including the Rooms room) even when the window is wide enough to tab each set of rooms separately. This updates the chatbox focus text to match.

That code uses the roomList.concat(sideRoomList) trick to create a master list of all chat rooms. While I was there I let the scope creep and applied the trick to the focusNextRoom code too. And then for good measure I implemented a request that the rooms should wrap around so that Right on the Rooms room should focus the leftmost room and vice versa, because that actually ended up further simplifying the code.