### PR TITLE
Show exact HP for my active side

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1144,6 +1144,8 @@
 				text += '</h2>';
 				if (pokemon.fainted) {
 					text += '<p>HP: (fainted)</p>';
+				} else if (myPokemon) {
+					text += '<p>HP: ' + myPokemon.hpDisplay() + ' (' + myPokemon.hp + '/' + myPokemon.maxhp + ')' + (pokemon.status ? ' <span class="status ' + pokemon.status + '">' + pokemon.status.toUpperCase() + '</span>' : '') + '</p>';
 				} else {
 					var exacthp = '';
 					if (pokemon.maxhp != 100 && pokemon.maxhp != 1000 && pokemon.maxhp != 48) exacthp = ' (' + pokemon.hp + '/' + pokemon.maxhp + ')';


### PR DESCRIPTION
When choosing your move, if you hover over your own active Pokémon, you see your exact ability, item and stats, but not your exact HP, as mentioned in http://www.smogon.com/forums/posts/6570673 (you do see your exact HP if you can switch as then you can hover over the switch choices).