### PR TITLE
Add IV Options

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2072,6 +2072,9 @@
 			});
 			this.suppressSliderCallback = false;
 		},
+		autoivpopup: function () {
+			app.addPopup(window.AutoIVPopup);
+		},
 		setStatFormGuesses: function () {
 			this.updateStatForm(true);
 		},
@@ -2661,6 +2664,8 @@
 		},
 		unChooseMove: function (moveName) {
 			var set = this.curSet;
+			var ivprefs = Tools.prefs('autoiv');
+			var trickroom = (this.curTeam.format.indexOf('double') !== -1 || this.curTeam.format.indexOf('vgc') !== -1 ? ivprefs.trdouble : ivprefs.trsingle);
 			if (!moveName || !set || this.curTeam.format === 'gen7hiddentype') return;
 			if (moveName.substr(0, 13) === 'Hidden Power ') {
 				if (set.ivs) {
@@ -2671,7 +2676,7 @@
 				}
 			}
 			var resetSpeed = false;
-			if (moveName === 'Gyro Ball') {
+			if (moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom)) {
 				resetSpeed = true;
 			}
 			this.chooseMove('', resetSpeed);
@@ -2689,6 +2694,9 @@
 		chooseMove: function (moveName, resetSpeed) {
 			var set = this.curSet;
 			if (!set) return;
+			var ivprefs = Tools.prefs('autoiv');
+			var trickroom = (this.curTeam.format.indexOf('double') !== -1 || this.curTeam.format.indexOf('vgc') !== -1 ? ivprefs.trdouble : ivprefs.trsingle);
+			if (!ivprefs.neverchange) trickroom = false;
 			var gen = this.curTeam.gen;
 
 			var minSpe;
@@ -2719,7 +2727,7 @@
 				this.curSet.happiness = 255;
 			} else if (moveName === 'Frustration') {
 				this.curSet.happiness = 0;
-			} else if (moveName === 'Gyro Ball') {
+			} else if (moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom)) {
 				minSpe = true;
 			}
 
@@ -2739,7 +2747,7 @@
 				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
 					minAtk = false;
 				}
-				if (minSpe === false && moveName === 'Gyro Ball') {
+				if (minSpe === false && (moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom))) {
 					minSpe = undefined;
 				}
 			}
@@ -2758,7 +2766,7 @@
 			}
 			if (gen < 3) return;
 			if (!set.ivs['atk'] && set.ivs['atk'] !== 0) set.ivs['atk'] = 31;
-			if (minAtk) {
+			if (minAtk && !ivprefs.neverchange) {
 				// min Atk
 				set.ivs['atk'] = (hasHiddenPower ? set.ivs['atk'] % hpModulo : 0);
 			} else {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2052,7 +2052,7 @@
 
 				buf += '<p><em>Protip:</em> You can also set natures by typing "+" and "-" next to a stat.</p>';
 			}
-			
+
 			buf += '<p><button name="autoiv">Automatic IVs</button></p>';
 			buf += '</div>';
 			this.$chart.html(buf);

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2097,8 +2097,6 @@
 			});
 			app.addPopup(this.AutoIVPopup);
 		},
