### PR TITLE
Disallow | in team names

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1160,6 +1160,10 @@
 				app.addPopupMessage("Names can't contain slashes, since they're used as a folder separator.");
 				name = name.replace(/[\\\/]/g, '');
 			}
+			if (name.indexOf('|') >= 0) {
+				app.addPopupMessage("Names can't contain the character |, since they're used for storing teams.");
+				name = name.replace(/\|/g, '');
+			}
 			this.curTeam.name = name;
 			e.currentTarget.value = name;
 			this.save();


### PR DESCRIPTION
This really messes up teams if you use it :/

I have no idea about the appropriate message for this, but I tried making it similar to the slashes one.