### PR TITLE
Past generation adaptation for the teambuilder

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -621,14 +621,16 @@
 				'N': '&mdash;'
 			};
 			buf += '<span class="detailcell detailcell-first"><label>Level</label>' + (set.level || 100) + '</span>';
-			buf += '<span class="detailcell"><label>Gender</label>' + GenderChart[template.gender || set.gender || 'N'] + '</span>';
-			buf += '<span class="detailcell"><label>Happiness</label>' + (typeof set.happiness === 'number' ? set.happiness : 255) + '</span>';
-			buf += '<span class="detailcell"><label>Shiny</label>' + (set.shiny ? 'Yes' : 'No') + '</span>';
+			if (this.curTeam.gen > 1) {
+				buf += '<span class="detailcell"><label>Gender</label>' + GenderChart[template.gender || set.gender || 'N'] + '</span>';
+				buf += '<span class="detailcell"><label>Happiness</label>' + (typeof set.happiness === 'number' ? set.happiness : 255) + '</span>';
+				buf += '<span class="detailcell"><label>Shiny</label>' + (set.shiny ? 'Yes' : 'No') + '</span>';
+			}
 
 			buf += '</button></div>';
 			buf += '</div><div class="setrow">';
-			buf += '<div class="setcell setcell-item"><label>Item</label><input type="text" name="item" class="chartinput" value="' + Tools.escapeHTML(set.item) + '" /></div>';
-			buf += '<div class="setcell setcell-ability"><label>Ability</label><input type="text" name="ability" class="chartinput" value="' + Tools.escapeHTML(set.ability) + '" /></div>';
+			if (this.curTeam.gen > 1) buf += '<div class="setcell setcell-item"><label>Item</label><input type="text" name="item" class="chartinput" value="' + Tools.escapeHTML(set.item) + '" /></div>';
+			if (this.curTeam.gen > 2) buf += '<div class="setcell setcell-ability"><label>Ability</label><input type="text" name="ability" class="chartinput" value="' + Tools.escapeHTML(set.ability) + '" /></div>';
 			buf += '</div></div>';
 
 			// moves
