### PR TITLE
fxPrefix is incorrect for downloaded Replays

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -342,6 +342,7 @@ var Tools = {
 	})(),
 
 	fxPrefix: (function () {
+		if (window.Replays) return 'http://play.pokemonshowdown.com/fx/';
 		if (document.location.protocol === 'file:') return 'fx/';
 		return '//play.pokemonshowdown.com/fx/';
 	})(),


### PR DESCRIPTION
Well, I guess it works if you upload your downloaded Replay, or if you download it into a clone of this repository...