### PR TITLE
Fix new icons clipping team names

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -626,7 +626,7 @@ p.or:after {
 	display: block;
 }
 .teamselect small .picon {
-	margin: 0 -3px;
+	margin: 4px -3px;
 }
 .select:hover, .team.team-hover {
 	border-color: #555555;


### PR DESCRIPTION
Underscores to demonstrate:
Currently:
![](https://i.gyazo.com/423b6dfefb4ba31ba73c17b9b14e194c.png)
Fixed:
![](https://i.gyazo.com/6258557692e1ea3cdd4448378b501f49.png)