### PR TITLE
Fix Pokemon name when trapped

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -163,7 +163,8 @@
 					switch (args[0]) {
 					case 'trapped':
 						requestData.trapped = true;
-						this.battle.activityQueue.push('|message|' + pokemon.getName() + ' is trapped and cannot switch!');
+						var pokeName = pokemon.side.n === 0 ? Tools.escapeHTML(pokemon.name) : "The opposing " + (this.battle.ignoreOpponent || this.battle.ignoreNicks ? pokemon.species : Tools.escapeHTML(pokemon.name));
+						this.battle.activityQueue.push('|message|' + pokeName + ' is trapped and cannot switch!');
 						break;
 					case 'cant':
 						for (var i = 0; i < requestData.moves.length; i++) {


### PR DESCRIPTION
I am apparently very good at overlooking things when adding something :| Fixes http://www.smogon.com/forums/threads/ps-serious-bug-reports.3521891/page-10#post-7061792

Have to reimplment the old `Pokemon#getName` here since this is escaped at some point, and I don't think there's any other way to do it.