@@ -645,6 +647,7 @@
 			buf += '<span class="statrow statrow-head"><label></label> <span class="statgraph"></span> <em>EV</em></span>';
 			var stats = {};
 			for (var j in BattleStatNames) {
+				if (j === 'spd' && this.curTeam.gen === 1) continue;
 				stats[j] = this.getStat(j, set);
 				var ev = '<em>' + (set.evs[j] || '') + '</em>';
 				if (BattleNatures[set.nature] && BattleNatures[set.nature].plus === j) {
@@ -657,7 +660,8 @@
 				if (width > 75) width = 75;
 				var color = Math.floor(stats[j] * 180 / 714);
 				if (color > 360) color = 360;
-				buf += '<span class="statrow"><label>' + BattleStatNames[j] + '</label> <span class="statgraph"><span style="width:' + width + 'px;background:hsl(' + color + ',40%,75%);"></span></span> ' + ev + '</span>';
+				var statName = this.curTeam.gen === 1 && j === 'spa' ? 'Spc' : BattleStatNames[j];
+				buf += '<span class="statrow"><label>' + statName + '</label> <span class="statgraph"><span style="width:' + width + 'px;background:hsl(' + color + ',40%,75%);"></span></span> ' + ev + '</span>';
 			}
 			buf += '</button></div></div>';
 
@@ -725,6 +729,7 @@
 			this.curTeam.gen = this.getGen(this.curTeam.format);
 			this.save();
 			if (this.curTeam.gen === 5 && !Tools.loadedSpriteData['bw']) Tools.loadSpriteData('bw');
+			this.update();
 		},
 		nicknameChange: function (e) {
 			var i = +$(e.currentTarget).closest('li').attr('value');
@@ -1027,6 +1032,7 @@
 			// stat cell
 			var buf = '<span class="statrow statrow-head"><label></label> <span class="statgraph"></span> <em>EV</em></span>';
 			for (var stat in stats) {
+				if (stat === 'spd' && this.curTeam.gen === 1) continue;
 				stats[stat] = this.getStat(stat, set);
 				var ev = '<em>' + (set.evs[stat] || '') + '</em>';
 				if (BattleNatures[set.nature] && BattleNatures[set.nature].plus === stat) {
@@ -1055,6 +1061,7 @@
 			buf = '<div></div>';
 			var totalev = 0;
 			for (var stat in stats) {
+				if (stat === 'spd' && this.curTeam.gen === 1) continue;
 				var width = stats[stat] * 180 / 504;
 				if (stat == 'hp') width = stats[stat] * 180 / 704;
 				if (width > 179) width = 179;
@@ -1066,10 +1073,11 @@
 			buf += '<div><em>Remaining:</em></div>';
 			this.$chart.find('.graphcol').html(buf);
 
-			if (totalev <= 510) {
-				this.$chart.find('.totalev').html('<em>' + (totalev > 508 ? 0 : 508 - totalev) + '</em>');
+			var maxEv = this.curTeam.gen > 2 ? 510 : this.curTeam.gen === 1 ? 1275 : 1530;
+			if (totalev <= maxEv) {
+				this.$chart.find('.totalev').html('<em>' + (totalev > (maxEv-2) ? 0 : (maxEv-2) - totalev) + '</em>');
 			} else {
-				this.$chart.find('.totalev').html('<b>' + (510 - totalev) + '</b>');
+				this.$chart.find('.totalev').html('<b>' + (maxEv - totalev) + '</b>');
 			}
 			this.$chart.find('select[name=nature]').val(set.nature || 'Serious');
 		},
@@ -1098,7 +1106,7 @@
 			this.updateChartTimeout = setTimeout(function () {
 				self.updateChartTimeout = null;
 				if (self.curChartType === 'stats' || self.curChartType === 'details' || !self.curChartName) return;
-				self.$chart.html(Chart.chart(self.$('input[name=' + self.curChartName + ']').val(), self.curChartType, true, _.bind(self.arrangeCallback[self.curChartType], self)));
+				self.$chart.html(Chart.chart(self.$('input[name=' + self.curChartName + ']').val(), self.curChartType, true, _.bind(self.arrangeCallback[self.curChartType], self), null, self.curTeam.gen));
 			}, 10);
 		},
 		updateChartTimeout: null,
@@ -1113,7 +1121,7 @@
 			this.updateChartTimeout = setTimeout(function () {
 				self.updateChartTimeout = null;
 				if (self.curChartType === 'stats' || self.curChartType === 'details') return;
-				self.$chart.html(Chart.chart(self.$('input[name=' + self.curChartName + ']').val(), self.curChartType, false, _.bind(self.arrangeCallback[self.curChartType], self)));
+				self.$chart.html(Chart.chart(self.$('input[name=' + self.curChartName + ']').val(), self.curChartType, false, _.bind(self.arrangeCallback[self.curChartType], self), null, self.curTeam.gen));
 			}, 200);
 		},
 		selectPokemon: function (i) {
@@ -1228,14 +1236,21 @@
 			}
 
 			var stats = {hp:'',atk:'',def:'',spa:'',spd:'',spe:''};
+			if (this.curTeam.gen === 1) delete stats.spd;
 			if (!set) return;
 			var nature = BattleNatures[set.nature || 'Serious'];
 			if (!nature) nature = {};
 
 			// label column
 			buf += '<div class="col labelcol"><div></div>';
-			buf += '<div><label>HP</label></div><div><label>Attack</label></div><div><label>Defense</label></div><div><label>Sp. Atk.</label></div><div><label>Sp. Def.</label></div><div><label>Speed</label></div>';
-			buf += '</div>';
+			buf += '<div><label>HP</label></div><div><label>Attack</label></div><div><label>Defense</label></div><div>';
+			if (this.curTeam.gen === 1) {
+				buf += '<label>Special</label></div>';
+			} else {
+				buf += '<label>Sp. Atk.</label></div><div><label>Sp. Def.</label></div>';
+			}
+			
+			buf += '<div><label>Speed</label></div></div>';
 
 			buf += '<div class="col basestatscol"><div><em>Base</em></div>';
 			for (var i in stats) {
@@ -1276,15 +1291,17 @@
 				buf += '<div><input type="text" name="stat-' + i + '" value="' + val + '" class="inputform numform" /></div>';
 				totalev += (set.evs[i] || 0);
 			}
-			if (totalev <= 510) {
-				buf += '<div class="totalev"><em>' + (totalev > 508 ? 0 : 508 - totalev) + '</em></div>';
+			var maxEv = this.curTeam.gen > 2 ? 510 : this.curTeam.gen === 1 ? 1275 : 1530;
+			if (totalev <= maxEv) {
+				buf += '<div class="totalev"><em>' + (totalev > (maxEv-2) ? 0 : (maxEv-2) - totalev) + '</em></div>';
 			} else {
-				buf += '<div class="totalev"><b>' + (510 - totalev) + '</b></div>';
+				buf += '<div class="totalev"><b>' + (maxEv - totalev) + '</b></div>';
 			}
 			buf += '</div>';
 
 			buf += '<div class="col evslidercol"><div></div>';
 			for (var i in stats) {
+				if (i === 'spd' && this.curTeam.gen === 1) continue;
 				buf += '<div><input type="slider" name="evslider-' + i + '" value="' + Tools.escapeHTML(set.evs[i] || '0') + '" min="0" max="252" step="4" class="evslider" /></div>';
 			}
 			buf += '</div>';
@@ -1305,18 +1322,20 @@
 			}
 			buf += '</div>';
 
-			buf += '<p style="clear:both">Nature: <select name="nature">';
-			for (var i in BattleNatures) {
-				var curNature = BattleNatures[i];
-				buf += '<option value="' + i + '"' + (curNature === nature ? 'selected="selected"' : '') + '>' + i;
-				if (curNature.plus) {
-					buf += ' (+' + BattleStatNames[curNature.plus] + ', -' + BattleStatNames[curNature.minus] + ')';
+			if (this.curTeam.gen > 2) {
+				buf += '<p style="clear:both">Nature: <select name="nature">';
+				for (var i in BattleNatures) {
+					var curNature = BattleNatures[i];
+					buf += '<option value="' + i + '"' + (curNature === nature ? 'selected="selected"' : '') + '>' + i;
+					if (curNature.plus) {
+						buf += ' (+' + BattleStatNames[curNature.plus] + ', -' + BattleStatNames[curNature.minus] + ')';
+					}
+					buf += '</option>';
 				}
-				buf += '</option>';
-			}
-			buf += '</select></p>';
+				buf += '</select></p>';
 
-			buf += '<p><em>Protip:</em> You can also set natures by typing "+" and "-" next to a stat.</p>';
+				buf += '<p><em>Protip:</em> You can also set natures by typing "+" and "-" next to a stat.</p>';
+			}
 
 			buf += '</div>';
 			this.$chart.html(buf);
@@ -1488,28 +1507,30 @@
 			var set = this.curSet;
 			var template = Tools.getTemplate(set.species);
 			if (!set) return;
-			buf += '<h3>Details</h3>';
-			buf += '<form class="detailsform">';
+				buf += '<h3>Details</h3>';
+				buf += '<form class="detailsform">';
 
-			buf += '<div class="formrow"><label class="formlabel">Level:</label><div><input type="number" min="1" max="100" step="1" name="level" value="' + Tools.escapeHTML(set.level || 100) + '" class="textbox inputform numform" /></div></div>';
+				buf += '<div class="formrow"><label class="formlabel">Level:</label><div><input type="number" min="1" max="100" step="1" name="level" value="' + Tools.escapeHTML(set.level || 100) + '" class="textbox inputform numform" /></div></div>';
 
-			buf += '<div class="formrow"><label class="formlabel">Gender:</label><div>';
-			if (template.gender) {
-				var genderTable = {'M': "Male", 'F': "Female", 'N': "Genderless"};
-				buf += genderTable[template.gender];
-			} else {
-				buf += '<label><input type="radio" name="gender" value="M"' + (set.gender === 'M' ? ' checked' : '') + ' /> Male</label> ';
-				buf += '<label><input type="radio" name="gender" value="F"' + (set.gender === 'F' ? ' checked' : '') + ' /> Female</label> ';
-				buf += '<label><input type="radio" name="gender" value="N"' + (!set.gender ? ' checked' : '') + ' /> Random</label>';
+				if (this.curTeam.gen > 1) {
+				buf += '<div class="formrow"><label class="formlabel">Gender:</label><div>';
+				if (template.gender) {
+					var genderTable = {'M': "Male", 'F': "Female", 'N': "Genderless"};
+					buf += genderTable[template.gender];
+				} else {
+					buf += '<label><input type="radio" name="gender" value="M"' + (set.gender === 'M' ? ' checked' : '') + ' /> Male</label> ';
+					buf += '<label><input type="radio" name="gender" value="F"' + (set.gender === 'F' ? ' checked' : '') + ' /> Female</label> ';
+					buf += '<label><input type="radio" name="gender" value="N"' + (!set.gender ? ' checked' : '') + ' /> Random</label>';
+				}
+				buf += '</div></div>';
+
+				buf += '<div class="formrow"><label class="formlabel">Happiness:</label><div><input type="number" min="0" max="255" step="1" name="happiness" value="' + (typeof set.happiness === 'number' ? set.happiness : 255) + '" class="textbox inputform numform" /></div></div>';
+
+				buf += '<div class="formrow"><label class="formlabel">Shiny:</label><div>';
+				buf += '<label><input type="radio" name="shiny" value="yes"' + (set.shiny ? ' checked' : '') + ' /> Yes</label> ';
+				buf += '<label><input type="radio" name="shiny" value="no"' + (!set.shiny ? ' checked' : '') + ' /> No</label>';
+				buf += '</div></div>';
 			}
-			buf += '</div></div>';
-
-			buf += '<div class="formrow"><label class="formlabel">Happiness:</label><div><input type="number" min="0" max="255" step="1" name="happiness" value="' + (typeof set.happiness === 'number' ? set.happiness : 255) + '" class="textbox inputform numform" /></div></div>';
-
-			buf += '<div class="formrow"><label class="formlabel">Shiny:</label><div>';
-			buf += '<label><input type="radio" name="shiny" value="yes"' + (set.shiny ? ' checked' : '') + ' /> Yes</label> ';
-			buf += '<label><input type="radio" name="shiny" value="no"' + (!set.shiny ? ' checked' : '') + ' /> No</label>';
-			buf += '</div></div>';
 
 			buf += '</form>';
 			this.$chart.html(buf);
@@ -1553,9 +1574,11 @@
 				'N': '&mdash;'
 			};
 			buf += '<span class="detailcell detailcell-first"><label>Level</label>' + (set.level || 100) + '</span>';
-			buf += '<span class="detailcell"><label>Gender</label>' + GenderChart[set.gender || 'N'] + '</span>';
-			buf += '<span class="detailcell"><label>Happiness</label>' + (typeof set.happiness === 'number' ? set.happiness : 255) + '</span>';
-			buf += '<span class="detailcell"><label>Shiny</label>' + (set.shiny ? 'Yes' : 'No') + '</span>';
+			if (this.curTeam.gen > 1) {
+				buf += '<span class="detailcell"><label>Gender</label>' + GenderChart[set.gender || 'N'] + '</span>';
+				buf += '<span class="detailcell"><label>Happiness</label>' + (typeof set.happiness === 'number' ? set.happiness : 255) + '</span>';
+				buf += '<span class="detailcell"><label>Shiny</label>' + (set.shiny ? 'Yes' : 'No') + '</span>';
+			}
 			this.$('button[name=details]').html(buf);
 
 			this.save();
@@ -1650,7 +1673,7 @@
 				e.preventDefault();
 
 				var name = e.currentTarget.name;
-				this.$chart.html(Chart.chart(e.currentTarget.value, this.curChartType, false, _.bind(this.arrangeCallback[this.curChartType], this)));
+				this.$chart.html(Chart.chart(e.currentTarget.value, this.curChartType, false, _.bind(this.arrangeCallback[this.curChartType], this), null, this.curTeam.gen));
 				var val = Chart.firstResult;
 				this.chartSet(val, true);
 				return;
@@ -1691,7 +1714,7 @@
 			if (this.arrangeCallback[this.curChartType]) {
 				arrange = _.bind(this.arrangeCallback[this.curChartType], this);
 			}
-			this.$chart.html(Chart.chart(e.currentTarget.value, type, false, arrange));
+			this.$chart.html(Chart.chart(e.currentTarget.value, type, false, arrange, null, this.curTeam.gen));
 			var val = Chart.firstResult;
 			var id = toId(e.currentTarget.value);
 			if (toId(val) !== id) {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -230,6 +230,7 @@
 			i = +i;
 			this.curTeam = teams[i];
 			this.curTeam.iconCache = '!';
+			this.curTeam.gen = this.getGen(this.curTeam.format);
 			Storage.activeSetList = this.curSetList = Storage.unpackTeam(this.curTeam.team);
 			this.curTeamIndex = i;
 			this.update();
@@ -1507,12 +1508,12 @@
 			var set = this.curSet;
 			var template = Tools.getTemplate(set.species);
 			if (!set) return;
-				buf += '<h3>Details</h3>';
-				buf += '<form class="detailsform">';
+			buf += '<h3>Details</h3>';
+			buf += '<form class="detailsform">';
 
-				buf += '<div class="formrow"><label class="formlabel">Level:</label><div><input type="number" min="1" max="100" step="1" name="level" value="' + Tools.escapeHTML(set.level || 100) + '" class="textbox inputform numform" /></div></div>';
+			buf += '<div class="formrow"><label class="formlabel">Level:</label><div><input type="number" min="1" max="100" step="1" name="level" value="' + Tools.escapeHTML(set.level || 100) + '" class="textbox inputform numform" /></div></div>';
 
-				if (this.curTeam.gen > 1) {
+			if (this.curTeam.gen > 1) {
 				buf += '<div class="formrow"><label class="formlabel">Gender:</label><div>';
 				if (template.gender) {
 					var genderTable = {'M': "Male", 'F': "Female", 'N': "Genderless"};

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -18,6 +18,7 @@
 			this.buildMovelists();
 			if (this.curTeam) {
 				this.curTeam.iconCache = '!';
+				this.curTeam.gen = this.getGen(this.curTeam.format);
 				Storage.activeSetList = this.curSetList;
 			}
 		},
@@ -721,8 +722,9 @@
 		},
 		formatChange: function (e) {
 			this.curTeam.format = e.currentTarget.value;
+			this.curTeam.gen = this.getGen(this.curTeam.format);
 			this.save();
-			if (this.curTeam.format.substr(0, 4) === 'gen5' && !Tools.loadedSpriteData['bw']) Tools.loadSpriteData('bw');
+			if (this.curTeam.gen === 5 && !Tools.loadedSpriteData['bw']) Tools.loadSpriteData('bw');
 		},
 		nicknameChange: function (e) {
 			var i = +$(e.currentTarget).closest('li').attr('value');
@@ -2324,6 +2326,11 @@
 			} else {
 				this.movelist = Tools.movelists[speciesid];
 			}
+		},
+		getGen: function (format) {
+			format = '' + format;
+			if (format.substr(0, 3) !== 'gen') return 6;
+			return parseInt(format.substr(3, 1)) || 6;
 		},
 		destroy: function () {
 			app.clearGlobalListeners();

--- a/js/utilichart.js
+++ b/js/utilichart.js
@@ -273,28 +273,74 @@ function BattleChart() {
 				self.pokemon.sort(thisSort);
 				self.lastPokemonSort = thisSort;
 			}
-			things = self.pokemon;
+			if (gen > 0) {
+				things = self.pokemon.filter(function (mon) {
+					if (gen < 6 && mon.forme.substr(0, 4) === 'Mega') return false;
+					if (gen === 1 && mon.num > 151) return false;
+					if (gen === 2 && mon.num > 251) return false;
+					if (gen === 3 && mon.num > 386) return false;
+					if (gen === 4 && mon.num > 493) return false;
+					if (gen === 5 && mon.num > 649) return false;
+					if (gen === 6 && mon.num > 721) return false;
+					return true;
+				});
+			} else {
+				things = self.pokemon;
+			}
 			break;
 		case 'item':
 			if (thisSort !== self.lastItemSort) {
 				self.items.sort(thisSort);
 				self.lastItemSort = thisSort;
 			}
-			things = self.items;
+			if (gen > 0) {
+				things = self.items.filter(function (item) {
+					if (gen === 1) return false;
+					if (gen === 2 && item.gen > 2) return false;
+					if (gen === 3 && item.gen > 3) return false;
+					if (gen === 4 && item.gen > 4) return false;
+					if (gen === 5 && item.gen > 5) return false;
+					return true;
+				});
+			} else {
+				things = self.items;
+			}
 			break;
 		case 'ability':
 			if (thisSort !== self.lastAbilitySort) {
 				self.abilities.sort(thisSort);
 				self.lastAbilitySort = thisSort;
 			}
-			things = self.abilities;
+			if (gen > 0) {
+				things = self.abilities.filter(function (ability) {
+					console.log(ability);
+					if (gen < 3) return false;
+					if (gen === 3 && ability.num > 76) return false;
+					if (gen === 4 && ability.num > 123) return false;
+					if (gen === 5 && ability.num > 164) return false;
+					return true;
+				});
+			} else {
+				things = self.abilities;
+			}
 			break;
 		case 'move':
 			if (thisSort !== self.lastMoveSort) {
 				self.moves.sort(thisSort);
 				self.lastMoveSort = thisSort;
 			}
-			things = self.moves;
+			if (gen > 0) {
+				things = self.moves.filter(function (move) {
+					if (gen === 1 && (move.num > 165 || move.id === 'hiddenpower')) return false;
+					if (gen === 2 && move.num > 251) return false;
+					if (gen === 3 && move.num > 354) return false;
+					if (gen === 4 && move.num > 467) return false;
+					if (gen === 5 && move.num > 559) return false;
+					return true;
+				});
+			} else {
+				things = self.moves;
+			}
 			break;
 		}
 

--- a/js/utilichart.js
+++ b/js/utilichart.js
@@ -40,23 +40,23 @@ function BattleChart() {
 		if (self.selectCallback) self.selectCallback(x);
 	};
 
-	this.row = function (thing, attrs, match, isFirst, dataCommand) {
+	this.row = function (thing, attrs, match, isFirst, dataCommand, gen) {
 		if (isFirst) {
 			self.firstResult = thing.name;
 		}
 		attrs = attrs || '';
 		switch (match.thingType) {
 		case 'pokemon':
-			return self.pokemonRow(thing, attrs, match, isFirst, dataCommand);
+			return self.pokemonRow(thing, attrs, match, isFirst, dataCommand, gen);
 		case 'item':
 			return self.itemRow(thing, attrs, match, isFirst, dataCommand);
 		case 'ability':
 			return self.abilityRow(thing, attrs, match, isFirst, dataCommand);
 		case 'move':
-			return self.moveRow(thing, attrs, match, isFirst, dataCommand);
+			return self.moveRow(thing, attrs, match, isFirst, dataCommand, gen);
 		}
 	};
-	this.pokemonRow = function (pokemon, attrs, match, isFirst, dataCommand) {
+	this.pokemonRow = function (pokemon, attrs, match, isFirst, dataCommand, gen) {
 		var tag = dataCommand ? 'div' : 'a';
 		var text = '<li class="result' + (isFirst ? ' firstresult' : '') + '"><' + tag + attrs + ' data-name="' + Tools.escapeHTML(pokemon.species) + '">';
 
@@ -105,36 +105,42 @@ function BattleChart() {
 		}
 		text += '</span> ';
 
-		text += '<span style="float:left;min-height:26px">';
-		if (pokemon.abilities['1']) {
-			text += '<span class="col twoabilitycol">';
-		}
-		else {
-			text += '<span class="col abilitycol">';
-		}
-		for (var i in pokemon.abilities) {
-			var ability = pokemon.abilities[i];
-			if (!ability) continue;
+		if (!gen || gen > 2) {
+			text += '<span style="float:left;min-height:26px">';
+			if (pokemon.abilities['1']) {
+				text += '<span class="col twoabilitycol">';
+			}
+			else {
+				text += '<span class="col abilitycol">';
+			}
+			for (var i in pokemon.abilities) {
+				var ability = pokemon.abilities[i];
+				if (!ability) continue;
 
-			if (i === '1') text += '<br />';
-			if (match.ability && match.ability[i]) {
-				ability = ability.substr(0, match.ability[i].start) + '<b>' + ability.substr(match.ability[i].start, match.ability[i].end - match.ability[i].start) + '</b>' + ability.substr(match.ability[i].end);
+				if (i === '1') text += '<br />';
+				if (match.ability && match.ability[i]) {
+					ability = ability.substr(0, match.ability[i].start) + '<b>' + ability.substr(match.ability[i].start, match.ability[i].end - match.ability[i].start) + '</b>' + ability.substr(match.ability[i].end);
+				}
+				if (i == 'H') {
+					ability = '</span><span class="col abilitycol"><em>' + (pokemon.unreleasedHidden ? '<s>' + ability + '</s>' : ability) + '</em>';
+				}
+				text += ability;
 			}
-			if (i == 'H') {
-				ability = '</span><span class="col abilitycol"><em>' + (pokemon.unreleasedHidden ? '<s>' + ability + '</s>' : ability) + '</em>';
-			}
-			text += ability;
+			if (!pokemon.abilities['H']) text += '</span><span class="col abilitycol">';
+			text += '</span>';
+			text += '</span>';
 		}
-		if (!pokemon.abilities['H']) text += '</span><span class="col abilitycol">';
-		text += '</span>';
-		text += '</span>';
 
 		text += '<span style="float:left;min-height:26px">';
 		text += '<span class="col statcol"><em>HP</em><br />' + pokemon.baseStats.hp + '</span> ';
 		text += '<span class="col statcol"><em>Atk</em><br />' + pokemon.baseStats.atk + '</span> ';
 		text += '<span class="col statcol"><em>Def</em><br />' + pokemon.baseStats.def + '</span> ';
-		text += '<span class="col statcol"><em>SpA</em><br />' + pokemon.baseStats.spa + '</span> ';
-		text += '<span class="col statcol"><em>SpD</em><br />' + pokemon.baseStats.spd + '</span> ';
+		if (!gen || gen > 1) {
+			text += '<span class="col statcol"><em>SpA</em><br />' + pokemon.baseStats.spa + '</span> ';
+			text += '<span class="col statcol"><em>SpD</em><br />' + pokemon.baseStats.spd + '</span> ';
+		} else {
+			text += '<span class="col statcol"><em>Spc</em><br />' + pokemon.baseStats.spa + '</span> ';
+		}
 		text += '<span class="col statcol"><em>Spe</em><br />' + pokemon.baseStats.spe + '</span> ';
 		var bst = 0;
 		for (i in pokemon.baseStats) bst += pokemon.baseStats[i];
@@ -195,7 +201,7 @@ function BattleChart() {
 
 		return text;
 	};
-	this.moveRow = function (move, attrs, match, isFirst) {
+	this.moveRow = function (move, attrs, match, isFirst, gen) {
 		var text = '<li class="result' + (isFirst ? ' firstresult' : '') + '"><a' + attrs + ' data-name="' + Tools.escapeHTML(move.name) + '">';
 
 		var name = Tools.escapeHTML(move.name);
@@ -236,7 +242,7 @@ function BattleChart() {
 
 		return text;
 	};
-	this.chart = function (searchTerm, type, init, thisArrange, thisSort) {
+	this.chart = function (searchTerm, type, init, thisArrange, thisSort, gen) {
 		if (!searchTerm) searchTerm = '';
 		else searchTerm = searchTerm.toLowerCase();
 		if (!init && searchTerm === self.lastSearch) return;
@@ -429,7 +435,7 @@ function BattleChart() {
 					if (firstMatch) {
 						text += '<li><h3>Matches</h3></li>';
 					}
-					text += self.row(match.thing, '', match, firstMatch);
+					text += self.row(match.thing, '', match, firstMatch, null, gen);
 					firstMatch = false;
 				}
 			}
@@ -450,7 +456,7 @@ function BattleChart() {
 				if (firstMatch) {
 					text += '<li><h3>Details Matches</h3></li>';
 				}
-				text += self.row(match.thing, '', match, firstMatch && noNameMatch);
+				text += self.row(match.thing, '', match, firstMatch && noNameMatch, null, gen);
 				firstMatch = false;
 			}
 		}
@@ -461,7 +467,7 @@ function BattleChart() {
 				if (firstMatch) {
 					text += '<li><h3>Details Matches</h3></li>';
 				}
-				text += self.row(match.thing, '', match, firstMatch && noNameMatch);
+				text += self.row(match.thing, '', match, firstMatch && noNameMatch, null, gen);
 				firstMatch = false;
 			}
 		}
@@ -477,7 +483,7 @@ function BattleChart() {
 						text += '<li><h3>' + buckets[i] + '</h3></li>';
 						firstMatch = false;
 					}
-					text += self.row(match.thing, '', match);
+					text += self.row(match.thing, '', match, null, null, gen);
 				}
 			}
 		}


### PR DESCRIPTION
The following set of changes update several parts of the teambuilder to allow it to give a better experience to past generation players.

First, Teambuilder is now able to get the generation from the format name, given they must follow the genN scheme.

Then, we are going to hide irrelevant stats from past gens, hiding ability, hiding item in gen 1, and last but not least, we are going to not to show future Pokémon in past gens.

This is just the first step of a fully functional multi-generation teambuilder.