### PR TITLE
Teambuilder: Show typing in set details

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1083,8 +1083,11 @@
 				buf += '<span class="detailcell"><label>Happiness</label>' + (typeof set.happiness === 'number' ? set.happiness : 255) + '</span>';
 				buf += '<span class="detailcell"><label>Shiny</label>' + (set.shiny ? 'Yes' : 'No') + '</span>';
 			}
+			buf += '</button></div></div>';
 
-			buf += '</button>';
+			// item/type icons
+			buf += '<div class="setrow setrow-icons">';
+			buf += '<div class="setcell">';
 			var itemicon = '<span class="itemicon"></span>';
 			if (set.item) {
 				var item = Tools.getItem(set.item);
@@ -1092,7 +1095,14 @@
 			}
 			buf += itemicon;
 			buf += '</div>';
-			buf += '</div><div class="setrow">';
+			buf += '<div class="setcell setcell-typeicons">';
+			var types = Tools.getTemplate(set.species).types;
+			if (types) {
+				for (var i = 0; i < types.length; i++) buf += Tools.getTypeIcon(types[i]);
+			}
+			buf += '</div></div>';
+
+			buf += '<div class="setrow">';
 			if (this.curTeam.gen > 1) buf += '<div class="setcell setcell-item"><label>Item</label><input type="text" name="item" class="textbox chartinput" value="' + Tools.escapeHTML(set.item) + '" /></div>';
 			if (this.curTeam.gen > 2) buf += '<div class="setcell setcell-ability"><label>Ability</label><input type="text" name="ability" class="textbox chartinput" value="' + Tools.escapeHTML(set.ability) + '" /></div>';
 			buf += '</div></div>';

--- a/style/client.css
+++ b/style/client.css
@@ -2542,11 +2542,21 @@ a.ilink.yours {
 }
 .setcol-details .itemicon {
 	display: block;
-	margin-top: 10px;
 	width: 24px;
 	height: 24px;
 	background-image: transparent none no-repeat scroll center center;
 	opacity: 0.8;
+}
+.setrow-icons {
+	height: 24px;
+}
+.setcell-typeicons {
+	margin-top: 4px;
+	margin-right: 4px;
+	float:  right;
+}
+.setcell-typeicons img {
+	margin-left: 1px;
 }
 .setcell-sprite {
 	height: 82px;
@@ -2556,7 +2566,7 @@ a.ilink.yours {
 	margin-top: 0;
 }
 .setcell-details {
-	height: 84px;
+	height: 60px;
 }
 .setcol-moves .setcell {
 	padding-bottom: 1px;


### PR DESCRIPTION
![grafik](https://cloud.githubusercontent.com/assets/5814184/20699944/8828aac4-b60a-11e6-9d80-2435c9d36d9c.png)

Since there will most likely always be a part of the users that doesn't know every mon's typing by heart, I think it is a good idea to display the typing right there in the set details, so that people won't have to return to the Pokemon selection menu every time they want to check which types they get STAB on or something. There's some free space there anyway.
 I hope I'm not destroying the aesthetics with this, should the typing be centered above the ability box, or somewhere else entirely? Should there be a label, or is it self-explanatory enough?