### PR TITLE
Fix issue with team select image not updating.

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -74,7 +74,17 @@
 			app.on('init:formats', this.updateFormats, this);
 			this.updateFormats();
 
-			app.user.on('saveteams', this.updateTeams, this);
+			app.user.on('saveteams', function(){
+        this.updateTeams;
+        var $searchForm = $('.mainmenu button.big').closest('form');
+			  var $formatButton = $searchForm.find('button[name=format]');
+		  	var $teamButton = $searchForm.find('button[name=team]');
+        var teamId = $teamButton.val();
+        var format = $formatButton.val();
+        $teamButton.replaceWith(this.renderTeams($formatButton.val(), $teamButton.val())); //just calling updateTeams doesn't work for some reason, but manually doing this works. 
+        console.log("reRendered");
+      }, this) //When teams are saved, forcibly rerender current team.
+
 		},
 
 		addPseudoPM: function (options) {
@@ -910,6 +920,7 @@
 				return buf;
 			}
 			var team = Storage.teams[i];
+      if((i+1) > Storage.teams.length) return 'Please select a new team'; //Quick workaround to make sure deleting the last team won't return the corrupted team message.
 			if (!team) return 'Error: Corrupted team';
 			var buf = '' + Tools.escapeHTML(team.name) + '<br />';
 			buf += Storage.getTeamIcons(team);

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -77,12 +77,11 @@
 			app.user.on('saveteams', function(){
         this.updateTeams;
         var $searchForm = $('.mainmenu button.big').closest('form');
-			  var $formatButton = $searchForm.find('button[name=format]');
+		    var $formatButton = $searchForm.find('button[name=format]');
 		  	var $teamButton = $searchForm.find('button[name=team]');
         var teamId = $teamButton.val();
         var format = $formatButton.val();
         $teamButton.replaceWith(this.renderTeams($formatButton.val(), $teamButton.val())); //just calling updateTeams doesn't work for some reason, but manually doing this works. 
-        console.log("reRendered");
       }, this) //When teams are saved, forcibly rerender current team.
 
 		},

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -200,6 +200,9 @@
 			buf += '</div>';
 
 			this.$el.html(buf);
+      app.user.trigger("saveteams"); //Make sure if we update something on this end it updates on the main menu end. This includes deletes which were not calling saveteams.
+      //One side effect is that reordering your teams will change which team will be currently selected.
+      //This can be worked around by only triggering saveteams when deleting something, but I will leave this here for now.
 		},
 		show: function () {
 			Room.prototype.show.apply(this, arguments);


### PR DESCRIPTION
Some minor workarounds to fix #443. Now, the teams will update whenever the team images on the teambuilder update, so including team swaps and deletions. Also, only calling updateTeams() did not  work when I tested it so I added the code to update the teams inline on the .on() function. Finally, I added a new message for when the teamIndex is over the teams size, so that users weren't confronted with a "Corrupted team" message when they deleted their last team while the index was pointing at it.