### PR TITLE
Fix active pokemon ability text in tooltip

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -386,7 +386,13 @@ var BattleTooltips = (function () {
 		var showOtherSees = isActive;
 		if (myPokemon) {
 			if (this.battle.gen > 2) {
-				text += '<p>Ability: ' + Tools.getAbility(pokemon.ability || myPokemon.baseAbility).name;
+				var abilityText = '';
+				if (pokemon.ability && (pokemon.ability !== pokemon.baseAbility)) {
+					abilityText = Tools.getAbility(pokemon.ability).name + ' (base: ' + Tools.getAbility(pokemon.baseAbility).name + ')';
+				} else {
+					abilityText = Tools.getAbility(pokemon.baseAbility).name;
+				}
+				text += '<p>Ability: ' + abilityText;
 				if (myPokemon.item) {
 					text += ' / Item: ' + Tools.getItem(myPokemon.item).name;
 				}
@@ -425,7 +431,11 @@ var BattleTooltips = (function () {
 					text += '</p>';
 				}
 			} else if (pokemon.ability) {
-				text += '<p>Ability: ' + Tools.getAbility(pokemon.ability).name + '</p>';
+				if (pokemon.ability === pokemon.baseAbility) {
+					text += '<p>Ability: ' + Tools.getAbility(pokemon.ability).name + '</p>';
+				} else {
+					text += '<p>Ability: ' + Tools.getAbility(pokemon.ability).name + ' (base: ' +  Tools.getAbility(pokemon.baseAbility).name + ')' + '</p>';
+				}
 			} else if (pokemon.baseAbility) {
 				text += '<p>Ability: ' + Tools.getAbility(pokemon.baseAbility).name + '</p>';
 			}

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -386,7 +386,7 @@ var BattleTooltips = (function () {
 		var showOtherSees = isActive;
 		if (myPokemon) {
 			if (this.battle.gen > 2) {
-				text += '<p>Ability: ' + Tools.getAbility(myPokemon.baseAbility).name;
+				text += '<p>Ability: ' + Tools.getAbility(pokemon.ability || myPokemon.baseAbility).name;
 				if (myPokemon.item) {
 					text += ' / Item: ' + Tools.getItem(myPokemon.item).name;
 				}


### PR DESCRIPTION
Currently the ability displayed in the active pokemon tooltip is the base ability of the pokemon, even after Skill Swap or similar skills.

For example, after Skill Swapping No Guard:
Before this change, it incorrectly displays No Guard as the current ability:
![before](https://cloud.githubusercontent.com/assets/14254843/15458413/bc04c1e0-2067-11e6-82a8-c822e7d8a0b2.PNG) 
After this change, it's more consistent with what the opponent sees:
![after](https://cloud.githubusercontent.com/assets/14254843/15458407/99c39304-2067-11e6-9bb0-2388da40efbd.PNG)