### PR TITLE
Add private message ignoring

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -517,6 +517,43 @@
 				}
 				return false;
 
+			case 'pmignore':
+				if (!target) {
+					this.parseCommand('/help pmignore');
+					return false;
+				}
+				if (toUserid(target) === app.user.get('userid')) {
+					this.add("You are not able to ignore yourself.");
+				} else if (app.ignorePMs[toUserid(target)]) {
+					this.add("User '" + toName(target) + "' is already on your PM ignore list. (Moderator messages will not be ignored.)");
+				} else {
+					app.ignorePMs[toUserid(target)] = 1;
+					this.add("User '" + toName(target) + "' PMs ignored. (Moderator messages will not be ignored.)");
+				}
+				return false;
+
+			case 'unpmignore':
+				if (!target) {
+					this.parseCommand('/help unpmignore');
+					return false;
+				}
+				if (!app.ignorePMs[toUserid(target)]) {
+					this.add("User '" + toName(target) + "' isn't on your PMs ignore list.");
+				} else {
+					delete app.ignorePMs[toUserid(target)];
+					this.add("User '" + toName(target) + "' PMs no longer ignored.");
+				}
+				return false;
+
+			case 'pmignorelist':
+				var ignoreList = Object.keys(app.ignorePMs);
+				if (ignoreList.length === 0) {
+					this.add('You are currently not ignoring anyone\'s PMs.');
+				} else {
+					this.add("You are currently ignoring PMs from: " + ignoreList.join(', '));
+				}
+				return false;
+
 			case 'clear':
 				if (this.clear) {
 					this.clear();
@@ -898,9 +935,18 @@
 					return false;
 				case 'ignore':
 				case 'unignore':
+				case 'ignorelist':
 					this.add('/ignore [user] - Ignore all messages from the user [user].');
 					this.add('/unignore [user] - Remove the user [user] from your ignore list.');
 					this.add('/ignorelist - List all the users that you currently ignore.');
+					this.add('Note that staff messages cannot be ignored.');
+					return false;
+				case 'pmignore':
+				case 'pmunignore':
+				case 'pmignorelist':
+					this.add('/ignore [user] - Ignore all private messages from the user [user].');
+					this.add('/unignore [user] - Remove the user [user] from your private message ignore list.');
+					this.add('/ignorelist - List all the users that you currently ignore private messages from.');
 					this.add('Note that staff messages cannot be ignored.');
 					return false;
 				case 'nick':

--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -131,7 +131,7 @@
 
 		addPM: function (name, message, target) {
 			var userid = toUserid(name);
-			if (app.ignore[userid] && name.substr(0, 1) in {' ': 1, '!': 1, '✖': 1, '‽': 1}) return;
+			if ((app.ignore[userid] || app.ignorePMs[userid]) && name.substr(0, 1) in {' ': 1, '!': 1, '✖': 1, '‽': 1}) return;
 
 			var isSelf = (toId(name) === app.user.get('userid'));
 			var oName = isSelf ? target : name;
@@ -325,6 +325,20 @@
 				} else {
 					delete app.ignore[userid];
 					$chat.append('<div class="chat">User ' + userid + ' no longer ignored.</div>');
+				}
+			} else if (text.toLowerCase() === '/pmignore') {
+				if (app.ignorePMs[userid]) {
+					$chat.append('<div class="chat">User ' + userid + ' is already on your PM ignore list. (Moderator messages will not be ignored.)</div>');
+				} else {
+					app.ignorePMs[userid] = 1;
+					$chat.append('<div class="chat">User ' + userid + '\'s PMs ignored. (Moderator messages will not be ignored.)</div>');
+				}
+			} else if (text.toLowerCase() === '/unpmignore') {
+				if (!app.ignorePMs[userid]) {
+					$chat.append('<div class="chat">User ' + userid + ' isn\'t on your PM ignore list.</div>');
+				} else {
+					delete app.ignorePMs[userid];
+					$chat.append('<div class="chat">User ' + userid + '\'s PMs no longer ignored.</div>');
 				}
 			} else if (text.toLowerCase() === '/clear') {
 				$chat.empty();
@@ -556,7 +570,7 @@
 			this.challengesFrom = data.challengesFrom;
 			this.challengeTo = data.challengeTo;
 			for (var i in data.challengesFrom) {
-				if (app.ignore[i]) {
+				if (app.ignore[i] || app.ignorePMs[i]) {
 					delete data.challengesFrom[i];
 					continue;
 				}

--- a/js/client.js
+++ b/js/client.js
@@ -365,6 +365,7 @@
 
 			this.user = new User();
 			this.ignore = {};
+			this.ignorePMs = {};
 			this.supports = {};
 
 			// down
@@ -846,6 +847,9 @@
 				if (app.ignore[toUserid(names[2])]) {
 					app.ignore[toUserid(names[1])] = 1;
 				}
+				if (app.ignorePMs[toUserid(names[2])]) {
+					app.ignorePMs[toUserid(names[1])] = 1;
+				}
 			}
 			if (roomid) {
 				if (this.rooms[roomid]) {
@@ -912,6 +916,9 @@
 				}
 				if (app.ignore[toUserid(name)]) {
 					delete app.ignore[toUserid(name)];
+				}
+				if (app.ignorePMs[toUserid(name)]) {
+					delete app.ignorePMs[toUserid(name)];
 				}
 				break;
 
@@ -2352,7 +2359,8 @@
 			this.update();
 		},
 		update: function () {
-			this.$el.html('<p><button name="toggleIgnoreUser">' + (app.ignore[this.userid] ? 'Unignore' : 'Ignore') + '</button></p>');
+			this.$el.html('<p><button name="toggleIgnoreUser">' + (app.ignore[this.userid] ? 'Unignore User' : 'Ignore User') + '</button></p>' +
+				'<p><button name="toggleIgnoreUserPMs">' + (app.ignorePMs[this.userid] ? 'Unignore Messages' : 'Ignore Messages') + '</button></p>');
 		},
 		toggleIgnoreUser: function () {
 			var buf = "User '" + this.name + "'";
@@ -2362,6 +2370,28 @@
 			} else {
 				app.ignore[this.userid] = 1;
 				buf += " ignored. (Moderator messages will not be ignored.)";
+			}
+			var $pm = $('.pm-window-' + this.userid);
+			if ($pm.length && $pm.css('display') !== 'none') {
+				$pm.find('.inner').append('<div class="chat">' + Tools.escapeHTML(buf) + '</div>');
+			} else {
+				var room = (app.curRoom && app.curRoom.add ? app.curRoom : app.curSideRoom);
+				if (!room || !room.add) {
+					app.addPopupMessage(buf);
+					return this.update();
+				}
+				room.add(buf);
+			}
+			app.dismissPopups();
+		},
+		toggleIgnoreUserPMs: function () {
+			var buf = "User '" + this.name + "'";
+			if (app.ignorePMs[this.userid]) {
+				delete app.ignorePMs[this.userid];
+				buf += " PMs no longer ignored.";
+			} else {
+				app.ignorePMs[this.userid] = 1;
+				buf += " PMs ignored. (Moderator messages will not be ignored.)";
 			}
 			var $pm = $('.pm-window-' + this.userid);
 			if ($pm.length && $pm.css('display') !== 'none') {


### PR DESCRIPTION
- Allow the ability to ignore PMs and challenges from users only, but still see their messages in chat.
> For anyone who has been staff, they've probably dealt with users in PMs who are very persistent, and this is a method to stop getting notifications from them, while still be able to see their chatroom messages for moderation purposes.

- Add new commands, and help entries - /pmignore, /pmunignore, /pmignorelist
- Add additional button in menu for users to press to ignore the target's PMs only.

Referenced in [a suggestion on smogon](http://www.smogon.com/forums/threads/suggestions.3534365/page-49#post-7249203) by SparksBlade.  I've had this "feature" via tampermonkey script for more than a year now, and it's certainly something that's very useful.