### PR TITLE
Allow status to be cured silently

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -4135,7 +4135,9 @@ var Battle = (function () {
 				var ofpoke = this.getPokemon(kwargs.of);
 				poke.status = '';
 
-				if (effect.id) switch (effect.id) {
+				if (kwargs.silent) {
+					// do nothing
+				} else if (effect.id) switch (effect.id) {
 				case 'psychoshift':
 					actions += '' + poke.getName() + ' moved its status onto ' + ofpoke.getLowerName() + '!';
 					this.resultAnim(poke, 'Cured', 'good');


### PR DESCRIPTION
Heal Bell can't cure soundproof allies in Generation 3 or 4, so we can't use `-cureteam`, but it doesn't list cured Pokémon, so we need to be able to make it `[silent]`.