### PR TITLE
Darkmode: Change HL roomtab border color

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -145,7 +145,7 @@ button:disabled {
 }
 .dark .tabbar a.button.notifying {
 	background: #6BACC5;
-	border-color: #6BACC5;
+	border-color: #2C9CC1;
 	color: #000;
 	text-shadow: none;
 }


### PR DESCRIPTION
This makes it so that if you were to get highlighted in two rooms next to each other, so that they will be separated better - more light lightmode.

BEFORE:
<img src="http://image.prntscr.com/image/d4a94ab4df3747d9a2c91c80bbf234dd.png">
AFTER:
<img src="http://image.prntscr.com/image/7e7da032338340ab85bda4a6ff9cb271.png">
