### PR TITLE
Fix dark mode style regressions

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -828,6 +828,13 @@ License: GPLv2
 	/* Readable link colour */
 	color: #DDEEFF;
 }
+.battle-log .inner .chat .broadcast-green strong,
+.battle-log .inner .chat .broadcast-blue strong,
+.battle-log .inner .chat .broadcast-red strong,
+.battle-log .inner .chat .message-announce strong {
+	/* readable bold text in broadcast boxes in battles */
+	color: white;
+}
 .broadcast-green {
 	background-color: #559955;
 	color: white;

--- a/style/client.css
+++ b/style/client.css
@@ -187,7 +187,10 @@ button:disabled {
 	color: #F9F9F9;
 }
 .dark .button:hover,
-.dark .tabbar a.button:hover,
+.dark .tabbar a.button:hover {
+	background: #606060;
+	border-color: #EEEEEE;
+}
 .dark .popupmenu button.button:hover {
 	background: #606060;
 	border-color: #EEEEEE;


### PR DESCRIPTION
1. subtly notifying roomtab title turned white on mouseover (I accidently broke this in #879)
2. bold text in modchat/modjoin boxes [turned blue](https://cloud.githubusercontent.com/assets/5814184/25301690/fa23b102-272d-11e7-8414-37a9a3ea36c9.png) in the battle chat since they now use ``<strong>`` as well



