### PR TITLE
Fix teambuilder problems with alternate forms

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2333,6 +2333,8 @@
 			this.updatePokemonSprite();
 		},
 		altForm: function (e) {
+			var target = $(e.target);
+			if (!(target.is('div') || target.is('i'))) return;
 			var set = this.curSet;
 			var i = 0;
 			if (!set) {

--- a/js/search.js
+++ b/js/search.js
@@ -794,7 +794,7 @@
 
 		case 'move':
 			template = Tools.getTemplate(set.species);
-			if (!(template.id in BattleTeambuilderTable.learnsets)) {
+			if (!(template.id in BattleTeambuilderTable.learnsets) || template.form) {
 				template = Tools.getTemplate(template.baseSpecies);
 			}
 			var moves = [];

--- a/style/client.css
+++ b/style/client.css
@@ -3115,6 +3115,10 @@ a.ilink.yours {
 	background-color: #AAAAAA;
 	color: black;
 }
+.dark .changeform i {
+	border: 1px solid #bbb;
+	color: #bbb;
+}
 
 .dark .ps-overlay {
 	background: rgba(40, 40, 40, .5);


### PR DESCRIPTION
- Visible changeform button in dark mode
Oversight on my part, I forgot to make an alternative for dark mode, and the current colour is practiacally invisible.

- Show all learned moves on alternate forms
The teambuilder right now only shows the pre-evolutions moveset if you pick an alternate form first.

- Stop the changeform click event from triggering when you click the Pokemon input box
Right now, if you click the input box to change pokemon and there's a Pokemon with an alternate sprite selected, the event triggers anyway. 