### PR TITLE
Fix ignoring in battles

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -6276,8 +6276,8 @@ var Battle = (function () {
 			var name = args[1].slice(0, pipeIndex);
 			var rank = name.charAt(0);
 			if (this.ignoreSpects && (rank === ' ' || rank === '+')) break;
-			if (this.ignoreOpponent && rank === '\u2605' && toUserid(name) !== app.user.get('userid')) break;
-			if (window.app && app.ignore && app.ignore[toUserid(name)] && (rank === ' ' || rank === '+' || rank === '\u2605')) break;
+			if (this.ignoreOpponent && rank === '\u2606' && toUserid(name) !== app.user.get('userid')) break;
+			if (window.app && app.ignore && app.ignore[toUserid(name)] && (rank === ' ' || rank === '+' || rank === '\u2606')) break;
 			var message = args[1].slice(pipeIndex + 1);
 			var isHighlighted = window.app && app.rooms && app.rooms[this.roomid].getHighlight(message);
 			var parsedMessage = Tools.parseChatMessage(message, name, '', isHighlighted);

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1261,7 +1261,7 @@
 		toggleIgnoreSpects: function (e) {
 			this.battle.ignoreSpects = !!e.currentTarget.checked;
 			this.battle.add('Spectators ' + (this.battle.ignoreSpects ? '' : 'no longer ') + 'ignored.');
-			var $messages = $('.battle-log').find('.chat').not('small:contains(\u2605)');
+			var $messages = $('.battle-log').find('.chat').has('small').not(':contains(\u2606)');
 			if (!$messages.length) return;
 			if (this.battle.ignoreSpects) {
 				$messages.hide();


### PR DESCRIPTION
This fixes two things:
1. the auth symbol change for players which caused player messages to always go through in battles, regardless of "ignore opponent" and /ignore
2. the automatic message hiding/unhiding when clicking "Ignore spectators", which used to hide _all_ chat messages. Now it only hides actual chat messages and joins/leaves, but not the details row of /dt or notes like "Spectatoers ignored.".