### PR TITLE
Fix Team Import/Export barely visible > 640px width

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -2469,6 +2469,7 @@ a.ilink.yours {
 }
 .teamwrapper.scaled {
 	width: 640px;
+	height: 100%;
 }
 .teamwrapper.scaled .teamchartbox {
 	bottom: auto;


### PR DESCRIPTION
Yeah, you could still drag the resizer down, but this make it less worse.