### PR TITLE
Omit forfeit dialog when leaving instant replay.

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -2124,6 +2124,7 @@ var Battle = (function () {
 		this.sides = [];
 		this.lastMove = '';
 		this.gen = 6;
+		this.replay = 0;
 
 		this.frameElem = frame;
 		this.logFrameElem = logFrame;
@@ -2254,6 +2255,7 @@ var Battle = (function () {
 		this.weatherMinTimeLeft = 0;
 		this.pseudoWeather = [];
 		this.lastMove = '';
+		this.replay = 1;
 
 		// DOM state
 		this.frameElem.empty();

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -71,7 +71,7 @@
 			if (this.battle) this.battle.destroy();
 		},
 		requestLeave: function (e) {
-			if (this.side && this.battle && !this.battle.done && !this.battle.forfeitPending) {
+			if (this.side && this.battle && !this.battle.done && !this.battle.forfeitPending && !this.battle.replay) {
 				app.addPopup(ForfeitPopup, {room: this, sourceEl: e && e.currentTarget});
 				return false;
 			}


### PR DESCRIPTION
If user finished a battle, leaving the room during an instant
replay would open an unneeded forfeit dialog.