### PR TITLE
Teambuilder: don't display M-Garchomp as banned

### DIFF
--- a/githooks/build-indexes
+++ b/githooks/build-indexes
@@ -372,7 +372,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 				return ["CAP", "Uber", "OU", "BL", "UU", "BL2", "RU", "BL3", "NU", "NFE", "LC Uber", "LC"];
 			}
 			if (gen === 'gen7') {
-				return ["CAP", "Uber", "OU", "BL", "UU", "BL2", "New", "Unreleased", "NFE", "LC Uber", "LC"];
+				return ["CAP", "Uber", "OU", "BL", "(OU)", "UU", "BL2", "RU", "BL3", "NU", "BL4", "PU", "New", "Unreleased", "NFE", "LC Uber", "LC"];
 			}
 			if (isDoubles) {
 				return ["DUber", "DOU", "DUU", "DNU", "NFE"];


### PR DESCRIPTION
Also prepare for the lower tiers to come so they won't initially get displayed as banned when they come out.
Unless there's a specific reason to only add new formats when they come out?