### PR TITLE
Fix choice display with mega evolution

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -740,18 +740,21 @@
 					var target = '';
 					buf += Tools.getSpecies(myActive[i]) + ' will ';
 					if (parts.length > 2) {
-						if (parts[2] === 'mega') {
+						var targetPos = parts[2];
+						if (targetPos === 'mega') {
 							buf += 'mega evolve, then ';
+							targetPos = parts[3];
 						}
-						var index = parts.length > 3 ? parts[3] : parts[2];
-						var targetActive = this.battle.yourSide.active;
-						// Targeting your own side in doubles / triples
-						if (index < 0) {
-							targetActive = myActive;
-							index = -index;
-							target += 'your ';
+						if (targetPos) {
+							var targetActive = this.battle.yourSide.active;
+							// Targeting your own side in doubles / triples
+							if (targetPos < 0) {
+								targetActive = myActive;
+								targetPos = -targetPos;
+								target += 'your ';
+							}
+							target += Tools.getSpecies(targetActive[targetPos - 1]);
 						}
-						target += Tools.getSpecies(targetActive[index - 1]);
 					}
 					buf += 'use ' + move + (target ? ' against ' + target : '') + '.<br />';
 					break;


### PR DESCRIPTION
When making https://github.com/Zarel/Pokemon-Showdown-Client/pull/796 I forgot `move 2 mega` was a valid choice that could happen, so at its current it doesn't work since it'll try to index to `'mega' - 1` in those cases. Opps.

This fixes that, but for once merging was too fast for me to have time to fix it before :(