-			app.addPopup(window.AutoIVPopup);
-		},
 		setStatFormGuesses: function () {
 			this.updateStatForm(true);
 		},

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2074,6 +2074,29 @@
 			this.suppressSliderCallback = false;
 		},
 		autoiv: function () {
+			var AutoIVPopup = this.AutoIVPopup = Popup.extend({
+				events: {
+					'change input': 'setOption'
+				},
+				initialize: function () {
+					var cur = this.teambuilderprefs = Tools.prefs('autoiv') || {};
+					var canChange = (cur.neverchange ? 'disabled' : '');
+					var buf = '<p class="optlabel">Change whether the teambuilder will automatically change your IVs.</p>';
+					buf += '<p><label class="optlabel"><input type="checkbox" name="neverchange"' + (cur.neverchange ? ' checked' : '') + ' /> Never automatically change my IVs (except for Hidden Powers).</label></p>';
+					buf += '<p><label class="optlabel"><input type="checkbox" name="trsingle"' + (cur.trsingle && !cur.neverchange ? ' checked' : '') + canChange + ' /> Change my speed IVs to 0 when I have Trick Room (Singles).</label></p>';
+					buf += '<p><label class="optlabel"><input type="checkbox" name="trdouble"' + (cur.trdouble && !cur.neverchange ? ' checked' : '') + canChange + ' /> Change my speed IVs to 0 when I have Trick Room (Doubles).</label></p>';
+					buf += '<p><button name="close">Close</button></p>';
+					this.$el.html(buf);
+				},
+				setOption: function (e) {
+					var name = $(e.currentTarget).prop('name');
+					this.teambuilderprefs[name] = !!e.currentTarget.checked;
+					Tools.prefs('autoiv', this.teambuilderprefs);
+					this.initialize();
+				}
+			});
+			app.addPopup(this.AutoIVPopup);
+		},
 			app.addPopup(window.AutoIVPopup);
 		},
 		setStatFormGuesses: function () {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2664,9 +2664,10 @@
 		},
 		unChooseMove: function (moveName) {
 			var set = this.curSet;
+			if (!moveName || !set || this.curTeam.format === 'gen7hiddentype') return;
 			var ivprefs = Tools.prefs('autoiv');
 			var trickroom = (this.curTeam.format.indexOf('double') !== -1 || this.curTeam.format.indexOf('vgc') !== -1 ? ivprefs.trdouble : ivprefs.trsingle);
-			if (!moveName || !set || this.curTeam.format === 'gen7hiddentype') return;
+			if (ivprefs.neverchange) trickroom = false;
 			if (moveName.substr(0, 13) === 'Hidden Power ') {
 				if (set.ivs) {
 					for (var i in set.ivs) {
@@ -2696,7 +2697,7 @@
 			if (!set) return;
 			var ivprefs = Tools.prefs('autoiv');
 			var trickroom = (this.curTeam.format.indexOf('double') !== -1 || this.curTeam.format.indexOf('vgc') !== -1 ? ivprefs.trdouble : ivprefs.trsingle);
-			if (!ivprefs.neverchange) trickroom = false;
+			if (ivprefs.neverchange) trickroom = false;
 			var gen = this.curTeam.gen;
 
 			var minSpe;

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2052,7 +2052,8 @@
 
 				buf += '<p><em>Protip:</em> You can also set natures by typing "+" and "-" next to a stat.</p>';
 			}
-
+			
+			buf += '<p><button name="autoiv">Automatic IVs</button></p>';
 			buf += '</div>';
 			this.$chart.html(buf);
 			var self = this;
@@ -2072,7 +2073,7 @@
 			});
 			this.suppressSliderCallback = false;
 		},
-		autoivpopup: function () {
+		autoiv: function () {
 			app.addPopup(window.AutoIVPopup);
 		},
 		setStatFormGuesses: function () {

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2699,7 +2699,7 @@
 				}
 			}
 			var resetSpeed = false;
-			if (moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom)) {
+			if ((moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom)) && !ivprefs.neverchange) {
 				resetSpeed = true;
 			}
 			this.chooseMove('', resetSpeed);
@@ -2750,7 +2750,7 @@
 				this.curSet.happiness = 255;
 			} else if (moveName === 'Frustration') {
 				this.curSet.happiness = 0;
-			} else if (moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom)) {
+			} else if ((moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom)) && !ivprefs.neverchange) {
 				minSpe = true;
 			}
 
@@ -2770,7 +2770,7 @@
 				} else if (move.id === 'metronome' || move.id === 'assist' || move.id === 'copycat' || move.id === 'mefirst') {
 					minAtk = false;
 				}
-				if (minSpe === false && (moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom))) {
+				if (minSpe === false && (moveName === 'Gyro Ball' || (moveName === 'Trick Room' && trickroom)) && !ivprefs.neverchange) {
 					minSpe = undefined;
 				}
 			}

--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -2689,7 +2689,6 @@
 			if (!moveName || !set || this.curTeam.format === 'gen7hiddentype') return;
 			var ivprefs = Tools.prefs('autoiv');
 			var trickroom = (this.curTeam.format.indexOf('double') !== -1 || this.curTeam.format.indexOf('vgc') !== -1 ? ivprefs.trdouble : ivprefs.trsingle);
