### PR TITLE
Allow the server to update psuedo weather backwards compatibly

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -2288,6 +2288,7 @@ var Battle = (function () {
 		// has playback gotten to the point where a player has won or tied?
 		// affects whether BGM is playing
 		this.ended = false;
+		this.usesUpkeep = false;
 		this.weather = '';
 		this.pseudoWeather = [];
 		this.weatherTimeLeft = 0;
@@ -2838,7 +2839,7 @@ var Battle = (function () {
 		if (turnnum == this.turn + 1) {
 			this.endLastTurnPending = true;
 		}
-		if (this.turn) this.updatePseudoWeatherLeft();
+		if (this.turn && !this.usesUpkeep) this.updatePseudoWeatherLeft(); // for compatibility with old replays
 		this.turn = turnnum;
 
 		if (this.mySide.active[0]) this.mySide.active[0].clearTurnstatuses();
@@ -6165,6 +6166,10 @@ var Battle = (function () {
 			this.yourSide.active[0] = null;
 			if (this.waitForResult()) return;
 			this.start();
+			break;
+		case 'upkeep':
+			this.usesUpkeep = true;
+			this.updatePseudoWeatherLeft();
 			break;
 		case 'turn':
 			if (this.endPrevAction()) return;


### PR DESCRIPTION
Rather conveniently from the client's point of view, weather upkeep data is explicitly sent to the client. This means that if a Pokémon faints and one with a weather Ability is switched in, the duration is set to 5 or 8 turns, and does not change at the end of the turn.

Unfortunately terrain Abilities do not have that luxury. PR #808 worked around this but for the first turn only; this means that terrain Abilities that activate on switching in for a fainted Pokémon will display the wrong turn count, as they are immediately changed at the end of the turn.

Of course you have to be careful to distinguish this case from that of a slow VoltTurn. As far as I can tell, there needs to be a message to inform the client that residual upkeep has taken place and it should update pseudo weather. This is the client side handling of that message.

For compatibility with old replays, the previous turn-based upkeep mechanics are used if no upkeep messages are seen. This helpfully also avoids having to send the upkeep message before the first turn.