### PR TITLE
Refresh autojoins after failed room join

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -1199,6 +1199,7 @@
 		unjoinRoom: function (id, reason) {
 			this.removeRoom(id, true);
 			if (this.curRoom) this.navigate(this.curRoom.id, {replace: true});
+			this.updateAutojoin();
 		},
 		tryJoinRoom: function (id) {
 			this.joinRoom(id);


### PR DESCRIPTION
This is mostly to prevent expired groupchats from staying on your autojoins indefinetely unless you join/leave another room manually.