### PR TITLE
Change the teambuilder clipboard design

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -2584,10 +2584,11 @@ a.ilink.yours {
 
 .teambuilder-clipboard-container {
 	height: 52px;
-	max-width: 560px;
+	max-width: 455px;
 	font-size: 8pt;
 	padding: 4px;
 	position: relative;
+	margin: auto;
 
 	border: 1px solid #FFAA00;
 	border-radius: 5px;
@@ -2598,7 +2599,7 @@ a.ilink.yours {
 	font-weight: bold;
 
 	position: absolute;
-	top: 4px;
+	bottom: 4px;
 	left: 8px;
 }
 .teambuilder-clipboard-data {
@@ -2663,7 +2664,7 @@ a.ilink.yours {
 }
 .teambuilder-clipboard-buttons {
 	display: block;
-	width: 520px;
+	width: 385px;
 
 	position: absolute;
 	top: 34px;


### PR DESCRIPTION
Moved the pokemon down and the clear button up so that it better fits with the new folders.
Current clipboard looks like this:
https://i.gyazo.com/bcf2ab5e17da803fff25c76a27db641a.png
https://i.gyazo.com/7767f32bd25633761a56aff95e8d0470.png
The changed one looks like this:
https://i.gyazo.com/36b612d75826ad821c8f65576c8abb7d.png
https://i.gyazo.com/a8ad0f372a3ce024f7f7c7d240972fc6.png