### PR TITLE
Adjust the top of the tooltip to fit in the window

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1227,6 +1227,8 @@
 				break;
 			}
 			$('#tooltipwrapper').html(text).appendTo(document.body);
+			var height = $('#tooltipwrapper .tooltip').height();
+			if (height > y) $('#tooltipwrapper').css('top', height);
 		},
 		hideTooltip: function () {
 			$('#tooltipwrapper').html('');


### PR DESCRIPTION
Now that move tracker increases the height of tooltips, it's possible for them to overflow the top of the window. The worst case would be something like a Greninja with an item and four moves.