### PR TITLE
Flip tooltips that don't fit above the element

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1234,6 +1234,15 @@
 				break;
 			}
 			$('#tooltipwrapper').html(text).appendTo(document.body);
+			if (elem) {
+				var height = $('#tooltipwrapper .tooltip').height();
+				if (height > y) {
+					y += height + 10;
+					if (ownHeight) y += $(elem).height();
+					else y += $(elem).parent().height();
+					$('#tooltipwrapper').css('top', y);
+				}
+			}
 		},
 		hideTooltip: function () {
 			$('#tooltipwrapper').html('');


### PR DESCRIPTION
Unlike PR #525 this seeks to flip the tooltip to appear below the element being hovered thus preventing it from interfering with the element itself. Doesn't attempt to solve the problem of the tooltip for Substitute being larger than the screen on a mobile phone.