### PR TITLE
Prevent users from ignoring themselves

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -451,7 +451,9 @@
 					this.parseCommand('/help ignore');
 					return false;
 				}
-				if (app.ignore[toUserid(target)]) {
+				if (toUserid(target) === app.user.get('userid')) {
+					this.add("You are not able to ignore yourself.");
+				} else if (app.ignore[toUserid(target)]) {
 					this.add("User '" + toName(target) + "' is already on your ignore list. (Moderator messages will not be ignored.)");
 				} else {
 					app.ignore[toUserid(target)] = 1;


### PR DESCRIPTION
Didn't even know it was possible until I saw this in the Help room:
[20:10:19] Madisaur: How do you un-ignore someone?
[20:10:24] Combeenation: /unignore (username)
[20:10:42] Madisaur: Thanks. Accidently ignored myself. It's rather frustrating.