### PR TITLE
Prevent teambuilder from crashing current versions of Opera

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -720,7 +720,8 @@
 				iconCache: ''
 			};
 
-			if (navigator.storage && navigator.storage.persist) {
+			// work around Opera 4x crashing when persist() is called
+			if (navigator.storage && navigator.storage.persist && !/ OPR\/4/.test(navigator.userAgent)) {
 				var self = this;
 				navigator.storage.persist().then(function (state) {
 					self.updatePersistence(state);


### PR DESCRIPTION
Fix for #911. [According to MDN](https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/persist), StorageManager#persist() was introduced in Opera 42. It's crashing in 44, so I'm just gonna prevent all versions starting with 4 to executing that code, I don't want to rely on them fixing it in 45.