### PR TITLE
Allow formatting in PMs and fix spelling mistake

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1438,7 +1438,7 @@
 					'<span class="message-pm"><i class="pmnote" data-name="' + Tools.escapeHTML(oName) + '">(Private to ' + Tools.escapeHTML(pm) + ')</i> ' + Tools.parseMessage(message) + '</span>' +
 					'</div>'
 				);
-				return; // PMs independently notify in the man menu; no need to make them notify again with `inchatpm`.
+				return; // PMs independently notify in the main menu; no need to make them notify again with `inchatpm`.
 			}
 
 			var lastMessageDates = Tools.prefs('logtimes') || (Tools.prefs('logtimes', {}), Tools.prefs('logtimes'));

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -153,7 +153,7 @@
 			var $lastMessage = $chat.children().last();
 			var textContent = $lastMessage.html().indexOf('<span class="spoiler">') >= 0 ? '(spoiler)' : $lastMessage.children().last().text();
 			if (textContent && app.curSideRoom && app.curSideRoom.addPM && Tools.prefs('inchatpm')) {
-				app.curSideRoom.addPM(name, textContent, target);
+				app.curSideRoom.addPM(name, message, target);
 			}
 
 			if (!isSelf && textContent) {


### PR DESCRIPTION
- fix spelling mistake in client-chat man -> main
- use ``message`` instead of ``textContent`` for showing PMs in chat.  It goes through ``Tools.parseMessage()`` in addChat in client-chat anyways when generating the green message in chatroom, so no need to use the just text version of the PM.