### PR TITLE
Include the effect of Gravity in accuracy calculation

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -864,6 +864,10 @@ var BattleTooltips = (function () {
 			accuracy *= 1.1;
 			accuracyComment += ' (Boosted by Wide Lens)';
 		}
+		if (this.battle.hasPseudoWeather('Gravity')) {
+			accuracy *= 5 / 3;
+			accuracyComment += ' (Boosted by Gravity)';
+		}
 		return Math.round(accuracy) + accuracyComment;
 	};
 


### PR DESCRIPTION
Because it doesn't depend on the target, unlike all the other accuracy-changing effects that I could find.