### PR TITLE
Apply highlights in battles as well

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5975,11 +5975,20 @@ var Battle = (function () {
 			args.shift();
 			args.shift();
 			var message = args.join('|');
-			var parsedMessage = Tools.parseChatMessage(message, name, '');
+			var isHighlighted = window.app.rooms && app.rooms[this.roomid] && app.rooms[this.roomid].getHighlight(message);
+			var parsedMessage = Tools.parseChatMessage(message, name, '', isHighlighted);
 			if (!$.isArray(parsedMessage)) parsedMessage = [parsedMessage];
 			for (var i = 0; i < parsedMessage.length; i++) {
 				if (!parsedMessage[i]) continue;
 				this.log(parsedMessage[i], preempt);
+			}
+			if (isHighlighted) {
+				var $lastMessage = preempt ? this.logPreemptElem.children().last() : this.logElem.children().last();
+				var notifyTitle = "Mentioned by " + name + (this.roomid ? " in " + this.roomid : '');
+				var notifyText = $lastMessage.html().indexOf('<span class="spoiler">') >= 0 ? '(spoiler)' : $lastMessage.children().last().text();
+				app.rooms[this.roomid].notifyOnce(notifyTitle, "\"" + notifyText + "\"", 'highlight');
+			} else if (name !== '~') { // |c|~| prefixes a system message
+				app.rooms[this.roomid].subtleNotifyOnce();
 			}
 			break;
 		case 'chatmsg':

--- a/style/battle.css
+++ b/style/battle.css
@@ -694,6 +694,12 @@ License: GPLv2
 	padding: 3px 0 3px 0;
 	font-size: 8pt;
 }
+.battle-log .chat.highlighted {
+	margin-left: -8px;
+	margin-right: -8px;
+	padding-left: 8px;
+	padding-right: 8px;
+}
 .battle-log .chat strong {
 	color: #40576A;
 }


### PR DESCRIPTION
Also fix ignoring in battles to not work on staff members.

I hope it's ok to put the highlight stuff in Tools - figured it's the best place for it to be accessible from client-chat.js and battle.js, similarly to parseChatMessage which is already there.