### PR TITLE
Fix small dark mode label color inconsistency

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -3397,7 +3397,8 @@ a.ilink.yours {
 	text-shadow: #5A6570 1px 1px 0,#5A6570 1px -1px 0,#5A6570 -1px 1px 0,#5A6570 -1px -1px 0;
 }
 .dark .setchart label,
-.dark .setchart-nickname label {
+.dark .setchart-nickname label,
+.dark .setchart .statrow-head em {
 	color: #BBB;
 }
 


### PR DESCRIPTION
To be specific, changed the "EV" here to match the color of the stat name labels:
 ![grafik](https://cloud.githubusercontent.com/assets/5814184/22152920/45846c82-df25-11e6-85c6-3a6d16f89ed8.png)
