### PR TITLE
Prevent move tooltips from covering the buttons

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1065,7 +1065,12 @@
 					"sound": "Has no effect on Pokemon with the Ability Soundproof."
 				};
 				if (move.desc) {
-					text += '<p class="section">' + move.desc;
+					text += '<p class="section">';
+					if (move.shortDesc && ($(window).width() < 640 || $(window).height() < 580)) {
+						text += move.shortDesc;
+					} else {
+						text += move.desc;
+					}
 					for (var i in move.flags) {
 						if (i === 'distance' && move.target !== 'any') continue;
 						text += " " + flags[i];


### PR DESCRIPTION
Clicking moves with long descriptions was next to impossible on mobile
devices after 1114cb3, so the short move descriptions are now used
instead on smaller resolutions.

*Edit*: If https://github.com/Zarel/Pokemon-Showdown-Client/pull/534 allows for clicking through tooltips on touch screens, feel free to close this since it would be unnecessary.