### PR TITLE
Autojoin lobby on unregistered servers

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -381,7 +381,7 @@
 					this.addRoom('lobby', null, true);
 				}
 				Storage.whenPrefsLoaded(function () {
-					if (!Config.server.registered) return;
+					if (!Config.server.registered) return app.send('/autojoin');
 					var autojoin = (Tools.prefs('autojoin') || '');
 					var autojoinIds = [];
 					if (typeof autojoin === 'string') {


### PR DESCRIPTION
Overlooked in #851 without this if you attempt to connect to a unregistered server (like a local test server) lobby wont load until you leave and rejoin it.