### PR TITLE
Tooltips should be ignored by the mouse

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -1864,6 +1864,7 @@ a.ilink.yours {
 	left: 100px;
 	text-align: left;
 	color: black;
+	pointer-events: none;
 }
 #tooltipwrapper .tooltipinner {
 	position: relative;


### PR DESCRIPTION
I've noticed that when a tooltip gets very big then the mouse can get confused if it overlaps the trigger area. By using this slightly non-standard but apparently well supported style we can cause the tooltips to be ignored allowing you to mouse over (and indeed click through if necessary) the entire trigger area even if the tooltip overlaps it.
This may also improve the behaviour on touch screens but I don't have one to try it with.