### PR TITLE
Increase flexibility of alternate form popup size

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -3359,7 +3359,9 @@
 			}
 			buf += '</div>';
 
-			this.$el.html(buf).css({'max-width': (4 + spriteSize) * (formCount < 6 ? formCount : 6), 'height': 42 + (4 + spriteSize) * (formCount < 6 ? 1 : formCount / 6)});
+			var height = Math.ceil(formCount / 7);
+			var width = Math.ceil(formCount / height);
+			this.$el.html(buf).css({'max-width': (4 + spriteSize) * width, 'height': 42 + (4 + spriteSize) * height});
 		},
 		setForm: function (form) {
 			var template = Tools.getTemplate(this.curSet.species);


### PR DESCRIPTION
Minior has 7 forms, which, once they're supported, will confuse the teambuilder. This changes the calculation for the height and width:
- The height is the smallest height needed to fit given a width of no more than 7
- The width is then reduced if this is possible without increasing the height
For example, in the case of Vivillon, which has 18 forms, 3 rows are needed, but then we find we only need 6 columns.