### PR TITLE
Fix some dark mode visibility issues

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -892,7 +892,7 @@ License: GPLv2
 }
 a.subtle {
 	text-decoration: none;
-	color: black;
+	color: inherit;
 }
 a.subtle:hover {
 	text-decoration: underline;

--- a/style/client.css
+++ b/style/client.css
@@ -178,7 +178,8 @@ button:disabled {
 }
 */
 .dark .button,
-.dark .tabbar a.button {
+.dark .tabbar a.button,
+.dark .popupmenu button.button {
 	background: #484848;
 	box-shadow: inset 0 3px 4px rgba(255, 255, 255, 0.25);
 	border-color: #A9A9A9;
@@ -186,9 +187,11 @@ button:disabled {
 	color: #F9F9F9;
 }
 .dark .button:hover,
-.dark .tabbar a.button:hover {
+.dark .tabbar a.button:hover,
+.dark .popupmenu button.button:hover {
 	background: #606060;
 	border-color: #EEEEEE;
+	color: #F9F9F9;
 }
 .dark .tabbar a.button.notifying:hover {
 	background: #92C2D3;
@@ -766,6 +769,9 @@ p.or:after {
 }
 .teamselect:disabled strong {
 	color: #777777;
+}
+.dark .teamselect:disabled strong {
+	color: #505050;
 }
 .teamselect small {
 	margin: -1px 0 0 -3px;


### PR DESCRIPTION
This changes this: 
![grafik](https://cloud.githubusercontent.com/assets/5814184/23573835/42515d16-0079-11e7-9a49-9d5116365328.png) 
to this:
![grafik](https://cloud.githubusercontent.com/assets/5814184/23573843/558d2202-0079-11e7-8352-100d8f228760.png)
The color attribute is repeated in the :hover rule because otherwise `.dark .popupmenu button:hover` would overwrite it (with black). Not sure if there's a more elegant way to solve this.

It also changes this:
![grafik](https://cloud.githubusercontent.com/assets/5814184/23574250/e66356e0-007c-11e7-8671-f90a886ecdae.png)
to this:
![grafik](https://cloud.githubusercontent.com/assets/5814184/23574253/f4a0602c-007c-11e7-86c9-f56c6302e977.png)

Lastly, this also changes subtle links to not be black in dark mode by inheriting the regular text color. Zarel mentioned fixing that in the dev room a while ago (and it is indeed fixed on the site), but apparently that change was never actually committed.

