### PR TITLE
Update battle log when ignoring something

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -524,18 +524,21 @@ var Pokemon = (function () {
 			this.baseAbility = ability;
 		}
 	};
+	Pokemon.prototype.htmlName = function () {
+		return '<span class="battle-nickname' + (this.side.n === 0 ? '' : '-foe') + '" title="' + this.species + '">' + Tools.escapeHTML(this.name) + '</span>';
+	};
 	Pokemon.prototype.getName = function (shortName) {
 		if (this.side.n === 0) {
-			return Tools.escapeHTML(this.name);
+			return this.htmlName();
 		} else {
-			return (shortName ? "Opposing " : "The opposing ") + (this.side.battle.ignoreOpponent || this.side.battle.ignoreNicks ? this.species : Tools.escapeHTML(this.name));
+			return (shortName ? "Opposing " : "The opposing ") + this.htmlName();
 		}
 	};
 	Pokemon.prototype.getLowerName = function (shortName) {
 		if (this.side.n === 0) {
-			return Tools.escapeHTML(this.name);
+			return this.htmlName();
 		} else {
-			return (shortName ? "opposing " : "the opposing ") + (this.side.battle.ignoreOpponent || this.side.battle.ignoreNicks ? this.species : Tools.escapeHTML(this.name));
+			return (shortName ? "opposing " : "the opposing ") + this.htmlName();
 		}
 	};
 	Pokemon.prototype.getTitle = function () {
@@ -553,7 +556,7 @@ var Pokemon = (function () {
 			if (plaintext) {
 				name += ' (' + this.species + ')';
 			} else {
-				name += ' <small>(' + this.species + ')</small>';
+				name = '<span class="battle-nickname' + (this.side && this.side.n === 0 ? '' : '-foe') + '" title="' + this.species + '">' + name + ' <small>(' + this.species + ')</small>' + '</span>';
 			}
 		}
 		if (plaintext) {
@@ -2475,6 +2478,11 @@ var Battle = (function () {
 
 		if (this.mySide) this.mySide.reset();
 		if (this.yourSide) this.yourSide.reset();
+
+		if (this.ignoreNicks) {
+			var $log = $('.battle-log .inner');
+			if ($log.length) $log.addClass('hidenicks');
+		}
 
 		// activity queue state
 		this.animationDelay = 0;

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1117,6 +1117,13 @@
 		toggleIgnoreSpects: function (e) {
 			this.battle.ignoreSpects = !!e.currentTarget.checked;
 			this.battle.add('Spectators ' + (this.battle.ignoreSpects ? '' : 'no longer ') + 'ignored.');
+			var $messages = $('.battle-log').find('.chat').not('small:contains(\u2605)');
+			if (!$messages.length) return;
+			if (this.battle.ignoreSpects) {
+				$messages.hide();
+			} else {
+				$messages.show();
+			}
 		},
 		toggleIgnoreNicks: function (e) {
 			this.battle.ignoreNicks = !!e.currentTarget.checked;
@@ -1124,13 +1131,32 @@
 			this.battle.add('Nicknames ' + (this.battle.ignoreNicks ? '' : 'no longer ') + 'ignored.');
 			this.toggleNicknames(this.battle.mySide);
 			this.toggleNicknames(this.battle.yourSide);
+
+			var $log = $('.battle-log .inner');
+			if (!$log.length) return;
+			if (this.battle.ignoreNicks) {
+				$log.addClass('hidenicks');
+			} else {
+				$log.removeClass('hidenicks');
+			}
 		},
 		toggleIgnoreOpponent: function (e) {
 			this.battle.ignoreOpponent = !!e.currentTarget.checked;
 			this.battle.add('Opponent ' + (this.battle.ignoreOpponent ? '' : 'no longer ') + 'ignored.');
+			var $log = $('.battle-log .inner');
+			var $messages = $log.find('.chatmessage-' + this.battle.yourSide.id);
+			if (!$messages.length) return;
+			if (this.battle.ignoreOpponent) {
+				$messages.hide();
+				$log.addClass('hidenicks');
+			} else {
+				$messages.show();
+				$log.removeClass('hidenicks');
+			}
 		},
 		toggleNicknames: function (side) {
 			for (var i = 0; i < side.active.length; i++) {
+				if (!side.active[i]) continue;
 				side.active[i].statbarElem.html(side.getStatbarHTML(side.active[i], true));
 				side.updateStatbar(side.active[i], true, true);
 			}

--- a/style/battle.css
+++ b/style/battle.css
@@ -906,3 +906,12 @@ button.subtle {
 button.subtle:hover {
 	text-decoration: underline;
 }
+.hidenicks span.battle-nickname,
+.hidenicks span.battle-nickname-foe {
+	font-size: 0;
+}
+.hidenicks span.battle-nickname::before,
+.hidenicks span.battle-nickname-foe::before{
+	content: attr(title);
+	font-size: 9pt;
+}


### PR DESCRIPTION
Continuation from the suggestion in https://github.com/Zarel/Pokemon-Showdown-Client/pull/783. Battle chat now updates when someone clicks Ignore Opponent / Spectators / Nicknames and hides what the user doesn't want to see.

Hiding nicknames is about as efficient as I can get it, I think. I've done my best to keep the html structure (and hover-over things) intact but I may have missed something. It's not the most elegant method but it seems to work fine...
