### PR TITLE
Make subtle buttons more visible in dark mode

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -875,3 +875,27 @@ License: GPLv2
 	font-size:9pt;
 	content: '...';
 }
+a.subtle {
+	text-decoration: none;
+	color: black;
+}
+a.subtle:hover {
+	text-decoration: underline;
+	color: #6688CC;
+}
+button.subtle {
+	border: 0;
+	background: transparent;
+	padding: 0;
+	margin: 0;
+	color: #224466;
+	outline: 0;
+	font-size: 9pt;
+	font-family: Verdana, sans-serif;
+}
+.dark button.subtle {
+	color: #7598BD;
+}
+button.subtle:hover {
+	text-decoration: underline;
+}

--- a/style/client.css
+++ b/style/client.css
@@ -69,27 +69,6 @@ body {
 .textbox:focus {
 	background: #FFFFFF;
 }
-a.subtle {
-	text-decoration: none;
-	color: black;
-}
-a.subtle:hover {
-	text-decoration: underline;
-	color: #6688CC;
-}
-button.subtle {
-	border: 0;
-	background: transparent;
-	padding: 0;
-	margin: 0;
-	color: #224466;
-	outline: 0;
-	font-size: 9pt;
-	font-family: Verdana, sans-serif;
-}
-button.subtle:hover {
-	text-decoration: underline;
-}
 .buttonbar {
 	margin-top: 1em;
 	text-align: center;


### PR DESCRIPTION
While this isn't a huge issue, the "(x lines from y hidden)" message can be pretty hard to read in front of a blueish background (e.g. http://i.imgur.com/yUxRvRY.png). I changed it to look like this: http://i.imgur.com/MlXvtq2.png
Something I'm not really sure about is where to place the new rule in the css file - I put it in the dark mode/chat section since that seemed the most fitting.