### PR TITLE
Increase opacity in battle background

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -26,7 +26,7 @@ License: GPLv2
 	top: -90px;
 	left: -50px;
 	background: transparent url(../fx/bg-beach.png) no-repeat scroll left top;
-	opacity: 0.6;
+	opacity: 0.8;
 }
 .battle a {
 	color: #2277FF;


### PR DESCRIPTION
Now it looks too bright, making the Pokémon look like they are out of place