### PR TITLE
Prevent blankposting with "[[**]]"

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -542,6 +542,15 @@ var Tools = {
 		// ~~strikethrough~~
 		str = str.replace(/\~\~([^< ](?:[^<]*?[^< ])??)\~\~/g,
 			options.hidestrikethrough ? '$1' : '<s>$1</s>');
+		// __italics__
+		str = str.replace(/\_\_([^< ](?:[^<]*?[^< ])??)\_\_/g,
+			options.hideitalics ? '$1' : '<i>$1</i>');
+		// **bold**
+		str = str.replace(/\*\*([^< ](?:[^<]*?[^< ])??)\*\*/g,
+			options.hidebold ? '$1' : '<b>$1</b>');
+		// ^^superscript^^
+		str = str.replace(/\^\^([^< ](?:[^<]*?[^< ])??)\^\^/g,
+			options.hidesuperscript ? '$1' : '<sup>$1</sup>');
 		// <<roomid>>
 		str = str.replace(/&lt;&lt;([a-z0-9-]+)&gt;&gt;/g,
 			options.hidelinks ? '&laquo;$1&raquo;' : '&laquo;<a href="/$1" target="_blank">$1</a>&raquo;');
@@ -614,21 +623,12 @@ var Tools = {
 			});
 			// [[blah]]
 			//   Short form of gl[blah]
-			str = str.replace(/\[\[([^< ](?:[^<`]*?[^< ])??)\]\]/ig, function (p0, p1) {
+			str = str.replace(/\[\[([^< ](?:[^<`]*?[^< ])??)\]\]/g, function (p0, p1) {
 				var q = Tools.escapeHTML(encodeURIComponent(Tools.unescapeHTML(p1)));
 				return '<a href="http://www.google.com/search?ie=UTF-8&btnI&q=' + q +
 					'" target="_blank">' + p1 + '</a>';
 			});
 		}
-		// __italics__
-		str = str.replace(/\_\_([^< ](?:[^<]*?[^< ])??)\_\_(?![^<]*?<\/a)/g,
-			options.hideitalics ? '$1' : '<i>$1</i>');
-		// **bold**
-		str = str.replace(/\*\*([^< ](?:[^<]*?[^< ])??)\*\*/g,
-			options.hidebold ? '$1' : '<b>$1</b>');
-		// ^^superscript^^
-		str = str.replace(/\^\^([^< ](?:[^<]*?[^< ])??)\^\^/g,
-			options.hidesuperscript ? '$1' : '<sup>$1</sup>');
 
 		if (!options.hidespoiler) {
 			var untilIndex = 0;


### PR DESCRIPTION
Putting bold and italics parsing before the [[ ]] parsing prevents the issue that caused the seemingly empty post. At first I went with the lookaround for "&lt;/a&gt;" like it was done for italics, but reordering seems cleaner. As a bonus, all these similar formatting options are now in one place.

Also remove unneeded regex flag.