### PR TITLE
Always remove the element when a sprite faints

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -1146,6 +1146,11 @@ var Sprite = (function () {
 			opacity: 0
 		}, 'accel');
 		this.battle.activityWait(this.elem);
+		var self = this;
+		this.elem.promise().done(function() {
+			self.elem.remove();
+			self.elem = null;
+		});
 	};
 	Sprite.prototype.delay = function (time) {
 		this.elem.delay(time);


### PR DESCRIPTION
I was in a random triples battle today and noticed that one of my opponent's fainted Pokémon reappeared on screen for some reason. After the battle I instant replayed and then skipped to the end and it didn't appear, but if I then replayed it though at normal speed then it did. I'm assuming that this is because the element should have been removed after the Pokémon fainted, as happens during fast forward.
I tried adding my callback first but that seems to cancel the activity callback so I moved it to happen afterwards instead.