### PR TITLE
Improve the way usernames look on user popups

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -2297,7 +2297,7 @@
 
 			var buf = '<div class="userdetails">';
 			if (avatar) buf += '<img class="trainersprite' + (userid === ownUserid ? ' yours' : '') + '" src="' + Tools.resolveAvatar(avatar) + '" />';
-			buf += '<strong><a href="//pokemonshowdown.com/users/' + userid + '" target="_blank">' + Tools.escapeHTML(name) + '</a></strong><br />';
+			buf += '<a class="name" href="//pokemonshowdown.com/users/' + userid + '" target="_blank">' + Tools.escapeHTML(name) + '</a><br />';
 			buf += '<small>' + (group || '&nbsp;') + '</small>';
 			if (data.rooms) {
 				var battlebuf = '';

--- a/style/client.css
+++ b/style/client.css
@@ -2888,6 +2888,11 @@ a.ilink.yours {
 .userdetails .offline {
 	color: red;
 }
+.userdetails .name {
+	font-weight: bold;
+	text-decoration: underline;
+	color: #248;
+}
 .trainersprite.yours {
 	cursor: pointer;
 }


### PR DESCRIPTION

![schermafdruk van 2016-01-12 18 57 15](https://cloud.githubusercontent.com/assets/4457584/12272069/a958e0d2-b95e-11e5-8a4f-8cda2f0bea23.png)
This removes the ugly default html look of the usernames, and removes purple usernames