### PR TITLE
Dont mark Gen 7 OU pokemon as banned

### DIFF
--- a/githooks/build-indexes
+++ b/githooks/build-indexes
@@ -372,7 +372,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 				return ["CAP", "Uber", "OU", "BL", "UU", "BL2", "RU", "BL3", "NU", "NFE", "LC Uber", "LC"];
 			}
 			if (gen === 'gen7') {
-				return ["CAP", "Uber", "Bank-Uber", "New", "Bank", "Unreleased", "NFE", "Bank-NFE", "LC", "Bank-LC"];
+				return ["CAP", "Uber", "Bank-Uber", "OU", "Bank-OU", "New", "Bank", "Unreleased", "NFE", "Bank-NFE", "LC-Uber", "LC", "Bank-LC"];
 			}
 			if (isDoubles) {
 				return ["DUber", "DOU", "DUU", "DNU", "NFE"];
@@ -398,6 +398,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		}
 		if (!formatSlices['OU'] && !isDoubles) formatSlices['OU'] = formatSlices['New'];
 		if (!formatSlices['UU'] && !isDoubles) formatSlices['UU'] = formatSlices['New'];
+		if (!formatSlices['RU'] && !isDoubles) formatSlices['RU'] = formatSlices['New'];
 
 		if (isDoubles) continue;
 

--- a/js/search.js
+++ b/js/search.js
@@ -812,7 +812,7 @@
 			if (format === 'ubers' || format === 'uber') tierSet = tierSet.slice(slices.Uber);
 			else if (this.gen === 7 && format === 'vgc2017') tierSet = tierSet.slice(slices.Legal);
 			else if (this.gen === 7 && (format === 'pokebankubers' || format === 'pokebankanythinggoes')) tierSet = tierSet.slice(slices.Uber);
-			else if (this.gen === 7 && (format === 'ou' || format === 'pokebankou')) tierSet = tierSet.slice(slices.New);
+			else if (this.gen === 7 && (format === 'ou' || format === 'pokebankou')) tierSet = tierSet.slice(slices.OU);
 			else if (format === 'ou') tierSet = tierSet.slice(slices.OU);
 			else if (format === 'uu') tierSet = tierSet.slice(slices.UU);
 			else if (format === 'ru') tierSet = tierSet.slice(slices.RU);


### PR DESCRIPTION
Currently, whenever no format or a gen 7 format is selected in teambuilder, pokemon that are OU in gen 7 are incorrectly marked as banned. This is my attempt to fix this. I might be doing this wrong, If I am please do point it out. I was unable to test this as I cannot run the files in `./githooks`, but from what I've seen this should work.