### PR TITLE
Fix linking with formatting

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -337,13 +337,13 @@ var linkRegex = new RegExp(
 			'/' +
 			'(?:' +
 				'(?:' +
-					'[^\\s()&]|&amp;|&quot;' +
+					'[^\\s()&<>]|&amp;|&quot;' +
 					'|' + parenthesisRegex +
 				')*' +
 				// URLs usually don't end with punctuation, so don't allow
 				// punctuation symbols that probably aren't related to URL.
 				'(?:' +
-					'[^\\s`()\\[\\]{}\'".,!?;:&]' +
+					'[^\\s`()\\[\\]{}\'".,!?;:&<>]' +
 					'|' + parenthesisRegex +
 				')' +
 			')?' +


### PR DESCRIPTION
- stop redirecting to stuff such as ``https://docs.google.com/document/d/1HN-sTiW6Psm-Xa87ew4eS3WrLnH4k8rGcwqmbm-Glg0/edit</b>`` (sample mafia link that glitched up) when the entire link is done with formatting

I believe adding those ``<>`` in those places will fix it (tested using testclient.html locally)