### PR TITLE
Better touch handling on mobile devices

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -61,12 +61,12 @@ var BattleTooltips = (function () {
 		// Prevent default on touch events to block mouse events when touch is used
 		e.preventDefault();
 
-		// If tooltip is open and the last finger left, close the tooptip
+		// If tooltip is open and the last finger just left, close the tooptip
 		if (touchTooltipTimeout === undefined && e.touches.length === 0) {
 			BattleTooltips.hideTooltip();
 		}
 	};
-	BattleTooltips._handleTouchEndFor = function (e) {
+	BattleTooltips._handleTouchEndFor = function (e, elem) {
 		// Close tooptip if needed
 		BattleTooltips._handleTouchLeaveFor(e);
 
@@ -76,6 +76,9 @@ var BattleTooltips = (function () {
 			clearTimeout(touchTooltipTimeout);
 			touchTooltipTimeout = undefined;
 			runClickActionOfButtonWithTooltip = true;
+
+			// Need to call `click` event manually because we prevented default behaviour of `touchend` event
+			elem.click();
 		}
 	};
 	// Call click on mouse up, because `runClickActionOfButtonWithTooltip` must be set before the click
@@ -83,7 +86,6 @@ var BattleTooltips = (function () {
 		BattleTooltips.hideTooltip();
 		runClickActionOfButtonWithTooltip = true;
 	};
-	// `Click` event always occurred last after touch + mouse events
 	// Stop click from doing it's action unless `runClickActionOfButtonWithTooltip` was set to true
 	// (in `_handleMouseUpFor` or in `_handleTouchEndFor`)
 	BattleTooltips._handleClickFor = function (e) {
@@ -98,7 +100,7 @@ var BattleTooltips = (function () {
 		var roomid = this.room.id;
 		return ' onclick="BattleTooltips._handleClickFor(event)"' +
 		' ontouchstart="BattleTooltips._handleTouchStartFor(event, \'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')"' +
-		' ontouchend="BattleTooltips._handleTouchEndFor(event)"' +
+		' ontouchend="BattleTooltips._handleTouchEndFor(event, this)"' +
 		' ontouchleave="BattleTooltips._handleTouchLeaveFor(event)"' +
 		' ontouchcancel="BattleTooltips._handleTouchLeaveFor(event)"' +
 		' onmouseover="BattleTooltips.showTooltipFor(\'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')"' +

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -37,11 +37,71 @@ var BattleTooltips = (function () {
 	};
 
 	// tooltips
-	BattleTooltips.prototype.tooltipAttrs = function (thing, type, ownHeight) {
-		var roomid = this.room.id;
-		return ' onmouseover="BattleTooltips.showTooltipFor(\'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')" ontouchstart="BattleTooltips.showTooltipFor(\'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')" onmouseout="BattleTooltips.hideTooltip()" onmouseup="BattleTooltips.hideTooltip()"';
-	};
+	if (navigator.userAgent.match(/(Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini)/)) {
+		// If user is using a mobile phone or tablet, use touch events
 
+		// Touch delay, pressing finger more than that time will cause the tooltip to open.
+		// Shorter time will cause teh button to click
+		var touchDelayForTap = 300; // ms
+
+		// Each time a finger presses the button this function will be callled
+		// First finger starts the counter, and when last fingers leaves time is checked
+		BattleTooltips._onTouchStart = function (roomid, thing, type, elem, ownHeight) {
+			// Saving number of Touch start happends (number of fingers on teh button,
+		  // though most of the time will be 1, don't won't a nasty bug like tooltip stuck open)
+			// Starts by 1 and increases each time this func is called
+			elem._numOfTaps = elem._numOfTaps !== undefined ? (elem._numOfTaps + 1) : 1;
+
+			// On first tap start counting
+			if (elem._numOfTaps === 1) {
+				setTimeout(function () {
+					// When tap is undefined means `_onTouchEnd` deleted it by the end of the time, perform the action
+					if (elem._numOfTaps === undefined) {
+						// short tap
+						elem._isCalledFromTocuh = true;
+						elem.click();
+					} else {
+						// When tap is not defined open the tooltip until `_onTouchEnd` will close it
+						elem._toolTipIsOpen = true;
+						BattleTooltips.showTooltipFor(roomid, thing, type, elem, ownHeight);
+					}
+				}, touchDelayForTap);
+			}
+		};
+		BattleTooltips._onTouchEnd = function (elem) {
+			// _numOfTaps always defined by `_onTouchStart` - is 1 or higher
+			elem._numOfTaps--;
+			// Delete variable when last finger left, no need for memory
+			if (elem._numOfTaps === 0) {
+				delete elem._numOfTaps;
+			}
+
+			// If tooltip is open and the last finger left, close the tooptip
+			if (elem._toolTipIsOpen && elem._numOfTaps === undefined) {
+				// Delete variable
+				delete elem._toolTipIsOpen;
+				BattleTooltips.hideTooltip();
+			}
+		};
+		// We define
+		BattleTooltips._onClick = function (elem, e) {
+			if (!elem._isCalledFromTocuh) {
+				e.stopPropagation();
+			} else {
+				delete elem._isCalledFromTocuh;
+			}
+		};
+		BattleTooltips.prototype.tooltipAttrs = function (thing, type, ownHeight) {
+			var roomid = this.room.id;
+			return ' onclick="BattleTooltips._onClick(this, event)" ontouchstart="BattleTooltips._onTouchStart(\'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')" ontouchend="BattleTooltips._onTouchEnd(this)" ontouchleave="BattleTooltips._onTouchEnd(this)"';
+		};
+	} else {
+		// If user is using a desktop, use mouse events
+		BattleTooltips.prototype.tooltipAttrs = function (thing, type, ownHeight) {
+			var roomid = this.room.id;
+			return ' onmouseover="BattleTooltips.showTooltipFor(\'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')" onmouseout="BattleTooltips.hideTooltip()" onmouseup="BattleTooltips.hideTooltip()"';
+		};
+	}
 	BattleTooltips.prototype.showTooltip = function (thing, type, elem, ownHeight) {
 		var room = this.room;
 

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -37,7 +37,7 @@ var BattleTooltips = (function () {
 	};
 	// tooltips
 	// Touch delay, pressing finger more than that time will cause the tooltip to open.
-	// Shorter time will cause teh button to click
+	// Shorter time will cause the button to click
 	var touchDelayForTap = 300; // ms
 
 	// Each time a finger presses the button this function will be callled
@@ -49,10 +49,10 @@ var BattleTooltips = (function () {
 		// Saving number of Touch start happends (number of fingers on teh button,
 	  // though most of the time will be 1, don't won't a nasty bug like tooltip stuck open)
 		// Starts by 1 and increases each time this func is called
-		elem._numOfTaps = elem._numOfTaps !== undefined ? (elem._numOfTaps + 1) : 1;
+		elem._numOfTouches = event.touches.length;
 
 		// On first tap start counting
-		if (elem._numOfTaps === 1) {
+		if (elem._numOfTouches === 1) {
 			// Timeout will be canceled by `_handleTouchEndFor` if a short tap have occurred
 			elem._timeout = setTimeout(function () {
 				elem._toolTipIsOpen = true;
@@ -64,15 +64,14 @@ var BattleTooltips = (function () {
 		// Prevent default on touch events to block mouse events when touch is used
 		event.preventDefault();
 
-		// _numOfTaps always defined by `_onTouchStart` - is 1 or higher
-		elem._numOfTaps--;
+		elem._numOfTouches = event.touches.length;
 		// Delete variable when last finger left, no need for memory
-		if (elem._numOfTaps === 0) {
-			delete elem._numOfTaps;
+		if (elem._numOfTouches === 0) {
+			delete elem._numOfTouches;
 		}
 
 		// If tooltip is open and the last finger left, close the tooptip
-		if (elem._toolTipIsOpen && elem._numOfTaps === undefined) {
+		if (elem._toolTipIsOpen && elem._numOfTouches === undefined) {
 			// Delete variable
 			delete elem._toolTipIsOpen;
 			BattleTooltips.hideTooltip();
@@ -82,7 +81,7 @@ var BattleTooltips = (function () {
 		// Save bool for firing the action before changing the variables
 		// If tooltip is not opened and the last finger left,
 		// meaning the timeout in `_handleTouchStartFor` wasn't fired, fire the action
-		var shouldFireAction = (elem._toolTipIsOpen === undefined && elem._numOfTaps === 1);
+		var shouldFireAction = (elem._toolTipIsOpen === undefined && elem._numOfTouches === 1);
 
 		// Decrease taps and close tooltip when needed
 		BattleTooltips._handleTouchLeaveFor(event, elem);
@@ -94,16 +93,6 @@ var BattleTooltips = (function () {
 
 			elem._isCalledManually = true;
 			elem.click();
-		}
-	};
-	BattleTooltips._handleTouchCancelFor = function (event, elem) {
-		if (elem._numOfTaps !== undefined) {
-			delete elem._numOfTaps;
-		}
-		if (elem._toolTipIsOpen) {
-			// Delete variable
-			delete elem._toolTipIsOpen;
-			BattleTooltips.hideTooltip();
 		}
 	};
 	// Call click on mouse up, because `_isCalledManually` must be set before the click
@@ -127,7 +116,7 @@ var BattleTooltips = (function () {
 		' ontouchstart="BattleTooltips._handleTouchStartFor(event, \'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')"' +
 		' ontouchend="BattleTooltips._handleTouchEndFor(event, this)"' +
 		' ontouchleave="BattleTooltips._handleTouchLeaveFor(event, this)"' +
-		' ontouchcancel="BattleTooltips._handleTouchCancelFor(event, this)"' +
+		' ontouchcancel="BattleTooltips._handleTouchLeaveFor(event, this)"' +
 		' onmouseover="BattleTooltips.showTooltipFor(\'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')"' +
 		' onmouseout="BattleTooltips.hideTooltip()"' +
 		' onmouseup="BattleTooltips._handleMouseUpFor(this)"';

--- a/style/client.css
+++ b/style/client.css
@@ -1906,11 +1906,11 @@ a.ilink.yours {
 .switchmenu button,
 .movemenu button {
 	-webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 	position: relative;
 	outline: none;
 	text-align: center;

--- a/style/client.css
+++ b/style/client.css
@@ -1905,12 +1905,6 @@ a.ilink.yours {
 }
 .switchmenu button,
 .movemenu button {
-	-webkit-touch-callout: none;
-	-webkit-user-select: none;
-	-khtml-user-select: none;
-	-moz-user-select: none;
-	-ms-user-select: none;
-	user-select: none;
 	position: relative;
 	outline: none;
 	text-align: center;

--- a/style/client.css
+++ b/style/client.css
@@ -1905,6 +1905,12 @@ a.ilink.yours {
 }
 .switchmenu button,
 .movemenu button {
+	-webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 	position: relative;
 	outline: none;
 	text-align: center;


### PR DESCRIPTION
First of all, love the game, thanks for bringing Pokemon to the web!
Playing it at school, at work, even some before sleep for a long time!

One thing that bothered me for long is how it runs on mobile.
Works fast and all but buttons are a nightmare, tooltip stays until you click somewhere else, on iOS I find myself to click the button 20 times until it registers.

Not long ago I saw this on Github finally and decided to fix this today.

Anyway I changed the tooltip attributes from mouse events to touch events.
When you long press (more than 300ms) the tooltip shows, and when you short press (shorter than 300ms) the normal click event is called (which is kind of a hack, you are welcome to change).

Wished you made this more of a standalone project, pain to debug on release site.

Have a nice day and hope to see this in the site really soon!

***Update:***
*Before*:
- Focus stays sometimes when clicking, so you must click outside
![](http://s22.postimg.org/jsa5fewkh/focus_stays_small.gif)
- Sometimes it just clicks when wanting to see the tooltip
![](http://s17.postimg.org/yhyzl9ukf/clicks_when_letting_go_small.gif)

*After*:
- **You either see the tooltip or click, can't be both.**
- **disappears right after lifting the finger**

![](http://s10.postimg.org/lwpqga2d5/touch_demo_smaller.gif)