### PR TITLE
Teambuilder: Create a button which allows users to clone/duplicate their team.

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -608,10 +608,10 @@
 		reloadTeamsFolder: function () {
 			Storage.nwLoadTeams();
 		},
-		
+
 		clone: function (i) {
 			var newTeam = {
-				name: " Clone of "+teams[i].name,
+				name: " Clone of " + teams[i].name,
 				format: teams[i].format,
 				team: teams[i].team,
 				folder: teams[i].folder,

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -394,7 +394,7 @@
 					// support dragging and dropping buttons.
 					buf += '<li><div name="edit" data-value="' + i + '" class="team" draggable="true">' + formatText + '<strong>' + Tools.escapeHTML(team.name) + '</strong><br /><small>';
 					buf += Storage.getTeamIcons(team);
-					buf += '</small></div><div class="team-tools"><button name="edit" value="' + i + '"><i class="fa fa-pencil"></i>Edit</button><button name="delete" value="' + i + '"><i class="fa fa-trash"></i>Delete</button><button name="duplicate" value="' + i + '"><i class="fa fa-files-o"></i>Duplicate</button></li></div></li>';
+					buf += '</small></div><div class="team-tools"><button name="edit" value="' + i + '"><i class="fa fa-pencil"></i>Edit</button><button name="delete" value="' + i + '"><i class="fa fa-trash"></i>Delete</button><button name="clone" value="' + i + '"><i class="fa fa-files-o"></i>Clone</button></li></div></li>';
 				}
 				if (!atLeastOne) {
 					if (filterFolder) {
@@ -609,9 +609,9 @@
 			Storage.nwLoadTeams();
 		},
 		
-		duplicate: function (i) {
+		clone: function (i) {
 			var newTeam = {
-				name: teams[i].name + " - Copy",
+				name: " Clone of "+teams[i].name,
 				format: teams[i].format,
 				team: teams[i].team,
 				folder: teams[i].folder,

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -394,7 +394,7 @@
 					// support dragging and dropping buttons.
 					buf += '<li><div name="edit" data-value="' + i + '" class="team" draggable="true">' + formatText + '<strong>' + Tools.escapeHTML(team.name) + '</strong><br /><small>';
 					buf += Storage.getTeamIcons(team);
-					buf += '</small></div><button name="edit" value="' + i + '"><i class="fa fa-pencil"></i>Edit</button><button name="delete" value="' + i + '"><i class="fa fa-trash"></i>Delete</button></li>';
+					buf += '</small></div><div class="team-tools"><button name="edit" value="' + i + '"><i class="fa fa-pencil"></i>Edit</button><button name="delete" value="' + i + '"><i class="fa fa-trash"></i>Delete</button><button name="duplicate" value="' + i + '"><i class="fa fa-files-o"></i>Duplicate</button></li></div></li>';
 				}
 				if (!atLeastOne) {
 					if (filterFolder) {
@@ -608,6 +608,19 @@
 		reloadTeamsFolder: function () {
 			Storage.nwLoadTeams();
 		},
+		
+		duplicate: function (i) {
+			var newTeam = {
+				name: teams[i].name + " - Copy",
+				format: teams[i].format,
+				team: teams[i].team,
+				folder: teams[i].folder,
+				iconCache: teams[i].iconCache
+			};
+			teams.unshift(newTeam);
+			this.edit(0);
+		},
+
 		edit: function (i) {
 			this.teamScrollPos = this.$('.teampane').scrollTop();
 			if (i && i.currentTarget) {

--- a/style/client.css
+++ b/style/client.css
@@ -2336,7 +2336,7 @@ a.ilink.yours {
 	padding: 0;
 }
 .teamlist li {
-	margin: 3px 0;
+	margin: 10px 0;
 	padding: 0;
 }
 


### PR DESCRIPTION
Hello, I am requesting a pull request that contains functionality that will allow users to clone their teams.

Currently, if a user wants to have a copy of an existing team (say they want the same team but maybe with different moves, different items, different pokemons, etc.) they must first: Go to the export/import menu, copy the text, go back and create a new team, go back into export/import, paste the team and save. 

The clone button allows a user to instantly clone a team. After a team is cloned, the name of the team will have " Clone of" appended to the beginning of it. See the screenshots below to see how the clone button works. 


![clone-button](https://cloud.githubusercontent.com/assets/11294700/20950490/0632d2c6-bbee-11e6-94a6-c399c211e583.PNG)

![clone-of-title](https://cloud.githubusercontent.com/assets/11294700/20950507/18d4e4f0-bbee-11e6-96c7-3c7a27baef02.PNG)

_After duplicating the two teams and going back..._
![after-cloning](https://cloud.githubusercontent.com/assets/11294700/20950511/255b8094-bbee-11e6-833f-7c60f1b191ec.PNG)


A margin 10px was added to the ".teamlist li" on the CSS. When adding another button next to the edit and delete button, it causes it to go to the next line (which ends up underneath each teamlist). So I pushed all of the tools underneath of the team list display. I am not sure if this looks nice or if it is something you would like, but a review of the positioning of the clone button might need to be discussed. 

Anyhow, thank you for your time and I hope that this feature is implemented soon as it will help a lot of people! 