### PR TITLE
Stop reinitialising the battles room when formats change

### DIFF
--- a/js/client-rooms.js
+++ b/js/client-rooms.js
@@ -128,7 +128,6 @@
 			this.$list = this.$('.list');
 
 			this.format = '';
-			app.on('init:formats', this.initialize, this);
 			app.on('response:roomlist', this.update, this);
 			app.send('/cmd roomlist');
 			this.update();


### PR DESCRIPTION
Prior to #647 the battle room had to repopulate its format selector when formats changed. Unfortunately it did this by reinitialising itself which not also sent a `/cmd roomlist` but also added another format change listener, thus doubling the number of `/cmd roomlist`s sent each time formats change. Worse, you didn't even need to leave the battle room open for this to happen, so after three format changes you would get three flood warnings, then eleven, then 27, and so on. (Eventually the server will flood you!)

Of course with the fix to #647 no repopulation is necessary so that line of code can simply be removed.