### PR TITLE
Add GUI support for requesting timer to stay switched on

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1312,7 +1312,8 @@
 		initialize: function (data) {
 			this.room = data.room;
 			if (this.room.battle.kickingInactive) {
-				this.$el.html('<p><button name="timerOff"><strong>Stop timer</strong></button></p>');
+				this.$el.html('<p><button name="timerOff"><strong>Stop timer</strong></button></p>' +
+					'<p><button name="timerOn"><strong>Keep timer switched on</strong></button></p>');
 			} else {
 				this.$el.html('<p><button name="timerOn"><strong>Start timer</strong></button></p>');
 			}


### PR DESCRIPTION
The motivation for this is that it's possible to timerstall indefinitely by repeatedly switching the timer off and on in quick succession so the opponent doesn't get the chance to turn it on themself. This was somewhat alleviated by allowing multiple users to request the timer to be on, but most people probably aren't aware that they can use ``/timer on`` to do that, so there should be a button for it.