### PR TITLE
Allow use of multiple interval operators in hl regex

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -650,7 +650,7 @@
 			case 'highlight':
 				var highlights = Tools.prefs('highlights') || [];
 				if (target.indexOf(',') > -1) {
-					var targets = target.match(/[^,]+(,\d*}[^,]*)?/g);
+					var targets = target.match(/([^,]+?({\d*,\d*})?)+/g);
 					// trim the targets to be safe
 					for (var i = 0, len = targets.length; i < len; i++) {
 						targets[i] = targets[i].replace(/\n/g, '').trim();


### PR DESCRIPTION
I.e. `/hl add,abc{1,2}def{2,3}` will no longer lead to the highlights `abc{1,2}def{2` and `3}` being set, instead counting as one.