### PR TITLE
Rejoining a done battle checks the wrong flag

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -124,7 +124,7 @@
 			if (this.battle.activityQueue.length) return;
 			this.battle.activityQueue = log;
 			this.battle.fastForwardTo(-1);
-			if (this.battle.ended) this.battleEnded = true;
+			if (this.battle.done) this.battleEnded = true;
 			this.updateLayout();
 			this.updateControls();
 		},


### PR DESCRIPTION
To avoid the forfeit popup appearing when you rejoin a battle that you already played, `init` tries to check whether the battle already ended, however it checks the wrong flag so you get prompted anyway.