### PR TITLE
Make declared visited links readable in dark mode

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -799,7 +799,11 @@ License: GPLv2
 .message-announce a,
 .broadcast-green a,
 .broadcast-blue a,
-.broadcast-red a {
+.broadcast-red a,
+.dark .message-announce a,
+.dark .broadcast-green a,
+.dark .broadcast-blue a,
+.dark .broadcast-red a {
 	/* Readable link colour */
 	color: #DDEEFF;
 }


### PR DESCRIPTION
Make sure `.dark a:visited` doesn't apply to links in declares or colored
broadcast divs