### PR TITLE
Reset sprite when affected by Smack Down

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -4761,6 +4761,7 @@ var Battle = (function () {
 					actions += "" + poke.getName() + " fell straight down!";
 					poke.removeVolatile('magnetrise');
 					poke.removeVolatile('telekinesis');
+					if (poke.lastmove === 'fly' || poke.lastmove === 'bounce') poke.sprite.animReset();
 					break;
 				case 'substitute':
 					if (kwargs.damage) {


### PR DESCRIPTION
The lastmove check is there in case a levitating mon gets hit by No Guard Smack Down while using Dig or Dive. Considering how contrived that scenario is, I'm not sure if it's worth it. Seems cleaner this way though.