### PR TITLE
Add |notify|

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1237,12 +1237,12 @@
 					this.$chat.append('<div class="notice">' + Tools.sanitizeHTML(row.slice(1).join('|')) + '</div>');
 					break;
 
-				case 'globalhighlight':
-				case 'highlight':
+				case 'globalnotify':
+				case 'notify':
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
 					}
-					if (row[0] !== 'globalhighlight') this.notifyOnce("Highlighted by a declare", "\"" + row.slice(1).join('|') + "\"", 'highlight');
+					if (row[0] !== 'globalnotify') this.notifyOnce("You have a notification", "\"" + row.slice(1).join('|') + "\"", 'highlight');
 					break;
 
 				case 'error':

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1238,12 +1238,9 @@
 					break;
 
 				case 'globalnotify':
-					if (app.user.lastGlobalNotify !== row.slice(1).join('|')) {
-						app.rooms[''].addPM('~', '/html ' + row.slice(1).join('|'), '' + this.room.users[app.user.changed.userid]);
-						if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
-							soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
-						}
-						app.user.lastGlobalNotify = row.slice(1).join('|');
+					app.rooms[''].addPM('~', '/raw ' + row.slice(1).join('|'), '' + this.users[app.user.changed.userid]);
+					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
+						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
 					}
 					break;
 

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1238,9 +1238,12 @@
 					break;
 
 				case 'globalnotify':
-					app.rooms[''].addPM('~', '/html ' + row.slice(1).join('|'), '' + this.room.users[app.user.changed.userid]);
-					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
-						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
+					if (app.user.lastGlobalNotify !== row.slice(1).join('|')) {
+						app.rooms[''].addPM('~', '/html ' + row.slice(1).join('|'), '' + this.room.users[app.user.changed.userid]);
+						if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
+							soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
+						}
+						app.user.lastGlobalNotify = row.slice(1).join('|');
 					}
 					break;
 					

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1237,17 +1237,12 @@
 					this.$chat.append('<div class="notice">' + Tools.sanitizeHTML(row.slice(1).join('|')) + '</div>');
 					break;
 
+				case 'globalhighlight':
 				case 'highlight':
-					var soundOnly = row[1] === 'global';
-					this.$chat.append('<div class="notice">' + Tools.sanitizeHTML(row.slice((soundOnly ? 2 : 1)).join('|')) + '</div>');
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
 					}
-					if (!soundOnly) {
-						var $lastMessage = this.$chat.children().last();
-						var notifyText = $lastMessage.html().indexOf('<span class="spoiler">') >= 0 ? '(spoiler)' : $lastMessage.children().last().text();
-						this.notifyOnce("Highlighted by a declare", "\"" + notifyText + "\"", 'highlight');
-					}
+					if (row[0] !== 'globalhighlight') this.notifyOnce("Highlighted by a declare", "\"" + Tools.escapeHTML(row.slice(1).join('|')) + "\"", 'highlight');
 					break;
 
 				case 'error':

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1246,7 +1246,7 @@
 						app.user.lastGlobalNotify = row.slice(1).join('|');
 					}
 					break;
-					
+
 				case 'notify':
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1242,7 +1242,7 @@
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
 					}
-					if (row[0] !== 'globalhighlight') this.notifyOnce("Highlighted by a declare", "\"" + Tools.escapeHTML(row.slice(1).join('|')) + "\"", 'highlight');
+					if (row[0] !== 'globalhighlight') this.notifyOnce("Highlighted by a declare", "\"" + row.slice(1).join('|') + "\"", 'highlight');
 					break;
 
 				case 'error':

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1237,6 +1237,19 @@
 					this.$chat.append('<div class="notice">' + Tools.sanitizeHTML(row.slice(1).join('|')) + '</div>');
 					break;
 
+				case 'highlight':
+					var soundOnly = row[1] === 'global';
+					this.$chat.append('<div class="notice">' + Tools.sanitizeHTML(row.slice((soundOnly ? 2 : 1)).join('|')) + '</div>');
+					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
+						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
+					}
+					if (!soundOnly) {
+						var $lastMessage = this.$chat.children().last();
+						var notifyText = $lastMessage.html().indexOf('<span class="spoiler">') >= 0 ? '(spoiler)' : $lastMessage.children().last().text();
+						this.notifyOnce("Highlighted by a declare", "\"" + notifyText + "\"", 'highlight');
+					}
+					break;
+
 				case 'error':
 					this.$chat.append('<div class="notice message-error">' + Tools.escapeHTML(row.slice(1).join('|')) + '</div>');
 					break;

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1239,12 +1239,16 @@
 
 				case 'globalnotify':
 					app.rooms[''].addPM('~', '/html ' + row.slice(1).join('|'), '' + this.room.users[app.user.changed.userid]);
-					// Falls through
+					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
+						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
+					}
+					break;
+					
 				case 'notify':
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
 					}
-					if (row[0] !== 'globalnotify') this.notifyOnce("You have a notification", "\"" + row.slice(1).join('|') + "\"", 'highlight');
+					this.notifyOnce("You have a notification", "\"" + row.slice(1).join('|') + "\"", 'highlight');
 					break;
 
 				case 'error':

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1237,13 +1237,6 @@
 					this.$chat.append('<div class="notice">' + Tools.sanitizeHTML(row.slice(1).join('|')) + '</div>');
 					break;
 
-				case 'globalnotify':
-					app.rooms[''].addPM('~', '/raw ' + row.slice(1).join('|'), '' + this.users[app.user.changed.userid]);
-					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
-						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
-					}
-					break;
-
 				case 'notify':
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1238,6 +1238,8 @@
 					break;
 
 				case 'globalnotify':
+					app.rooms[''].addPM('~', '/html ' + row.slice(1).join('|'), '' + this.room.users[app.user.changed.userid]);
+					// Falls through
 				case 'notify':
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1241,7 +1241,7 @@
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
 					}
-					this.notifyOnce(row[1], "\"" + row.slice(2).join('|') + "\"", 'highlight');
+					this.notifyOnce(row[1], row.slice(2).join('|'), 'highlight');
 					break;
 
 				case 'error':

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1248,7 +1248,7 @@
 					if (!Tools.prefs('mute') && Tools.prefs('notifvolume')) {
 						soundManager.getSoundById('notif').setVolume(Tools.prefs('notifvolume')).play();
 					}
-					this.notifyOnce("You have a notification", "\"" + row.slice(1).join('|') + "\"", 'highlight');
+					this.notifyOnce(row[1], "\"" + row.slice(2).join('|') + "\"", 'highlight');
 					break;
 
 				case 'error':


### PR DESCRIPTION
Discussed in staff, not decided on yet so shouldn't be merged.

Adds the ability to highlight a user through protocol. This is used for declares.

 - `|notify|message to display when hovering room tab` Highlights the user normally in the room. http://imgur.com/a/wcj1k (note this image is from a global declare test, but global declares do not highlight in all rooms)

 - `|globalnotify|message` Sends a PM box from `~` with the message, accepts HTML, also sends a notification sound.

EDIT: update information to match changes

Paired with server pull request: https://github.com/Zarel/Pokemon-Showdown/pull/3294