### PR TITLE
Fix item display in Gen2 battles

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1146,7 +1146,7 @@
 						}
 						text += '</p>';
 					} else if (myPokemon.item) {
-						text += '<p> / Item: ' + Tools.getItem(myPokemon.item).name + '</p>';
+						text += '<p>Item: ' + Tools.getItem(myPokemon.item).name + '</p>';
 					}
 					text += '<p>' + myPokemon.stats['atk'] + '&nbsp;Atk /&nbsp;' + myPokemon.stats['def'] + '&nbsp;Def /&nbsp;' + myPokemon.stats['spa'];
 					if (this.battle.gen === 1) {


### PR DESCRIPTION
An earlier version of PR #476 showed the client's idea of the item even while the animation was playing. When this feature was removed an erroneous `/` got left behind in the tooltip for Generation 2.