### PR TITLE
Use exact format name

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -922,10 +922,7 @@
 					}
 					bufs[curBuf] += '<li><h3>' + Tools.escapeHTML(curSection) + '</li>';
 				}
-				var formatName = Tools.escapeFormat(format.id);
-				if (formatName.charAt(0) !== '[') formatName = '[Gen 6] ' + formatName;
-				formatName = formatName.replace('[Gen 7] ', '');
-				bufs[curBuf] += '<li><button name="selectFormat" value="' + i + '"' + (curFormat === i ? ' class="sel"' : '') + '>' + formatName + '</button></li>';
+				bufs[curBuf] += '<li><button name="selectFormat" value="' + i + '"' + (curFormat === i ? ' class="sel"' : '') + '>' + Tools.escapeFormat(format.id) + '</button></li>';
 			}
 
 			var html = '';


### PR DESCRIPTION
**This is in tandem with:** [Zarel/Pokemon-Showdown#3049](https://github.com/Zarel/Pokemon-Showdown/pull/3049)

If the changes in the above pull request are merged, this pull request is needed to not add `[Gen 7]` in front of gen 7 formats. If there's any issues or concerns don't hesitate to point them out.