### PR TITLE
Add /clear to PMs

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -326,6 +326,9 @@
 					delete app.ignore[userid];
 					$chat.append('<div class="chat">User ' + userid + ' no longer ignored.</div>');
 				}
+			} else if (text.toLowerCase() === '/clear') {
+				this.closePM(userid);
+				this.$pmBox.find('.pm-window-' + userid).find('.inner').empty();
 			} else {
 				text = ('\n' + text).replace(/\n\n/g, '\n').replace(/\n/g, '\n/pm ' + userid + ', ').substr(1);
 				if (text.length > 80000) {

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -329,6 +329,7 @@
 			} else if (text.toLowerCase() === '/clear') {
 				this.closePM(userid);
 				$chat.empty();
+				delete this.chatHistories[userid];
 			} else {
 				text = ('\n' + text).replace(/\n\n/g, '\n').replace(/\n/g, '\n/pm ' + userid + ', ').substr(1);
 				if (text.length > 80000) {

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -327,9 +327,7 @@
 					$chat.append('<div class="chat">User ' + userid + ' no longer ignored.</div>');
 				}
 			} else if (text.toLowerCase() === '/clear') {
-				this.closePM(userid);
 				$chat.empty();
-				delete this.chatHistories[userid];
 			} else {
 				text = ('\n' + text).replace(/\n\n/g, '\n').replace(/\n/g, '\n/pm ' + userid + ', ').substr(1);
 				if (text.length > 80000) {

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -328,7 +328,7 @@
 				}
 			} else if (text.toLowerCase() === '/clear') {
 				this.closePM(userid);
-				this.$pmBox.find('.pm-window-' + userid).find('.inner').empty();
+				$chat.empty();
 			} else {
 				text = ('\n' + text).replace(/\n\n/g, '\n').replace(/\n/g, '\n/pm ' + userid + ', ').substr(1);
 				if (text.length > 80000) {


### PR DESCRIPTION
In response to [this suggestion that I find useful and interesting][1], I added /clear to the PM box.  This does:
- closes the pm box
- flushes out chat history and the inner HTML.

(PS: Please let me know if you want this as a regular chatroom based command as well, I can __totally__ try to add that too!)

[1]: http://www.smogon.com/forums/threads/suggestions.3534365/page-49#post-7230510
