### PR TITLE
Mark damage-weakening berries as having been eaten

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -4339,6 +4339,7 @@ var Battle = (function () {
 					actions += '' + poke.getName() + ' ate its ' + item.name + '!';
 					this.lastmove = item.id;
 				} else if (kwargs.weaken) {
+					poke.prevItemEffect = 'eaten';
 					actions += 'The ' + item.name + ' weakened the damage to ' + poke.getLowerName() + '!';
 					this.lastmove = item.id;
 				} else if (effect.id) switch (effect.id) {


### PR DESCRIPTION
Damage-weakening berries send two berry events, but the second one clears the reason from the first, so we have to set it again.