### PR TITLE
Prevent duplicate challenge notifications

### DIFF
--- a/js/client-chat-tournament.js
+++ b/js/client-chat-tournament.js
@@ -384,14 +384,16 @@
 					if (this.info.isStarted && this.info.isJoined) {
 						// Update the challenges
 						if ('challenges' in this.updates) {
-							this.$challenge.toggleClass('active', this.info.challenges.length > 0);
 							if (this.info.challenges.length > 0) {
 								this.$challengeUser.text("vs. " + this.info.challenges[0]);
 								this.$challengeUserMenu.toggle(this.info.challenges.length > 1);
 								this.$challengeUserMenu.html(this.renderChallengeUsers());
 								this.toggleBoxVisibility(true);
-								this.room.notifyOnce("Tournament challenges available", "Room: " + this.room.title, 'tournament-challenges');
+								if (!this.$challenge.hasClass('active')) {
+									this.room.notifyOnce("Tournament challenges available", "Room: " + this.room.title, 'tournament-challenges');
+								}
 							}
+							this.$challenge.toggleClass('active', this.info.challenges.length > 0);
 						}
 
 						if ('challengeBys' in this.updates) {
@@ -408,12 +410,14 @@
 						}
 
 						if ('challenged' in this.updates) {
-							this.$challenged.toggleClass('active', !!this.info.challenged);
 							if (this.info.challenged) {
 								this.$challengedMessage.text("vs. " + this.info.challenged);
 								this.toggleBoxVisibility(true);
-								this.room.notifyOnce("Tournament challenge from " + this.info.challenged, "Room: " + this.room.title, 'tournament-challenged');
+								if (!this.$challenged.hasClass('active')) {
+									this.room.notifyOnce("Tournament challenge from " + this.info.challenged, "Room: " + this.room.title, 'tournament-challenged');
+								}
 							}
+							this.$challenged.toggleClass('active', !!this.info.challenged);
 						}
 
 						this.$noMatches.toggleClass('active',


### PR DESCRIPTION
If you have an outstanding notification then the challenge notification gets triggered whenever the bracket updates. This makes it so that you don't get notified again while a notification is still outstanding.