### PR TITLE
Fix the exporting of empty moves

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -1229,7 +1229,9 @@ Storage.exportTeam = function (team) {
 			if (move.substr(0, 13) === 'Hidden Power ') {
 				move = move.substr(0, 13) + '[' + move.substr(13) + ']';
 			}
-			text += '- ' + move + "  \n";
+			if (move) {
+				text += '- ' + move + "  \n";
+			}
 		}
 		text += "\n";
 	}


### PR DESCRIPTION
Hello. :)

Currently, when a Pokémon's move is not set or set to be empty and the user exports the Pokémon/team, a line with a dash but no name appears in the obtained text. [Screenshot of an example](http://image.prntscr.com/image/3ea16e2a4f744e639ef42081ac0bead1.png).

This pull requests fixes this problem by not writing the line if the move is empty.