### PR TITLE
Don't display side condition ids in replays

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -1392,8 +1392,9 @@ var Side = (function () {
 			}
 		}
 	};
-	Side.prototype.addSideCondition = function (condition) {
+	Side.prototype.addSideCondition = function (effect) {
 		var elem, curelem;
+		var condition = effect.id;
 		if (this.sideConditions[condition]) {
 			if (condition === 'spikes' || condition === 'toxicspikes') {
 				this.sideConditions[condition][2]++;
@@ -1434,7 +1435,7 @@ var Side = (function () {
 			}
 			return;
 		}
-		// Side conditions work as: [condition, elem, levels, minDuration, maxDuration]
+		// Side conditions work as: [effectName, elem, levels, minDuration, maxDuration]
 		switch (condition) {
 		case 'auroraveil':
 			this.battle.spriteElemsFront[this.n].append('<div class="sidecondition-auroraveil" style="display:none;position:absolute" />');
@@ -1458,7 +1459,7 @@ var Side = (function () {
 				opacity: .3
 			}, 300);
 			elem = curelem;
-			this.sideConditions[condition] = [condition, elem, 1, 5, 8];
+			this.sideConditions[condition] = [effect.name, elem, 1, 5, 8];
 			break;
 		case 'reflect':
 			this.battle.spriteElemsFront[this.n].append('<div class="sidecondition-reflect" style="display:none;position:absolute" />');
@@ -1482,7 +1483,7 @@ var Side = (function () {
 				opacity: .3
 			}, 300);
 			elem = curelem;
-			this.sideConditions[condition] = [condition, elem, 1, 5, this.battle.gen >= 4 ? 8 : 0];
+			this.sideConditions[condition] = [effect.name, elem, 1, 5, this.battle.gen >= 4 ? 8 : 0];
 			break;
 		case 'safeguard':
 			this.battle.spriteElemsFront[this.n].append('<div class="sidecondition-safeguard" style="display:none;position:absolute" />');
@@ -1506,7 +1507,7 @@ var Side = (function () {
 				opacity: .2
 			}, 300);
 			elem = curelem;
-			this.sideConditions[condition] = [condition, elem, 1, 5, 0];
+			this.sideConditions[condition] = [effect.name, elem, 1, 5, 0];
 			break;
 		case 'lightscreen':
 			this.battle.spriteElemsFront[this.n].append('<div class="sidecondition-lightscreen" style="display:none;position:absolute" />');
@@ -1530,7 +1531,7 @@ var Side = (function () {
 				opacity: .3
 			}, 300);
 			elem = curelem;
-			this.sideConditions[condition] = [condition, elem, 1, 5, this.battle.gen >= 4 ? 8 : 0];
+			this.sideConditions[condition] = [effect.name, elem, 1, 5, this.battle.gen >= 4 ? 8 : 0];
 			break;
 		case 'mist':
 			this.battle.spriteElemsFront[this.n].append('<div class="sidecondition-mist" style="display:none;position:absolute" />');
@@ -1554,13 +1555,13 @@ var Side = (function () {
 				opacity: .2
 			}, 300);
 			elem = curelem;
-			this.sideConditions[condition] = [condition, elem, 1, 5, 0];
+			this.sideConditions[condition] = [effect.name, elem, 1, 5, 0];
 			break;
 		case 'tailwind':
-			this.sideConditions[condition] = [condition, null, 1, this.battle.gen >= 5 ? 4 : 3, 0];
+			this.sideConditions[condition] = [effect.name, null, 1, this.battle.gen >= 5 ? 4 : 3, 0];
 			break;
 		case 'luckychant':
-			this.sideConditions[condition] = [condition, null, 1, 5, 0];
+			this.sideConditions[condition] = [effect.name, null, 1, 5, 0];
 			break;
 		case 'stealthrock':
 			this.battle.spriteElemsFront[this.n].append('<img src="' + BattleEffects.rock1.url + '" style="display:none;position:absolute" />');
@@ -1610,7 +1611,7 @@ var Side = (function () {
 				scale: .2
 			}, BattleEffects.rock2));
 			elem = elem.add(curelem);
-			this.sideConditions[condition] = [condition, elem, 1, 0, 0];
+			this.sideConditions[condition] = [effect.name, elem, 1, 0, 0];
 			break;
 		case 'spikes':
 			this.battle.spriteElemsFront[this.n].append('<img src="' + BattleEffects.caltrop.url + '" style="display:none;position:absolute" />');
@@ -1623,7 +1624,7 @@ var Side = (function () {
 				scale: .3
 			}, BattleEffects.caltrop));
 			elem = curelem;
-			this.sideConditions[condition] = [condition, elem, 1, 0, 0];
+			this.sideConditions[condition] = [effect.name, elem, 1, 0, 0];
 			break;
 		case 'toxicspikes':
 			this.battle.spriteElemsFront[this.n].append('<img src="' + BattleEffects.poisoncaltrop.url + '" style="display:none;position:absolute" />');
@@ -1636,7 +1637,7 @@ var Side = (function () {
 				scale: .3
 			}, BattleEffects.poisoncaltrop));
 			elem = curelem;
-			this.sideConditions[condition] = [condition, elem, 1, 0, 0];
+			this.sideConditions[condition] = [effect.name, elem, 1, 0, 0];
 			break;
 		case 'stickyweb':
 			this.battle.spriteElemsFront[this.n].append('<img src="' + BattleEffects.web.url + '" style="display:none;position:absolute" />');
@@ -1650,13 +1651,14 @@ var Side = (function () {
 				scale: 0.7
 			}, BattleEffects.web));
 			elem = curelem;
-			this.sideConditions[condition] = [condition, elem, 1, 0, 0];
+			this.sideConditions[condition] = [effect.name, elem, 1, 0, 0];
 			break;
 		default:
-			this.sideConditions[condition] = [condition, null, 1, 0, 0];
+			this.sideConditions[condition] = [effect.name, null, 1, 0, 0];
 		}
 	};
 	Side.prototype.removeSideCondition = function (condition) {
+		condition = toId(condition);
 		if (!this.sideConditions[condition]) return;
 		if (this.sideConditions[condition][1]) this.sideConditions[condition][1].remove();
 		delete this.sideConditions[condition];
@@ -2995,7 +2997,7 @@ var Battle = (function () {
 		this.updateWeather();
 	};
 	Battle.prototype.pseudoWeatherLeft = function (pWeather) {
-		var buf = '<br />' + pWeather[0];
+		var buf = '<br />' + Tools.getMove(pWeather[0]).name;
 		if (!pWeather[1] && pWeather[2]) {
 			pWeather[1] = pWeather[2];
 			pWeather[2] = 0;
@@ -3010,7 +3012,7 @@ var Battle = (function () {
 	};
 	Battle.prototype.sideConditionLeft = function (cond, siden) {
 		if (!cond[3] && !cond[4]) return '';
-		var buf = '<br />' + (siden ? "Foe's " : "") + cond[0];
+		var buf = '<br />' + (siden ? "Foe's " : "") + Tools.getMove(cond[0]).name;
 		if (!cond[3] && cond[4]) {
 			cond[3] = cond[4];
 			cond[4] = 0;
@@ -5305,7 +5307,7 @@ var Battle = (function () {
 				case 'brickbreak':
 					actions += poke.getName() + " shattered " + ofpoke.getTeamName() + " protections!";
 					ofpoke.removeSideCondition('Reflect');
-					ofpoke.removeSideCondition('Light Screen');
+					ofpoke.removeSideCondition('LightScreen');
 					break;
 				case 'beatup':
 					actions += "" + Tools.escapeHTML(kwargs.of) + "'s attack!";
@@ -5535,7 +5537,7 @@ var Battle = (function () {
 			case '-sidestart':
 				var side = this.getSide(args[1]);
 				var effect = Tools.getEffect(args[2]);
-				side.addSideCondition(effect.name);
+				side.addSideCondition(effect);
 
 				switch (effect.id) {
 				case 'stealthrock':

--- a/js/battle.js
+++ b/js/battle.js
@@ -1394,7 +1394,6 @@ var Side = (function () {
 	};
 	Side.prototype.addSideCondition = function (condition) {
 		var elem, curelem;
-		condition = toId(condition);
 		if (this.sideConditions[condition]) {
 			if (condition === 'spikes' || condition === 'toxicspikes') {
 				this.sideConditions[condition][2]++;
@@ -1658,7 +1657,6 @@ var Side = (function () {
 		}
 	};
 	Side.prototype.removeSideCondition = function (condition) {
-		condition = toId(condition);
 		if (!this.sideConditions[condition]) return;
 		if (this.sideConditions[condition][1]) this.sideConditions[condition][1].remove();
 		delete this.sideConditions[condition];
@@ -2997,7 +2995,7 @@ var Battle = (function () {
 		this.updateWeather();
 	};
 	Battle.prototype.pseudoWeatherLeft = function (pWeather) {
-		var buf = '<br />' + Tools.getMove(pWeather[0]).name;
+		var buf = '<br />' + pWeather[0];
 		if (!pWeather[1] && pWeather[2]) {
 			pWeather[1] = pWeather[2];
 			pWeather[2] = 0;
@@ -3012,7 +3010,7 @@ var Battle = (function () {
 	};
 	Battle.prototype.sideConditionLeft = function (cond, siden) {
 		if (!cond[3] && !cond[4]) return '';
-		var buf = '<br />' + (siden ? "Foe's " : "") + Tools.getMove(cond[0]).name;
+		var buf = '<br />' + (siden ? "Foe's " : "") + cond[0];
 		if (!cond[3] && cond[4]) {
 			cond[3] = cond[4];
 			cond[4] = 0;
@@ -5307,7 +5305,7 @@ var Battle = (function () {
 				case 'brickbreak':
 					actions += poke.getName() + " shattered " + ofpoke.getTeamName() + " protections!";
 					ofpoke.removeSideCondition('Reflect');
-					ofpoke.removeSideCondition('LightScreen');
+					ofpoke.removeSideCondition('Light Screen');
 					break;
 				case 'beatup':
 					actions += "" + Tools.escapeHTML(kwargs.of) + "'s attack!";


### PR DESCRIPTION
Currently things like screens or tailwind are showing in lower case in replays. The server is sending the correct name, but we're turning it into an id. This happens to work in battles because Tools.getMove turns it back into a name, but fails in replays. If we use the original name, we get the right behaviour in replays, and Tools.getMove becomes unnecessary. Example replay: http://replay.pokemonshowdown.com/gen7pokebankdoublesou-488415145