### PR TITLE
When clearing a transform, reset the cry too

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -878,6 +878,7 @@ var Sprite = (function () {
 	Sprite.prototype.removeTransform = function (species) {
 		if (this.oldsp) {
 			var sp = this.oldsp;
+			this.cryurl = sp.cryurl;
 			this.sp = sp;
 			this.oldsp = null;
 			this.elem.attr('src', sp.url);


### PR DESCRIPTION
From [this report](https://www.smogon.com/forums/posts7235125) it seems that commit b11409b changed the cry after any forme change, not just mega or primal. Unfortunately this included Transform/Imposter, so it needs to be reset in those cases. (Mega and primal transforms aren't removed when you switch out, so this doesn't affect them.)