### PR TITLE
Allow import a new pokemon to the team before selecting one

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -589,10 +589,11 @@
 			var buf = '<li value="' + i + '">';
 			if (!set.species) {
 				if (this.deletedSet) {
-					buf += '<div class="setmenu setmenu-left"><button name="undeleteSet"><i class="fa fa-undo"></i> Undo Delete</button></div>';
+					buf += '<div class="setmenu"><button name="undeleteSet"><i class="fa fa-undo"></i> Undo Delete</button><button name="importSet"><i class="fa fa-upload"></i>Import</button></div>';
+				} else {
+					buf += '<div class="setmenu"><button name="importSet"><i class="fa fa-upload"></i>Import</button></div>';
 				}
 				buf += '<div class="setchart"><div class="setcol setcol-icon" style="background-image:url(' + Tools.resourcePrefix + 'sprites/bw/0.png);"><span class="itemicon"></span><div class="setcell setcell-pokemon"><label>Pokemon</label><input type="text" name="pokemon" class="chartinput" value="" /></div></div></div>';
-				buf += '<div class="setmenu"><button name="importSet"><i class="fa fa-upload"></i>Import</button></div>';
 				buf += '</li>';
 				return buf;
 			}

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -592,6 +592,7 @@
 					buf += '<div class="setmenu setmenu-left"><button name="undeleteSet"><i class="fa fa-undo"></i> Undo Delete</button></div>';
 				}
 				buf += '<div class="setchart"><div class="setcol setcol-icon" style="background-image:url(' + Tools.resourcePrefix + 'sprites/bw/0.png);"><span class="itemicon"></span><div class="setcell setcell-pokemon"><label>Pokemon</label><input type="text" name="pokemon" class="chartinput" value="" /></div></div></div>';
+				buf += '<div class="setmenu"><button name="importSet"><i class="fa fa-upload"></i>Import</button></div>';
 				buf += '</li>';
 				return buf;
 			}


### PR DESCRIPTION
When selecting which pokemon to add to the team it was not possible to import a pokemon from text.

How it was before:
![Before](http://s3.postimg.org/atoa8h6s3/old.png)

How it is now:
![After](http://s3.postimg.org/eek5rpbbn/new.png)