### PR TITLE
Close the choice notification when the battle ends

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -224,6 +224,7 @@
 				// battle has ended
 				if (this.side) {
 					// was a player
+					this.closeNotification('choice');
 					this.$controls.html('<div class="controls"><p>' + replayDownloadButton + '<em><button name="instantReplay"><i class="fa fa-undo"></i> Instant Replay</button></p><p><button name="closeAndMainMenu"><strong>Main menu</strong><br /><small>(closes this battle)</small></button> <button name="closeAndRematch"><strong>Rematch</strong><br /><small>(closes this battle)</small></button></p></div>');
 				} else {
 					this.$controls.html('<div class="controls"><p>' + replayDownloadButton + '<em><button name="switchSides"><i class="fa fa-random"></i> Switch sides</button> <button name="instantReplay"><i class="fa fa-undo"></i> Instant Replay</button></p></div>');


### PR DESCRIPTION
If (for example) you forfeit, the notification lingers until you close the battle