### PR TITLE
Fix gen 7 mons' battle anims not showing

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -1146,7 +1146,6 @@ var Tools = {
 
 		// Decide what gen sprites to use.
 		var gen = {1:'rby', 2:'gsc', 3:'rse', 4:'dpp', 5:'bw', 6:'xy', 7:'xy'}[Math.max(options.gen, pokemon.gen)];
-		if (pokemon.gen === 7) gen = 'bw';
 		if (Tools.prefs('nopastgens')) gen = 'xy';
 		if (Tools.prefs('bwgfx') && gen === 'xy') gen = 'bw';
 


### PR DESCRIPTION
Currently, animations for gen 7 mons fail to load with the default options, because it tries to get them from sprites/bwani. I assume this was meant to be some kinda workaround from when we didn't have the models, but the commit in question https://github.com/Zarel/Pokemon-Showdown-Client/commit/df7a96c4a7af915111eab1eb547ad14b97fccfce doesn't really explain.
Anyway, I tested this with all combinations of animation options, and none of them showed a broken image.