-			if (ivprefs.neverchange) trickroom = false;
 			if (moveName.substr(0, 13) === 'Hidden Power ') {
 				if (set.ivs) {
 					for (var i in set.ivs) {
@@ -2719,7 +2718,6 @@
 			if (!set) return;
 			var ivprefs = Tools.prefs('autoiv');
 			var trickroom = (this.curTeam.format.indexOf('double') !== -1 || this.curTeam.format.indexOf('vgc') !== -1 ? ivprefs.trdouble : ivprefs.trsingle);
-			if (ivprefs.neverchange) trickroom = false;
 			var gen = this.curTeam.gen;
 
 			var minSpe;

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -572,7 +572,7 @@
 			app.addPopup(FormattingPopup);
 		},
 		autoiv: function () {
-			app.addPopup(TeambuilderPopup);
+			app.addPopup(AutoIVPopup);
 		},
 		login: function () {
 			app.addPopup(LoginPopup);

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -489,7 +489,7 @@
 
 			buf += '<hr />';
 			buf += '<p><strong>Teambuilder</strong></p>';
-			buf += '<p><label class="optlabel">Preferences: <button name="autoivs">Automatic IVs</button></label></p>';
+			buf += '<p><label class="optlabel">Preferences: <button name="autoiv">Automatic IVs</button></label></p>';
 			
 			if (window.nodewebkit) {
 				buf += '<hr />';
@@ -571,7 +571,7 @@
 		formatting: function () {
 			app.addPopup(FormattingPopup);
 		},
-		teambuilder: function () {
+		autoiv: function () {
 			app.addPopup(TeambuilderPopup);
 		},
 		login: function () {
@@ -617,7 +617,7 @@
 		}
 	});
 	
-	var TeambuilderPopup = this.TeambuilderPopup = Popup.extend({
+	var AutoIVPopup = this.TeambuilderPopup = Popup.extend({
 		events: {
 			'change input': 'setOption'
 		},

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -487,6 +487,10 @@
 			buf += '<p><label class="optlabel">Timestamps in PMs: <select name="timestamps-pms"><option value="off">Off</option><option value="minutes"' + (timestamps.pms === 'minutes' ? ' selected="selected"' : '') + '>[HH:MM]</option><option value="seconds"' + (timestamps.pms === 'seconds' ? ' selected="selected"' : '') + '>[HH:MM:SS]</option></select></label></p>';
 			buf += '<p><label class="optlabel">Chat preferences: <button name="formatting">Edit formatting</button></label></p>';
 
+			buf += '<hr />';
+			buf += '<p><strong>Teambuilder</strong></p>';
+			buf += '<p><label class="optlabel">Preferences: <button name="autoivs">Automatic IVs</button></label></p>';
+			
 			if (window.nodewebkit) {
 				buf += '<hr />';
 				buf += '<p><strong>Desktop app</strong></p>';
@@ -567,6 +571,9 @@
 		formatting: function () {
 			app.addPopup(FormattingPopup);
 		},
+		teambuilder: function () {
+			app.addPopup(TeambuilderPopup);
+		},
 		login: function () {
 			app.addPopup(LoginPopup);
 		},
@@ -607,6 +614,28 @@
 			var name = $(e.currentTarget).prop('name');
 			this.chatformatting['hide' + name] = !!e.currentTarget.checked;
 			Tools.prefs('chatformatting', this.chatformatting);
+		}
+	});
+	
+	var TeambuilderPopup = this.TeambuilderPopup = Popup.extend({
+		events: {
+			'change input': 'setOption'
+		},
+		initialize: function () {
+			var cur = this.teambuilderprefs = Tools.prefs('autoiv') || {};
+			var canChange = (cur.neverchange ? 'disabled' : '');
+			var buf = '<p class="optlabel">Change whether the teambuilder will automatically change your IVs.</p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="neverchange"' + (cur.neverchange ? ' checked' : '') + ' /> Never automatically change my IVs (except for Hidden Powers).</label></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="trsingle"' + (cur.trsingle && !cur.neverchange ? ' checked' : '') + canChange + ' /> Change my speed IVs to 0 when I have Trick Room (Singles).</label></p>';
+			buf += '<p><label class="optlabel"><input type="checkbox" name="trdouble"' + (cur.trdouble && !cur.neverchange ? ' checked' : '') + canChange + ' /> Change my speed IVs to 0 when I have Trick Room (Doubles).</label></p>';
+			buf += '<p><button name="close">Close</button></p>';
+			this.$el.html(buf);
+		},
+		setOption: function (e) {
+			var name = $(e.currentTarget).prop('name');
+			this.teambuilderprefs[name] = !!e.currentTarget.checked;
+			Tools.prefs('autoiv', this.teambuilderprefs);
+			this.initialize();
 		}
 	});
 

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -490,7 +490,7 @@
 			buf += '<hr />';
 			buf += '<p><strong>Teambuilder</strong></p>';
 			buf += '<p><label class="optlabel">Preferences: <button name="autoiv">Automatic IVs</button></label></p>';
-			
+
 			if (window.nodewebkit) {
 				buf += '<hr />';
 				buf += '<p><strong>Desktop app</strong></p>';
@@ -616,7 +616,7 @@
 			Tools.prefs('chatformatting', this.chatformatting);
 		}
 	});
-	
+
 	var AutoIVPopup = this.TeambuilderPopup = Popup.extend({
 		events: {
 			'change input': 'setOption'


### PR DESCRIPTION
Adds an option to allow Trick Room to change Speed IVs to 0 since it seemed like some people still wanted this in the Removal of Trick Room = Auto 0 Speed IVs thread, and also adds an option to disallow teambuilder changing IVs (except for past gens hidden power) (requested by thimo).

Currently it finds doubles formats by searching `this.curTeam.format` for "doubles" or "vgc" (Surrounding code just searched format for tiers to find level caps)
I also duplicate `AutoIVPopup` and I'm not sure if thats the best way to use a popup (or if it can be somewhere else where client-teambuilder and client-topbar can access it)
The button to access the options popup is just at the bottom of the options and bottom of iv tab in teambuilder (imgur.com/a/OWx2l this is a outdated picture but the buttons are in the same place), can the buttons stay in the same place or should they be moved elsewhere?