### PR TITLE
Don't track users in replays

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -2174,7 +2174,6 @@ var Battle = (function () {
 		// external
 		this.resumeButton = this.play;
 
-		this.users = {};
 		this.preloadCache = {};
 
 		this.preloadEffects();
@@ -5685,14 +5684,14 @@ var Battle = (function () {
 			break;
 		case 'join':
 		case 'j':
-			this.users[toUserid(args[1])] = ' ' + args[1];
+			if (this.roomid) app.rooms[this.roomid].users[toUserid(args[1])] = ' ' + args[1];
 			if (!this.ignoreSpects) {
 				this.log('<div class="chat"><small>' + Tools.escapeHTML(args[1]) + ' joined.</small></div>', preempt);
 			}
 			break;
 		case 'leave':
 		case 'l':
-			delete this.users[toUserid(args[1])];
+			if (this.roomid) delete app.rooms[this.roomid].users[toUserid(args[1])];
 			if (!this.ignoreSpects) {
 				this.log('<div class="chat"><small>' + Tools.escapeHTML(args[1]) + ' left.</small></div>', preempt);
 			}

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -38,7 +38,8 @@
 
 			BattleSound.setMute(Tools.prefs('mute'));
 			this.battle = new Battle(this.$battle, this.$chatFrame);
-			this.users = this.battle.users;
+			this.battle.roomid = this.id;
+			this.users = {};
 
 			this.$chat = this.$chatFrame.find('.inner');
 


### PR DESCRIPTION
As requested in PR #527 this moves the onus for enabling user tracking from the battle to the room.