### PR TITLE
Modchat messages are not battle messages

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -364,14 +364,14 @@ License: GPLv2
 	padding: 4px 6px 0 6px;
 	overflow: hidden;
 }
-.message strong {
+.messagebar strong {
 	color: #ffffff;
 	font-size: 12pt;
 }
-.message small {
+.messagebar small {
 	font-size: 8pt;
 }
-.message p {
+.messagebar p {
 	display: none;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
PR Zarel/Pokemon-Showdown#3427 changed the HTML for modchat messages to use `<strong>` instead of `<b>`. This means that a rule for the battle messagebar now trips over modchat messages. I'm assuming that these rules were probably only meant to apply to the messagebar, which is why they're after the rule for the messagebar itself in the first place. (In fact, I'm not sure why the messagebar also has the message class; that could probably be removed if you want.)