### PR TITLE
Show target of effectiveness of spread moves

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -2279,6 +2279,7 @@ var Battle = (function () {
 
 	Battle.prototype.resultWaiting = false;
 	Battle.prototype.multiHitMove = null;
+	Battle.prototype.activeMoveIsSpread = null;
 
 	// callback
 	Battle.prototype.faintCallback = null;
@@ -2422,6 +2423,7 @@ var Battle = (function () {
 		// activity queue state
 		this.animationDelay = 0;
 		this.multiHitMove = null;
+		this.activeMoveIsSpread = null;
 		this.activityStep = 0;
 		this.activityDelay = 0;
 		this.activityAfter = null;
@@ -3222,6 +3224,7 @@ var Battle = (function () {
 			} else if (!kwargs.notarget) {
 				var usedMove = kwargs.anim ? Tools.getMove(kwargs.anim) : move;
 				if (kwargs.spread) {
+					this.activeMoveIsSpread = kwargs.spread;
 					var targets = [pokemon.sprite];
 					var hitPokemon = kwargs.spread.split(',');
 					if (hitPokemon[0] !== '.') {
@@ -3787,21 +3790,21 @@ var Battle = (function () {
 				var poke = this.getPokemon(args[1]);
 				for (var j = 1; !poke && j < 10; j++) poke = this.getPokemon(minors[i + j][0][1]);
 				if (poke) this.resultAnim(poke, 'Critical hit', 'bad');
-				actions += "A critical hit! ";
+				actions += "A critical hit" + (this.activeMoveIsSpread ? " on " + poke.getLowerName() : "") + "! ";
 				break;
 
 			case '-supereffective':
 				var poke = this.getPokemon(args[1]);
 				for (var j = 1; !poke && j < 10; j++) poke = this.getPokemon(minors[i + j][0][1]);
 				if (poke) this.resultAnim(poke, 'Super-effective', 'bad');
-				actions += "It's super effective! ";
+				actions += "It's super effective" + (this.activeMoveIsSpread ? " on " + poke.getLowerName() : "") + "! ";
 				break;
 
 			case '-resisted':
 				var poke = this.getPokemon(args[1]);
 				for (var j = 1; !poke && j < 10; j++) poke = this.getPokemon(minors[i + j][0][1]);
 				if (poke) this.resultAnim(poke, 'Resisted', 'neutral');
-				actions += "It's not very effective... ";
+				actions += "It's not very effective" + (this.activeMoveIsSpread ? " on " + poke.getLowerName() : "..") + ". ";
 				break;
 
 			case '-immune':
@@ -6196,6 +6199,7 @@ var Battle = (function () {
 			this.activityStep--;
 			this.resultWaiting = false;
 			this.multiHitMove = null;
+			this.activeMoveIsSpread = null;
 			return true;
 		}
 		return false;


### PR DESCRIPTION
When watching a doubles battle on a small screen, you don't get to see the chat, but you do get to see the "It's super effective!" or "It's not very effective..." messages. However for a spread move it's unclear whom each effectiveness refers to. My understanding is that in the case of a spread move the cart identifies each effectiveness.
Before:
![before](https://cloud.githubusercontent.com/assets/13849513/13761540/2471b53e-ea31-11e5-8e2b-88fad3c4ed45.PNG)
After:
![after](https://cloud.githubusercontent.com/assets/13849513/13761610/9a1dd7ea-ea31-11e5-8be7-ba6480abed85.PNG)
