### PR TITLE
Don't unnecessarily update the tournament team selector

### DIFF
--- a/js/client-chat-tournament.js
+++ b/js/client-chat-tournament.js
@@ -292,7 +292,6 @@
 					if (joins.length > 0) message.push(arrayToPhrase(joins) + " joined the tournament");
 					if (leaves.length > 0) message.push(arrayToPhrase(leaves) + " left the tournament");
 					this.$lastJoinLeaveMessage.text(message.join("; ") + ".");
-					this.updateTeams();
 					break;
 
 				case 'start':
@@ -349,7 +348,7 @@
 						this.info.isActive = true;
 					}
 
-					if ('format' in this.updates) {
+					if ('format' in this.updates || 'isJoined' in this.updates) {
 						this.$format.text(window.BattleFormats && BattleFormats[this.info.format] ? BattleFormats[this.info.format].name : this.info.format);
 						this.updateTeams();
 					}
@@ -357,8 +356,6 @@
 						this.$generator.text(this.info.generator);
 					if ('isStarted' in this.updates) {
 						this.$status.text(this.info.isStarted ? "In Progress" : "Signups");
-						if (this.info.isStarted)
-							this.updateTeams();
 					}
 
 					// Update the toolbox


### PR DESCRIPTION
Several times I've selected a team during signups only to accidentally accept the challenge using my first team of the type of the tour. This is because the team selector is currently updated when anyone joins or leaves the tournament, or when the tournament starts, but it only needs to be updated when you yourself join or leave the tournament. (There are some other cases but those are already correct.)