### PR TITLE
Make resourcePrefix default to https: in replays to match fxPrefix

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -337,7 +337,7 @@ var Tools = {
 
 	resourcePrefix: (function () {
 		var prefix = '';
-		if (document.location.protocol === 'file:') prefix = 'http:';
+		if (document.location.protocol === 'file:') prefix = 'https:';
 		return prefix + '//play.pokemonshowdown.com/';
 	})(),
 


### PR DESCRIPTION
e9ba086 fixed fxPrefix to be https://play.pokemonshowdown.com/fx/ in downloaded replays but resourcePrefix is still http://play.pokemonshowdown.com/