### PR TITLE
Dark mode: Prettify notifying roomtab on hover

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -190,6 +190,9 @@ button:disabled {
 	background: #606060;
 	border-color: #EEEEEE;
 }
+.dark .tabbar a.button.notifying:hover {
+	background: #92C2D3;
+}
 .dark .button:active,
 .dark .tabbar a.button:active {
 	background: #3A3A3A;


### PR DESCRIPTION
It was partly being overwritten by the non-notifying hover style. Top left is the current situation for a notifying dark roomtab on mouseover, bottom left is the new one, right is how it looks without hover for comparison.

![unbenannt](https://cloud.githubusercontent.com/assets/5814184/20731048/daa679ec-b688-11e6-9bf4-7cb29f96243d.PNG)
