### PR TITLE
Prevent empty highlights

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -658,6 +658,7 @@
 					switch (targets[0]) {
 					case 'add':
 						for (var i = 1, len = targets.length; i < len; i++) {
+							if (!targets[i]) continue;
 							if (/[\\^$*+?()|{}[\]]/.test(targets[i])) {
 								// Catch any errors thrown by newly added regular expressions so they don't break the entire highlight list
 								try {


### PR DESCRIPTION
A command like `/highlight add, , , , , , , , , , , , , , , ` currently adds all of them as empty highlights, which means every message that is sent gets highlighted.

You could probably accomplish this by changing the regex too, but I don't know how to do that.