### PR TITLE
Rework /html as inline, old behavior kept as /raw

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -515,6 +515,8 @@ var Tools = {
 		case 'error':
 			return '<div class="chat message-error">' + Tools.escapeHTML(target) + '</div>';
 		case 'html':
+			return '<div class="chat chatmessage-' + toId(name) + hlClass + mineClass + '">' + timestamp + '<strong style="' + color + '">' + clickableName + ':</strong> <em>' + Tools.sanitizeHTML(target) + '</em></div>';
+		case 'raw':
 			return '<div class="chat">' + Tools.sanitizeHTML(target) + '</div>';
 		default:
 			// Not a command or unsupported. Parsed as a normal chat message.


### PR DESCRIPTION
This makes it so the client can send /html [message] and it can parse it like a chat message with HTML.

This commit is especially helpful to side-servers that sometimes add custom formatting, such as emoticons.