### PR TITLE
Teambuilder should ignore EV limits prior to Generation 3

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -109,6 +109,7 @@
 		update: function () {
 			teams = Storage.teams;
 			if (this.curTeam) {
+				this.ignoreEVLimits = (this.curTeam.gen < 3);
 				if (this.curSet) {
 					return this.updateSetView();
 				}
@@ -1415,7 +1416,7 @@
 
 				// cap
 				if (val > 252) val = 252;
-				if (val < 0) val = 0;
+				if (val < 0 || isNaN(val)) val = 0;
 
 				if (set.evs[stat] !== val || natureChange) {
 					set.evs[stat] = val;
@@ -2149,7 +2150,6 @@
 				}
 			}
 
-			this.ignoreEVLimits = (this.curTeam.format === 'classichackmons');
 			if (this.curTeam && this.ignoreEVLimits) {
 				evs = {hp:252, atk:252, def:252, spa:252, spd:252, spe:252};
 				if (hasMove['gyroball'] || hasMove['trickroom']) delete evs.spe;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1219,9 +1219,14 @@
 				delete guessedEVs.minusStat;
 				buf += ' </small><button name="setStatFormGuesses">' + role + ': ';
 				for (var i in guessedEVs) {
-					if (guessedEVs[i]) buf += '' + guessedEVs[i] + ' ' + BattleStatNames[i] + ' / ';
+					if (guessedEVs[i]) {
+						var statName = this.curTeam.gen === 1 && i === 'spa' ? 'Spc' : BattleStatNames[i];
+						buf += '' + guessedEVs[i] + ' ' + statName + ' / ';
+					}
 				}
-				buf += ' (+' + BattleStatNames[guessedPlus] + ', -' + BattleStatNames[guessedMinus] + ')</button><small> (<a target="_blank" href="' + this.smogdexLink(template) + '">Smogon&nbsp;analysis</a>)</small></p>';
+				if (guessedPlus && guessedMinus) buf += ' (+' + BattleStatNames[guessedPlus] + ', -' + BattleStatNames[guessedMinus] + ')';
+				else buf = buf.slice(0, -3);
+				buf += '</button><small> (<a target="_blank" href="' + this.smogdexLink(template) + '">Smogon&nbsp;analysis</a>)</small></p>';
 				//buf += ' <small>(' + role + ' | bulk: phys ' + Math.round(this.moveCount.physicalBulk/1000) + ' + spec ' + Math.round(this.moveCount.specialBulk/1000) + ' = ' + Math.round(this.moveCount.bulk/1000) + ')</small>';
 			}
 
@@ -1861,7 +1866,7 @@
 			var itemid = toId(set.item);
 			var abilityid = toId(set.ability);
 
-			if (set.moves.length < 4 && template.id !== 'unown' && template.id !== 'ditto') return '?';
+			if (set.moves.length < 4 && template.id !== 'unown' && template.id !== 'ditto' && this.curTeam.gen > 2) return '?';
 
 			for (var i = 0, len = set.moves.length; i < len; i++) {
 				var move = Tools.getMove(set.moves[i]);
@@ -2153,6 +2158,8 @@
 			if (this.curTeam && this.ignoreEVLimits) {
 				evs = {hp:252, atk:252, def:252, spa:252, spd:252, spe:252};
 				if (hasMove['gyroball'] || hasMove['trickroom']) delete evs.spe;
+				if (this.curTeam.gen === 1) delete evs.spd;
+				if (this.curTeam.gen < 3) return evs;
 			} else {
 				if (!statChart[role]) return {};
 


### PR DESCRIPTION
I had to move the place where `ignoreEVLimits` was set so that it would pick up changes in the format correctly. I also fixed a bug whereby if you manually delete an EV value you can then slide any of the other EVs as much as you like.