### PR TITLE
Update teams on deletions, undeletions, and drops

### DIFF
--- a/js/client-chat-tournament.js
+++ b/js/client-chat-tournament.js
@@ -208,13 +208,7 @@
 				return;
 			}
 
-			var teamIndex = undefined;
-			if (!forceFormatChange && this.$teamSelect.children().val()) {
-				teamIndex = parseInt(this.$teamSelect.children().val());
-				if (isNaN(teamIndex)) teamIndex = undefined;
-			}
-
-			this.$teamSelect.html(app.rooms[''].renderTeams(this.info.format, teamIndex));
+			this.$teamSelect.html(app.rooms[''].renderTeams.call(this, this.info.format));
 			this.$teamSelect.children().data('type', 'teamSelect');
 			this.$teamSelect.children().attr('name', 'tournamentButton');
 			this.$teamSelect.show();
@@ -266,6 +260,7 @@
 					var type = data[1];
 					this.room.$chat.append("<div class=\"notice tournament-message-create\">" + format + " " + Tools.escapeHTML(type) + " Tournament created.</div>");
 					this.room.notifyOnce("Tournament created", "Room: " + this.room.title + "\nFormat: " + format + "\nType: " + type, 'tournament-create');
+					this.curTeamIndex = 0;
 					this.updateTeams();
 					break;
 

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -561,10 +561,9 @@
 			var self = this;
 
 			this.$('button[name=team]').each(function (i, el) {
-				var val = el.value;
-				if (val === 'random') return;
+				if (el.value === 'random') return;
 				var format = $(el).closest('form').find('button[name=format]').val();
-				$(el).replaceWith(self.renderTeams(format, val));
+				$(el).replaceWith(self.renderTeams(format));
 			});
 		},
 		updateRightMenu: function () {
@@ -690,7 +689,7 @@
 			return '<button class="select formatselect' + (noChoice ? ' preselected' : '') + '" name="format" value="' + formatid + '"' + (noChoice ? ' disabled' : '') + '>' + Tools.escapeFormat(formatid) + '</button>';
 		},
 		curTeamFormat: '',
