### PR TITLE
Rocky Helmet is 20 times more popular than Power Herb

### DIFF
--- a/githooks/build-indexes
+++ b/githooks/build-indexes
@@ -308,6 +308,8 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			case 'assaultvest':
 			case 'focussash':
 			case 'powerherb':
+			case 'mentalherb':
+			case 'rockyhelmet':
 				greatItems.push(id);
 				break;
 			case 'lumberry':


### PR DESCRIPTION
At least, according to `ou-1500.json`. In fact, Power Herb is 46th, partly due to the number of Mega stones that are more popular. Top 15 items:
 1. Leftovers
 2. Life Orb (56% as popular)
 3. Choice Scarf (33%)
 4. Assault Vest (21%)
 5. Rocky Helmet (20%)
 6. Focus Sash (19%)
 7. Choice Band (15%)
 8. Choice Specs (13%)
 9. Sitrus Berry (8.3%)
 10. Toxic Orb (6.7%)
 11. Lum Berry (6.7%)
 12. Black Sludge (6.1%)
 13. Eviolite (6.0%)
 14. Charizardite X (5.5%)
 15. Air Balloon (5.4%)