### PR TITLE
Add FormatMod Support for OMs

### DIFF
--- a/js/client-formatmods.js
+++ b/js/client-formatmods.js
@@ -6,7 +6,7 @@
 
 			var keys = Object.keys(BattlePokedex);
 
-			for (var i = 0, key, poke; key < keys.length;) {
+			for (var i = 0, key, poke; i < keys.length;) {
 				key = keys[i++];
 				poke = $.extend(true, {}, BattlePokedex[key]);
 

--- a/js/client-formatmods.js
+++ b/js/client-formatmods.js
@@ -1,49 +1,53 @@
-(function(exports, $){
+(function (exports, $) {
+
 	var FormatMods = exports.FormatMods = ({
-		tiershift: function tierShiftMod () {
+		tiershift: function tierShiftMod() {
 			var mod = {};
 
 			var keys = Object.keys(BattlePokedex);
 
-			for(var i=0, key, poke;key = keys[i++];){
+			for (var i = 0, key, poke; key < keys.length;) {
+				key = keys[i++];
 				poke = $.extend(true, {}, BattlePokedex[key]);
 
-				switch(poke.tier){
-					case "UU":
-					case "BL2": FormatMods._IncreaseStats(poke, 5); break;
+				switch (poke.tier) {
 
-					case "RU":
-					case "BL3": FormatMods._IncreaseStats(poke, 10); break;
+				case "UU":
+				case "BL2": FormatMods._IncreaseStats(poke, 5); break;
 
-					case "NU":
-					case "BL4": FormatMods._IncreaseStats(poke, 15); break;
+				case "RU":
+				case "BL3": FormatMods._IncreaseStats(poke, 10); break;
 
-					case "PU":
-					case "NFE":
-					case "LC Uber":
-					case "LC": FormatMods._IncreaseStats(poke, 20); break;
+				case "NU":
+				case "BL4": FormatMods._IncreaseStats(poke, 15); break;
+
+				case "PU":
+				case "NFE":
+				case "LC Uber":
+				case "LC": FormatMods._IncreaseStats(poke, 20); break;
+
 				}
 
-				mod[key] = poke
+				mod[key] = poke;
 			}
 
 			return mod;
 		}
 	});
 
-	FormatMods._IncreaseStats = function _SumStat (poke, quant) {
+	FormatMods._IncreaseStats = function _SumStat(poke, quant) {
 		var stats = poke.baseStats;
 
-		stats.atk = Math.clamp(stats.atk + quant, 1, 255);
-		stats.def = Math.clamp(stats.def + quant, 1, 255);
-		stats.hp  = Math.clamp(stats.hp  + quant, 1, 255);
-		stats.spa = Math.clamp(stats.spa + quant, 1, 255);
-		stats.spd = Math.clamp(stats.spd + quant, 1, 255);
-		stats.spe = Math.clamp(stats.spe + quant, 1, 255);
-	}
+		stats.atk = clamp(stats.atk + quant, 1, 255);
+		stats.def = clamp(stats.def + quant, 1, 255);
+		stats.hp = clamp(stats.hp + quant, 1, 255);
+		stats.spa = clamp(stats.spa + quant, 1, 255);
+		stats.spd = clamp(stats.spd + quant, 1, 255);
+		stats.spe = clamp(stats.spe + quant, 1, 255);
+	};
 
-	Math.clamp = function clamp(num, min, max){
-		return num < min? min : num > max? max : num;
+	function clamp(num, min, max) {
+		return num < min ? min : num > max ? max : num;
 	}
 
 })(window, jQuery);

--- a/js/client-formatmods.js
+++ b/js/client-formatmods.js
@@ -1,0 +1,49 @@
+(function(exports, $){
+	var FormatMods = exports.FormatMods = ({
+		tiershift: function tierShiftMod () {
+			var mod = {};
+
+			var keys = Object.keys(BattlePokedex);
+
+			for(var i=0, key, poke;key = keys[i++];){
+				poke = $.extend(true, {}, BattlePokedex[key]);
+
+				switch(poke.tier){
+					case "UU":
+					case "BL2": FormatMods._IncreaseStats(poke, 5); break;
+
+					case "RU":
+					case "BL3": FormatMods._IncreaseStats(poke, 10); break;
+
+					case "NU":
+					case "BL4": FormatMods._IncreaseStats(poke, 15); break;
+
+					case "PU":
+					case "NFE":
+					case "LC Uber":
+					case "LC": FormatMods._IncreaseStats(poke, 20); break;
+				}
+
+				mod[key] = poke
+			}
+
+			return mod;
+		}
+	});
+
+	FormatMods._IncreaseStats = function _SumStat (poke, quant) {
+		var stats = poke.baseStats;
+
+		stats.atk = Math.clamp(stats.atk + quant, 1, 255);
+		stats.def = Math.clamp(stats.def + quant, 1, 255);
+		stats.hp  = Math.clamp(stats.hp  + quant, 1, 255);
+		stats.spa = Math.clamp(stats.spa + quant, 1, 255);
+		stats.spd = Math.clamp(stats.spd + quant, 1, 255);
+		stats.spe = Math.clamp(stats.spe + quant, 1, 255);
+	}
+
+	Math.clamp = function clamp(num, min, max){
+		return num < min? min : num > max? max : num;
+	}
+
+})(window, jQuery);

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -125,7 +125,7 @@
 			teams = Storage.teams;
 
 			if (this.curTeam) {
-				this.checkTierSystem();
+				this.checkFormatMods();
 
 				this.ignoreEVLimits = (this.curTeam.gen < 3);
 				if (this.curSet) {
@@ -3225,7 +3225,7 @@
 			app.clearGlobalListeners();
 			Room.prototype.destroy.call(this);
 		},
-		checkTierSystem: function () {
+		checkFormatMods: function () {
 			if(FormatMods.currentMod && this.curTeam.format && FormatMods.currentMod.format === this.curTeam.format)
 				return;
 

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -3226,16 +3226,18 @@
 			Room.prototype.destroy.call(this);
 		},
 		checkFormatMods: function () {
-			if(FormatMods.currentMod && this.curTeam.format && FormatMods.currentMod.format === this.curTeam.format)
+			var FormatMods = exports.FormatMods;
+
+			if (FormatMods.currentMod && this.curTeam.format && FormatMods.currentMod.format === this.curTeam.format)
 				return;
 
 			var mod = exports.FormatMods[this.curTeam.format] && exports.FormatMods[this.curTeam.format].call(this);
 
-			if(mod !== undefined)
+			if (mod !== undefined)
 				FormatMods.currentMod = {
 					format: this.curTeam.format,
 					mod: mod
-				}
+				};
 			else
 				delete FormatMods.currentMod;
 		}

--- a/js/search.js
+++ b/js/search.js
@@ -346,6 +346,8 @@
 		var buf = [];
 		var illegalBuf = [];
 		var legal = this.legalityFilter;
+		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+
 		if (qType === 'pokemon') {
 			switch (fType) {
 			case 'type':
@@ -428,6 +430,9 @@
 	Search.prototype.allPokemon = function () {
 		if (this.filters || this.sortCol) return this.filteredPokemon();
 		var resultSet = [['sortpokemon', '']];
+
+		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+
 		for (var id in BattlePokedex) {
 			switch (id) {
 			case 'bulbasaur':
@@ -519,6 +524,8 @@
 		var filters = this.filters || [];
 		var sortCol = this.sortCol;
 
+		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+
 		this.resultSet = [['sortpokemon', '']];
 		if (filters.length) this.resultSet.push(['html', this.getFilterText()], ['header', "Filtered results"]);
 		if (sortCol === 'type') {
@@ -603,6 +610,9 @@
 		resultSet.push(['header', "Filtered results"]);
 		var illegalResultSet = [];
 		var filters = this.filters;
+
+		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+
 		for (var id in BattleMovedex) {
 			var move = BattleMovedex[id];
 			if (move.exists === false) continue;
@@ -693,6 +703,8 @@
 		this.renderedIndex = i;
 	};
 	Search.prototype.setType = function (qType, format, set, cur) {
+		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+
 		if (!format) format = '';
 		if (this.qType !== qType) {
 			this.filters = null;
@@ -733,16 +745,16 @@
 			var slices = table.formatSlices;
 			var agTierSet = [];
 			if (this.gen >= 6) agTierSet = [['header', "AG"], ['pokemon', 'rayquazamega']];
-			if (format === 'uber' || format === 'ubers') tierSet = tierSet.slice(slices.Uber);
+			if (format === 'ubers' || format === 'uber') tierSet = tierSet.slice(slices.Uber);
 			else if (format === 'ou') tierSet = tierSet.slice(slices.OU);
 			else if (format === 'uu') tierSet = tierSet.slice(slices.UU);
 			else if (format === 'ru') tierSet = tierSet.slice(slices.RU);
 			else if (format === 'nu') tierSet = tierSet.slice(slices.NU);
 			else if (format === 'pu') tierSet = tierSet.slice(slices.PU);
-			else if (format === 'fu') tierSet = tierSet.slice(slices.PU);
 			else if (format === 'lc' || format === 'lcuu') tierSet = tierSet.slice(slices.LC);
 			else if (format === 'cap') tierSet = tierSet.slice(0, slices.Uber).concat(tierSet.slice(slices.OU));
-			else if (format === 'ag' || format === 'anythinggoes') tierSet = agTierSet.concat(tierSet.slice(slices.Uber));
+			else if (format === 'anythinggoes' || format === 'ag') tierSet = agTierSet.concat(tierSet.slice(slices.Uber));
+			else if (format === 'balancedhackmons' || format === 'bh') tierSet = agTierSet.concat(tierSet.slice(slices.Uber));
 			else if (format === 'doublesou') tierSet = tierSet.slice(slices.DOU);
 			else if (format === 'doublesuu') tierSet = tierSet.slice(slices.DUU);
 			else if (format === 'doublesnu') tierSet = tierSet.slice(slices.DNU);
@@ -918,6 +930,8 @@
 	// These all have static versions
 
 	Search.prototype.renderRow = function (id, type, matchStart, matchLength, errorMessage, attrs) {
+		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+
 		// errorMessage = '<span class="col illegalcol"><em>' + errorMessage + '</em></span>';
 		switch (type) {
 		case 'html':

--- a/js/search.js
+++ b/js/search.js
@@ -346,7 +346,7 @@
 		var buf = [];
 		var illegalBuf = [];
 		var legal = this.legalityFilter;
-		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = (exports.FormatMods.currentMod && exports.FormatMods.currentMod.mod) || exports.BattlePokedex;
 
 		if (qType === 'pokemon') {
 			switch (fType) {
@@ -431,7 +431,7 @@
 		if (this.filters || this.sortCol) return this.filteredPokemon();
 		var resultSet = [['sortpokemon', '']];
 
-		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = (exports.FormatMods.currentMod && exports.FormatMods.currentMod.mod) || exports.BattlePokedex;
 
 		for (var id in BattlePokedex) {
 			switch (id) {
@@ -524,7 +524,7 @@
 		var filters = this.filters || [];
 		var sortCol = this.sortCol;
 
-		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = (exports.FormatMods.currentMod && exports.FormatMods.currentMod.mod) || exports.BattlePokedex;
 
 		this.resultSet = [['sortpokemon', '']];
 		if (filters.length) this.resultSet.push(['html', this.getFilterText()], ['header', "Filtered results"]);
@@ -611,7 +611,7 @@
 		var illegalResultSet = [];
 		var filters = this.filters;
 
-		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = (exports.FormatMods.currentMod && exports.FormatMods.currentMod.mod) || exports.BattlePokedex;
 
 		for (var id in BattleMovedex) {
 			var move = BattleMovedex[id];
@@ -703,7 +703,7 @@
 		this.renderedIndex = i;
 	};
 	Search.prototype.setType = function (qType, format, set, cur) {
-		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = (exports.FormatMods.currentMod && exports.FormatMods.currentMod.mod) || exports.BattlePokedex;
 
 		if (!format) format = '';
 		if (this.qType !== qType) {
@@ -930,7 +930,7 @@
 	// These all have static versions
 
 	Search.prototype.renderRow = function (id, type, matchStart, matchLength, errorMessage, attrs) {
-		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = (exports.FormatMods.currentMod && exports.FormatMods.currentMod.mod) || exports.BattlePokedex;
 
 		// errorMessage = '<span class="col illegalcol"><em>' + errorMessage + '</em></span>';
 		switch (type) {

--- a/js/search.js
+++ b/js/search.js
@@ -346,7 +346,7 @@
 		var buf = [];
 		var illegalBuf = [];
 		var legal = this.legalityFilter;
-		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
 
 		if (qType === 'pokemon') {
 			switch (fType) {
@@ -431,7 +431,7 @@
 		if (this.filters || this.sortCol) return this.filteredPokemon();
 		var resultSet = [['sortpokemon', '']];
 
-		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
 
 		for (var id in BattlePokedex) {
 			switch (id) {
@@ -524,7 +524,7 @@
 		var filters = this.filters || [];
 		var sortCol = this.sortCol;
 
-		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
 
 		this.resultSet = [['sortpokemon', '']];
 		if (filters.length) this.resultSet.push(['html', this.getFilterText()], ['header', "Filtered results"]);
@@ -611,7 +611,7 @@
 		var illegalResultSet = [];
 		var filters = this.filters;
 
-		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
 
 		for (var id in BattleMovedex) {
 			var move = BattleMovedex[id];
@@ -703,7 +703,7 @@
 		this.renderedIndex = i;
 	};
 	Search.prototype.setType = function (qType, format, set, cur) {
-		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
 
 		if (!format) format = '';
 		if (this.qType !== qType) {
@@ -930,7 +930,7 @@
 	// These all have static versions
 
 	Search.prototype.renderRow = function (id, type, matchStart, matchLength, errorMessage, attrs) {
-		var BattlePokedex = FormatMods.currentMod.mod || exports.BattlePokedex;
+		var BattlePokedex = exports.FormatMods.currentMod.mod || exports.BattlePokedex;
 
 		// errorMessage = '<span class="col illegalcol"><em>' + errorMessage + '</em></span>';
 		switch (type) {

--- a/testclient.html
+++ b/testclient.html
@@ -101,6 +101,7 @@
 		<script src="js/client-topbar.js"></script>
 		<script src="js/client-mainmenu.js"></script>
 		<script src="js/client-teambuilder.js"></script>
+		<script src="js/client-formatmods.js"></script>
 		<script src="js/client-ladder.js"></script>
 		<script src="js/client-chat.js"></script>
 		<script src="js/client-chat-tournament.js"></script>


### PR DESCRIPTION
This is my first pull, if im doing something wrong please tell me, what i did is simple, i wanted to make PS to recognize OMs and adjust pokemon stats depending of the format, for testing i created the "Tier Shift" support.

How does it works? 

When update() is called on client-teambuilder.js i call a function named checkFormatMods(), in that function i check for existing mods and i apply it if didnt applied before. If there is no mod for the current format, then delete the current mod.

In search.js functions, instead of using global BattlePokedex, im creating a scope variable that overrides the global one, and i give it the value of the current mod or the global object depending of the situation.

This system is extensible and i'll make it more sophisticated, but... tomorrow.

No more changes.