-		curTeamIndex: -1,
+		curTeamIndex: 0,
 		renderTeams: function (formatid, teamIndex) {
 			if (!Storage.teams || !window.BattleFormats) {
 				return '<button class="select teamselect" name="team" disabled><em>Loading...</em></button>';
@@ -896,8 +895,12 @@
 			var formatid = this.sourceEl.closest('form').find('button[name=format]').val();
 			i = +i;
 			this.sourceEl.val(i).html(TeamPopup.renderTeam(i));
-			app.rooms[''].curTeamIndex = i;
-			app.rooms[''].curTeamFormat = formatid;
+			if (this.sourceEl[0].offsetParent.className === 'mainmenuwrapper') {
+				app.rooms[''].curTeamIndex = i;
+				app.rooms[''].curTeamFormat = formatid;
+			} else if (this.sourceEl[0].offsetParent.className === 'tournament-box active') {
+				app.curSideRoom.tournamentBox.curTeamIndex = i;
+			}
 			this.close();
 		}
 	}, {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -237,6 +237,16 @@
 			i = +i;
 			this.deletedTeamLoc = i;
 			this.deletedTeam = teams.splice(i, 1)[0];
+			for (var room in app.rooms) {
+				var selection = app.rooms[room].$('button.teamselect').val();
+				if (!selection || selection === 'random') continue;
+				var obj = app.rooms[room].id === "" ? app.rooms[room] : app.rooms[room].tournamentBox;
+				if (i < obj.curTeamIndex) {
+					obj.curTeamIndex--;
+				} else if (i === obj.curTeamIndex) {
+					obj.curTeamIndex = -1;
+				}
+			}
 			Storage.deleteTeam(this.deletedTeam);
 			app.user.trigger('saveteams');
 			this.update();
@@ -244,6 +254,16 @@
 		undoDelete: function () {
 			if (this.deletedTeamLoc >= 0) {
 				teams.splice(this.deletedTeamLoc, 0, this.deletedTeam);
+				for (var room in app.rooms) {
+					var selection = app.rooms[room].$('button.teamselect').val();
+					if (!selection || selection === 'random') continue;
+					var obj = app.rooms[room].id === "" ? app.rooms[room] : app.rooms[room].tournamentBox;
+					if (this.deletedTeamLoc < obj.curTeamIndex + 1) {
+						obj.curTeamIndex++;
+					} else if (obj.curTeamIndex === -1) {
+						obj.curTeamIndex = this.deletedTeamLoc;
+					}
+				}
 				var undeletedTeam = this.deletedTeam;
 				this.deletedTeam = null;
 				this.deletedTeamLoc = -1;
@@ -256,6 +276,12 @@
 			Storage.importTeam(this.$('.teamedit textarea').val(), true);
 			teams = Storage.teams;
 			Storage.saveAllTeams();
+			for (var room in app.rooms) {
+				var selection = app.rooms[room].$('button.teamselect').val();
+				if (!selection || selection === 'random') continue;
+				var obj = app.rooms[room].id === "" ? app.rooms[room] : app.rooms[room].tournamentBox;
+				obj.curTeamIndex = 0;
+			}
 			this.back();
 		},
 		"new": function () {
@@ -276,6 +302,12 @@
 				iconCache: ''
 			};
 			teams.unshift(newTeam);
+			for (var room in app.rooms) {
+				var selection = app.rooms[room].$('button.teamselect').val();
+				if (!selection || selection === 'random') continue;
+				var obj = app.rooms[room].id === "" ? app.rooms[room] : app.rooms[room].tournamentBox;
+				obj.curTeamIndex++;
+			}
 			this.edit(0);
 		},
 		"import": function () {
@@ -355,6 +387,18 @@
 				var team = Storage.teams[originalLoc];
 				Storage.teams.splice(originalLoc, 1);
 				Storage.teams.splice(newLoc, 0, team);
+				for (var room in app.rooms) {
+					var selection = app.rooms[room].$('button.teamselect').val();
+					if (!selection || selection === 'random') continue;
+					var obj = app.rooms[room].id === "" ? app.rooms[room] : app.rooms[room].tournamentBox;
+					if (originalLoc === obj.curTeamIndex) {
+						obj.curTeamIndex = newLoc;
+					} else if (originalLoc > obj.curTeamIndex && newLoc <= obj.curTeamIndex) {
+						obj.curTeamIndex++;
+					} else if (originalLoc < obj.curTeamIndex && newLoc >= obj.curTeamIndex) {
+						obj.curTeamIndex--;
+					}
+				}
 				Storage.saveTeams();
 				app.user.trigger('saveteams');
 			}

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -238,6 +238,7 @@
 			this.deletedTeamLoc = i;
 			this.deletedTeam = teams.splice(i, 1)[0];
 			Storage.deleteTeam(this.deletedTeam);
+			app.user.trigger('saveteams');
 			this.update();
 		},
 		undoDelete: function () {
@@ -247,6 +248,7 @@
 				this.deletedTeam = null;
 				this.deletedTeamLoc = -1;
 				Storage.saveTeam(undeletedTeam);
+				app.user.trigger('saveteams');
 				this.update();
 			}
 		},
@@ -353,6 +355,8 @@
 				var team = Storage.teams[originalLoc];
 				Storage.teams.splice(originalLoc, 1);
 				Storage.teams.splice(newLoc, 0, team);
+				Storage.saveTeams();
+				app.user.trigger('saveteams');
 			}
 
 			// possibly half-works-around a hover issue in


### PR DESCRIPTION
Fixes #443.

Also: dragging and dropping teams did not update `showdown_teams` in localStorage. It does so now.