### PR TITLE
Avoid changing border width or padding on hover

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -1033,7 +1033,7 @@ p.or:after {
 	font-size: 8pt;
 }
 .roomlist a.ilink:hover {
-	border: 1px solid #8899AA;
+	border-color: #8899AA;
 	background: #F1F4F9;
 	color: #224466;
 	text-decoration: none;
@@ -1789,7 +1789,7 @@ a.ilink.yours {
     font-weight: bold;
 }
 .megaevo:hover {
-    border: 1px solid #888;
+    border-color: #888;
     background: #E5E5E5;
     color: black;
 }
@@ -2300,7 +2300,7 @@ a.ilink.yours {
 }
 .setmenu button:hover,
 .teamlist button:hover {
-	border: 1px solid #888888;
+	border-color: #888888;
 	background: #D5D5D5;
 }
 .setmenu button i,
@@ -2731,7 +2731,7 @@ a.ilink.yours {
 	cursor: pointer;
 }
 .teambuilder-results .result a:hover {
-	border: 1px solid #D8D8D8;
+	border-color: #D8D8D8;
 	background: #F8F8F8;
 }
 .teambuilder-results .firstresult a,

--- a/style/client.css
+++ b/style/client.css
@@ -2291,9 +2291,9 @@ a.ilink.yours {
 .teamlist button {
 	cursor: pointer;
 	background: transparent;
-	border: 0;
+	border: 1px solid transparent;
 	border-radius: 4px;
-	padding: 3px 6px;
+	padding: 2px 5px;
 	margin: 0;
 	font-size: 9pt;
 	font-family: Verdana, sans-serif;
@@ -2301,7 +2301,6 @@ a.ilink.yours {
 .setmenu button:hover,
 .teamlist button:hover {
 	border: 1px solid #888888;
-	padding: 2px 5px;
 	background: #D5D5D5;
 }
 .setmenu button i,
@@ -2724,20 +2723,19 @@ a.ilink.yours {
 	overflow: visible;
 }
 .teambuilder-results .result a {
+	border: 1px solid transparent;
 	border-radius: 4px;
-	padding: 1px 1px 1px 5px;
+	padding: 0px 0px 0px 4px;
 	margin: 0 5px 1px 5px;
 	background: transparent;
 	cursor: pointer;
 }
 .teambuilder-results .result a:hover {
-	padding: 0px 0px 0px 4px;
 	border: 1px solid #D8D8D8;
 	background: #F8F8F8;
 }
 .teambuilder-results .firstresult a,
 .teambuilder-results .firstresult a:hover {
-	padding: 0px 0px 0px 4px;
 	border: 1px solid #CCCCCC;
 	background: #F2F2F2;
 }


### PR DESCRIPTION
Cosmetic issue whereby if you're not at 100% zoom then moving pixels from padding to border causes layout to get recalculated. In my case it causes the wastebasket icon for the "Delete" button (but not the text!) to move when the edit button is hovered at 90% zoom.

I noticed the problem with the teamlist button but I changed the other hover too just in case. (I didn't find any other hovers which changed the border or padding.)