### PR TITLE
Switching battle tabs should honour the 'noanim' pref

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -92,7 +92,10 @@
 		},
 		focus: function () {
 			this.tooltips.hideTooltip();
-			if (this.battle.playbackState === 3) this.battle.play();
+			if (this.battle.playbackState === 3) {
+				this.battle.play();
+				if (Tools.prefs('noanim')) this.battle.fastForwardTo(-1);
+			}
 			ConsoleRoom.prototype.focus.call(this);
 		},
 		blur: function () {


### PR DESCRIPTION
As mentioned in http://www.smogon.com/forums/posts/7050644 the pref to disable animations isn't honoured when you switch between battles. (Maybe there's an easy way to just let the battle play out in the background rather than waiting for the user to switch tabs, but I couldn't see it.)