### PR TITLE
Allow tab completion to work in battles

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -2169,6 +2169,7 @@ var Battle = (function () {
 		// external
 		this.resumeButton = this.play;
 
+		this.users = {};
 		this.preloadCache = {};
 
 		this.preloadEffects();
@@ -5679,12 +5680,14 @@ var Battle = (function () {
 			break;
 		case 'join':
 		case 'j':
+			this.users[toUserid(args[1])] = ' ' + args[1];
 			if (!this.ignoreSpects) {
 				this.log('<div class="chat"><small>' + Tools.escapeHTML(args[1]) + ' joined.</small></div>', preempt);
 			}
 			break;
 		case 'leave':
 		case 'l':
+			delete this.users[toUserid(args[1])];
 			if (!this.ignoreSpects) {
 				this.log('<div class="chat"><small>' + Tools.escapeHTML(args[1]) + ' left.</small></div>', preempt);
 			}

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -38,6 +38,7 @@
 
 			BattleSound.setMute(Tools.prefs('mute'));
 			this.battle = new Battle(this.$battle, this.$chatFrame);
+			this.users = this.battle.users;
 
 			this.$chat = this.$chatFrame.find('.inner');
 


### PR DESCRIPTION
Console rooms know about autocompletion but only chat rooms maintain a user list. This makes the battle maintain a dummy user list (thus the necessity to prepend `' '` to the user before adding it to the list).