### PR TITLE
Prevent roomtabs unnecessarily jumping to the side

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -1471,7 +1471,7 @@
 			if (leftWidth < leftMinMain) {
 				leftWidth = leftMinMain;
 			}
-			if (this.curRoom.type === 'battle' && this.sideRoom.type === 'chat') {
+			if (this.curRoom.type === 'battle' && this.sideRoom.type !== 'battle') {
 				// I give up; hardcoding
 				var offset = Math.floor((available - leftMinMain - rightMin) / 2);
 				if (offset > 0) leftWidth += offset;


### PR DESCRIPTION
Only a situation where a battle is open in both the left and right room shouldn't use the hardcoding, since the right battle wouldn't get enough space otherwise.

See https://github.com/Zarel/Pokemon-Showdown-Client/commit/07a339f62c6d897f01ddeb539d28f05d49189d85#commitcomment-18000443
