### PR TITLE
Fix level changing in gen 1 teambuilder causing invalid happiness

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2356,6 +2356,7 @@
 
 			// happiness
 			var happiness = parseInt(this.$chart.find('input[name=happiness]').val(), 10);
+			if (isNaN(happiness)) happiness = 255;
 			if (happiness > 255) happiness = 255;
 			if (happiness < 0) happiness = 255;
 			set.happiness = happiness;


### PR DESCRIPTION
Because there's no happiness input in gen 1 mode, it gets undefined, which it parses as NaN.