### PR TITLE
Tooltips: fix OHKO moves accuracy text

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -837,6 +837,10 @@ var BattleTooltips = (function () {
 		}
 		if (!accuracy || accuracy === true) return '&mdash;';
 		if (ability === 'No Guard') return '&mdash; (Boosted by No Guard)';
+		if (move.ohko) {
+			if (this.battle.gen === 1) return accuracy + '% (Will fail if target\'s speed is higher)';
+			return accuracy + '% (Will fail if target\'s level is higher, increases 1% per each level above target)';
+		}
 		if (pokemon.boosts && pokemon.boosts.accuracy) {
 			if (pokemon.boosts.accuracy > 0) {
 				accuracy *= (pokemon.boosts.accuracy + 3) / 3;


### PR DESCRIPTION
Currently OHKO moves show their accuracy as if they were affected by acc boosts/items/abilities (so for example, Hone Claws will increase the shown %).

This change also adds some text regarding how the true accuracy of the moves is calculated, the exact percentage can't be shown since there's no target data consistently available (target in double battles etc.).