### PR TITLE
Keep sound playing when switching sides during team preview

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5949,7 +5949,7 @@ var Battle = (function () {
 			this.playbackState = 5;
 		} else if (this.paused) {
 			this.paused = false;
-			if (this.playbackState === 1) {
+			if (!dontResetSound && this.playbackState === 1) {
 				this.soundStop();
 			}
 			this.playbackState = 2;


### PR DESCRIPTION
Not sure why resetting the battle during team preview turns the sound off, but it does, and switching sides doesn't want that.