### PR TITLE
Use correct tooltip limit for right hand battles

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -961,7 +961,7 @@
 			}
 			var y = offset.top - 5;
 
-			if (x > 335) x = 335;
+			if (x > this.leftWidth + 335) x = this.leftWidth + 335;
 			if (y < 140) y = 140;
 			if (x > $(window).width() - 303) x = Math.max($(window).width() - 303, 0);
 			if (!$('#tooltipwrapper').length) $(document.body).append('<div id="tooltipwrapper" onclick="$(\'#tooltipwrapper\').html(\'\');"></div>');

--- a/js/client.js
+++ b/js/client.js
@@ -2030,6 +2030,7 @@
 
 		bestWidth: 659,
 		show: function (position, leftWidth) {
+			this.leftWidth = 0;
 			switch (position) {
 			case 'left':
 				this.$el.css({left: 0, width: leftWidth, right: 'auto'});


### PR DESCRIPTION
When you use Shift+Arrow to move a battle to the right hand side of the screen the tooltips don't work as they are limited to 335 pixels horizontally. By keeping the `leftWidth` property up-to-date we can ensure that the tooltips are limited appropriately according to the position of the battle.