### PR TITLE
Add .dark .teambuilder-clipboard-data

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -2679,6 +2679,9 @@ a.ilink.yours {
 	right: 8px;
 	z-index: 2;
 }
+.dark .teambuilder-clipboard-data {
+	color: #000000;
+}
 .teambuilder-clipboard-data:hover {
 	border: 1px solid #BBBBBB;
 }


### PR DESCRIPTION
This helps to make this property more visible in darkmode

BEFORE:
<img src="http://image.prntscr.com/image/98777f98977b4f13be163d381e0ca1fb.png">

AFTER:
<img src="http://image.prntscr.com/image/ba19ea1f692541b0a1c9eab6fa2582b7.png">