### PR TITLE
Mark root directory as root for eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@
 const os = require('os');
 
 module.exports = {
+	"root": true,
 	"env": {
 		"node": true,
 		"browser": true


### PR DESCRIPTION
So it doesn't try to read any ancestor directories' eslint configs

Made `npm test` very broken when it was inside another directory tree containing eslint configs (cough server cough)