### PR TITLE
Fix active pokemon ability text in tooltip

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -386,7 +386,13 @@ var BattleTooltips = (function () {
 		var showOtherSees = isActive;
 		if (myPokemon) {
 			if (this.battle.gen > 2) {
-				text += '<p>Ability: ' + Tools.getAbility(pokemon.ability || myPokemon.baseAbility).name;
+				var abilityText = '';
+				if (pokemon.ability && (pokemon.ability !== pokemon.baseAbility)) {
+					abilityText = Tools.getAbility(pokemon.ability).name + ' (base: ' + Tools.getAbility(pokemon.baseAbility).name + ')';
+				} else {
+					abilityText = Tools.getAbility(myPokemon.baseAbility).name;
+				}
+				text += '<p>Ability: ' + abilityText;
 				if (myPokemon.item) {
 					text += ' / Item: ' + Tools.getItem(myPokemon.item).name;
 				}
@@ -425,7 +431,11 @@ var BattleTooltips = (function () {
 					text += '</p>';
 				}
 			} else if (pokemon.ability) {
-				text += '<p>Ability: ' + Tools.getAbility(pokemon.ability).name + '</p>';
+				if (pokemon.ability === pokemon.baseAbility) {
+					text += '<p>Ability: ' + Tools.getAbility(pokemon.ability).name + '</p>';
+				} else {
+					text += '<p>Ability: ' + Tools.getAbility(pokemon.ability).name + ' (base: ' +  Tools.getAbility(pokemon.baseAbility).name + ')' + '</p>';
+				}
 			} else if (pokemon.baseAbility) {
 				text += '<p>Ability: ' + Tools.getAbility(pokemon.baseAbility).name + '</p>';
 			}

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -386,7 +386,7 @@ var BattleTooltips = (function () {
 		var showOtherSees = isActive;
 		if (myPokemon) {
 			if (this.battle.gen > 2) {
-				text += '<p>Ability: ' + Tools.getAbility(myPokemon.baseAbility).name;
+				text += '<p>Ability: ' + Tools.getAbility(pokemon.ability || myPokemon.baseAbility).name;
 				if (myPokemon.item) {
 					text += ' / Item: ' + Tools.getItem(myPokemon.item).name;
 				}


### PR DESCRIPTION
Updated as recommended in #713  to show the current and base ability of the active pokemon, as a bonus it also works on the foe's active pokemon. 
![capture](https://cloud.githubusercontent.com/assets/14254843/15491028/af84c414-213a-11e6-90c8-000cd62de90f.PNG)
