### PR TITLE
Read gen7doubles info

### DIFF
--- a/githooks/build-indexes
+++ b/githooks/build-indexes
@@ -265,7 +265,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 	let buf = '// automatically built with githooks/build-indexes\n\n';
 
 	// process.stdout.write("\n  ");
-	for (const genIdent of [7, 6, -6, 5, 4, 3, 2, 1]) {
+	for (const genIdent of [7, -7, 6, -6, 5, 4, 3, 2, 1]) {
 		const isDoubles = (genIdent < 0);
 		const genNum = (isDoubles ? -genIdent : genIdent);
 		const gen = 'gen' + genNum;


### PR DESCRIPTION
Teambuilder currently crashes when building a team for a Gen 7 Doubles format. 

This should (in theory) fix it, but i was unable to test this as i don't know how to make the githook run.

I apologize for my ignorance.