### PR TITLE
Properly calculate DVs when calculating stats in Gen1/2

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2826,6 +2826,7 @@
 
 			var baseStat = template.baseStats[stat];
 			var iv = (set.ivs[stat] || 0);
+			if (this.curTeam.gen <= 2) iv &= 30;
 			var ev = set.evs[stat];
 			if (evOverride !== undefined) ev = evOverride;
 			if (ev === undefined) ev = (this.curTeam.gen > 2 ? 0 : 252);


### PR DESCRIPTION
The Teambuilder uses 31 IVs by default however this needs to map to 15 DVs rather than 15.5 as it currently does. For example, Zapdos should have a maximum speed of 298 in Gen2, but 299 in Gen3.