### PR TITLE
Client: support custom ranks

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1624,7 +1624,7 @@
 			text += '<li' + (this.room.userForm === userid ? ' class="cur"' : '') + ' id="' + this.room.id + '-userlist-user-' + Tools.escapeHTML(userid) + '">';
 			text += '<button class="userbutton username" data-name="' + Tools.escapeHTML(name) + '">';
 			var group = name.charAt(0);
-			var details = GroupDetails[group] || {rank: 0};
+			var details = window.GroupDetails[group] || {rank: 0};
 			text += '<em class="group' + (details.group === 2 ? ' staffgroup' : '') + '">' + Tools.escapeHTML(group) + '</em>';
 			if (details.group === 2) {
 				text += '<strong><em style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</em></strong>';
@@ -1654,8 +1654,8 @@
 		},
 		comparator: function (a, b) {
 			if (a === b) return 0;
-			var aRank = (GroupDetails[this.room.users[a] ? this.room.users[a].substr(0, 1) : app.defaultGroup || ' '] || {order: 6}).order;
-			var bRank = (GroupDetails[this.room.users[b] ? this.room.users[b].substr(0, 1) : app.defaultGroup || ' '] || {order: 6}).order;
+			var aRank = (window.GroupDetails[this.room.users[a] ? this.room.users[a].substr(0, 1) : app.defaultGroup || ' '] || {order: 6}).order;
+			var bRank = (window.GroupDetails[this.room.users[b] ? this.room.users[b].substr(0, 1) : app.defaultGroup || ' '] || {order: 6}).order;
 			if (aRank !== bRank) return aRank - bRank;
 			return (a > b ? 1 : -1);
 		},

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1656,11 +1656,11 @@
 			if (a === b) return 0;
 			var aRank = (
 				Config.groups[(this.room.users[a] ? this.room.users[a].charAt(0) : Config.defaultGroup || ' ')] ||
-				{order: (Config.defaultOrder || 5.5)}
+				{order: (Config.defaultOrder || 10005.5)}
 			).order;
 			var bRank = (
 				Config.groups[(this.room.users[b] ? this.room.users[b].charAt(0) : Config.defaultGroup || ' ')] ||
-				{order: (Config.defaultOrder || 5.5)}
+				{order: (Config.defaultOrder || 10005.5)}
 			).order;
 
 			if (aRank !== bRank) return aRank - bRank;

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1624,11 +1624,11 @@
 			text += '<li' + (this.room.userForm === userid ? ' class="cur"' : '') + ' id="' + this.room.id + '-userlist-user-' + Tools.escapeHTML(userid) + '">';
 			text += '<button class="userbutton username" data-name="' + Tools.escapeHTML(name) + '">';
 			var group = name.charAt(0);
-			var details = window.GroupDetails[group] || {rank: 0};
+			var details = Config.groups[group] || {type: 0};
 			text += '<em class="group' + (details.group === 2 ? ' staffgroup' : '') + '">' + Tools.escapeHTML(group) + '</em>';
-			if (details.group === 2) {
+			if (details.type === 2) {
 				text += '<strong><em style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</em></strong>';
-			} else if (details.group === 1) {
+			} else if (details.type === 1) {
 				text += '<strong style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</strong>';
 			} else {
 				text += '<span style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</span>';
@@ -1654,8 +1654,8 @@
 		},
 		comparator: function (a, b) {
 			if (a === b) return 0;
-			var aRank = (window.GroupDetails[this.room.users[a] ? this.room.users[a].substr(0, 1) : app.defaultGroup || ' '] || {order: 6}).order;
-			var bRank = (window.GroupDetails[this.room.users[b] ? this.room.users[b].substr(0, 1) : app.defaultGroup || ' '] || {order: 6}).order;
+			var aRank = (Config.groups[this.room.users[a] ? this.room.users[a].substr(0, 1) : Config.defaultGroup || ' '] || {order: 6}).order;
+			var bRank = (Config.groups[this.room.users[b] ? this.room.users[b].substr(0, 1) : Config.defaultGroup || ' '] || {order: 6}).order;
 			if (aRank !== bRank) return aRank - bRank;
 			return (a > b ? 1 : -1);
 		},

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -369,7 +369,7 @@
 			var cmd = '';
 			var target = '';
 			var noSpace = false;
-			if (text.substr(0, 2) !== '//' && text.substr(0, 1) === '/') {
+			if (text.substr(0, 2) !== '//' && text.charAt(0) === '/') {
 				var spaceIndex = text.indexOf(' ');
 				if (spaceIndex > 0) {
 					cmd = text.substr(1, spaceIndex - 1);
@@ -1155,7 +1155,7 @@
 		addRow: function (line) {
 			var name, name2, room, action, silent, oldid;
 			if (line && typeof line === 'string') {
-				if (line.substr(0, 1) !== '|') line = '||' + line;
+				if (line.charAt(0) !== '|') line = '||' + line;
 				var row = line.substr(1).split('|');
 				switch (row[0]) {
 				case 'init':
@@ -1654,8 +1654,15 @@
 		},
 		comparator: function (a, b) {
 			if (a === b) return 0;
-			var aRank = (Config.groups[this.room.users[a] ? this.room.users[a].substr(0, 1) : Config.defaultGroup || ' '] || {order: (Config.defaultOrder || 6)}).order;
-			var bRank = (Config.groups[this.room.users[b] ? this.room.users[b].substr(0, 1) : Config.defaultGroup || ' '] || {order: (Config.defaultOrder || 6)}).order;
+			var aRank = (
+				Config.groups[(this.room.users[a] ? this.room.users[a].charAt(0) : Config.defaultGroup || ' ')] ||
+				{order: (Config.defaultOrder || 5.5)}
+			).order;
+			var bRank = (
+				Config.groups[(this.room.users[b] ? this.room.users[b].charAt(0) : Config.defaultGroup || ' ')] ||
+				{order: (Config.defaultOrder || 5.5)}
+			).order;
+
 			if (aRank !== bRank) return aRank - bRank;
 			return (a > b ? 1 : -1);
 		},

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1570,36 +1570,6 @@
 			}
 			this.$el.html(buf);
 		},
-		ranks: {
-			'~': 2,
-			'#': 2,
-			'&': 2,
-			'@': 1,
-			'%': 1,
-			'*': 1,
-			'\u2606': 1,
-			'\u2605': 1,
-			'+': 1,
-			' ': 0,
-			'!': 0,
-			'✖': 0,
-			'‽': 0
-		},
-		rankOrder: {
-			'~': 1,
-			'#': 2,
-			'&': 3,
-			'@': 4,
-			'%': 5,
-			'*': 6,
-			'\u2606': 7,
-			'\u2605': 8,
-			'+': 9,
-			' ': 10,
-			'!': 11,
-			'✖': 12,
-			'‽': 13
-		},
 		toggleUserlist: function (e) {
 			e.preventDefault();
 			e.stopPropagation();
@@ -1654,10 +1624,11 @@
 			text += '<li' + (this.room.userForm === userid ? ' class="cur"' : '') + ' id="' + this.room.id + '-userlist-user-' + Tools.escapeHTML(userid) + '">';
 			text += '<button class="userbutton username" data-name="' + Tools.escapeHTML(name) + '">';
 			var group = name.charAt(0);
-			text += '<em class="group' + (this.ranks[group] === 2 ? ' staffgroup' : '') + '">' + Tools.escapeHTML(group) + '</em>';
-			if (group === '~' || group === '&' || group === '#') {
+			var details = GroupDetails[group] || {rank: 0};
+			text += '<em class="group' + (details.group === 2 ? ' staffgroup' : '') + '">' + Tools.escapeHTML(group) + '</em>';
+			if (details.group === 2) {
 				text += '<strong><em style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</em></strong>';
-			} else if (group === '%' || group === '@') {
+			} else if (details.group === 1) {
 				text += '<strong style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</strong>';
 			} else {
 				text += '<span style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</span>';
@@ -1683,8 +1654,8 @@
 		},
 		comparator: function (a, b) {
 			if (a === b) return 0;
-			var aRank = (this.rankOrder[this.room.users[a] ? this.room.users[a].substr(0, 1) : ' '] || 6);
-			var bRank = (this.rankOrder[this.room.users[b] ? this.room.users[b].substr(0, 1) : ' '] || 6);
+			var aRank = (GroupDetails[this.room.users[a] ? this.room.users[a].substr(0, 1) : app.defaultGroup || ' '] || {order: 6}).order;
+			var bRank = (GroupDetails[this.room.users[b] ? this.room.users[b].substr(0, 1) : app.defaultGroup || ' '] || {order: 6}).order;
 			if (aRank !== bRank) return aRank - bRank;
 			return (a > b ? 1 : -1);
 		},

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1624,11 +1624,11 @@
 			text += '<li' + (this.room.userForm === userid ? ' class="cur"' : '') + ' id="' + this.room.id + '-userlist-user-' + Tools.escapeHTML(userid) + '">';
 			text += '<button class="userbutton username" data-name="' + Tools.escapeHTML(name) + '">';
 			var group = name.charAt(0);
-			var details = Config.groups[group] || {type: 0};
+			var details = Config.groups[group] || {type: 'user'};
 			text += '<em class="group' + (details.group === 2 ? ' staffgroup' : '') + '">' + Tools.escapeHTML(group) + '</em>';
-			if (details.type === 2) {
+			if (details.type === 'leadership') {
 				text += '<strong><em style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</em></strong>';
-			} else if (details.type === 1) {
+			} else if (details.type === 'staff') {
 				text += '<strong style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</strong>';
 			} else {
 				text += '<span style="' + hashColor(userid) + '">' + Tools.escapeHTML(name.substr(1)) + '</span>';
@@ -1654,8 +1654,8 @@
 		},
 		comparator: function (a, b) {
 			if (a === b) return 0;
-			var aRank = (Config.groups[this.room.users[a] ? this.room.users[a].substr(0, 1) : Config.defaultGroup || ' '] || {order: 6}).order;
-			var bRank = (Config.groups[this.room.users[b] ? this.room.users[b].substr(0, 1) : Config.defaultGroup || ' '] || {order: 6}).order;
+			var aRank = (Config.groups[this.room.users[a] ? this.room.users[a].substr(0, 1) : Config.defaultGroup || ' '] || {order: (Config.defaultOrder || 6)}).order;
+			var bRank = (Config.groups[this.room.users[b] ? this.room.users[b].substr(0, 1) : Config.defaultGroup || ' '] || {order: (Config.defaultOrder || 6)}).order;
 			if (aRank !== bRank) return aRank - bRank;
 			return (a > b ? 1 : -1);
 		},

--- a/js/client.js
+++ b/js/client.js
@@ -2291,17 +2291,17 @@
 		'!': {
 			name: "<span style='color:#777777'>Muted (!)</span>",
 			type: 0,
-			order: 11,
+			order: 10001,
 		},
 		'✖': {
 			name: "<span style='color:#777777'>Namelocked (✖)</span>",
 			type: 0,
-			order: 12,
+			order: 10002,
 		},
 		'‽': {
 			name: "<span style='color:#777777'>Locked (‽)</span>",
 			type: 0,
-			order: 13,
+			order: 10003,
 		}
 	};
 

--- a/js/client.js
+++ b/js/client.js
@@ -1034,15 +1034,15 @@
 				// use slice instead of simple [0], [1], [2] in case someone finds it fun to put a comma in the name of the rank.
 				var symbol = entry[0];
 				var groupName = entry.slice(1, entry.length - 1).join(",").trim();
-				var groupRank = parseInt(entry[entry.length - 1], 10) || 0;
+				var groupType = parseInt(entry[entry.length - 1], 10) || 0;
 
 				if (!groupName) this.defaultGroup = symbol;
 
-				authTiers[groupRank].push({
+				authTiers[groupType].push({
 					symbol: symbol,
 					data: {
 						name: groupName ? Tools.escapeHTML(groupName + ' (' + symbol + ')') : null,
-						group: groupRank,
+						type: groupType,
 					},
 				});
 			}
@@ -1053,34 +1053,34 @@
 					symbol: '!',
 					data: {
 						name: "<span style='color:#777777'>Muted (!)</span>",
-						group: 0,
+						type: 0,
 					},
 				},
 				{
 					symbol: '✖',
 					data: {
 						name: "<span style='color:#777777'>Namelocked (✖)</span>",
-						group: 0,
+						type: 0,
 					},
 				},
 				{
 					symbol: '‽',
 					data: {
 						name: "<span style='color:#777777'>Locked (‽)</span>",
-						group: 0,
+						type: 0,
 					},
 				}
 			]);
 
 			// now determine the order for sorting of the auth
-			window.GroupDetails = GroupDetails = {};
+			Config.groups = {};
 			var index = 0;
 			for (var t = 2; t >= 0; t--) {
 				var tier = authTiers[t];
 				for (var g = 0; g < tier.length; g++) {
 					var tarGroup = tier[g];
-					GroupDetails[tarGroup.symbol] = tarGroup.data;
-					GroupDetails[tarGroup.symbol].order = ++index;
+					Config.groups[tarGroup.symbol] = tarGroup.data;
+					Config.groups[tarGroup.symbol].order = ++index;
 				}
 			}
 		},
@@ -2272,69 +2272,69 @@
 		}
 	});
 
-	var GroupDetails = window.GroupDetails = window.GroupDetails || {
+	Config.groups = Config.groups || {
 		'~': {
 			name: "Administrator (~)",
-			group: 2,
+			type: 2,
 			order: 1,
 		},
 		'#': {
 			name: "Room Owner (#)",
-			group: 2,
+			type: 2,
 			order: 2,
 		},
 		'&': {
 			name: "Leader (&amp;)",
-			group: 2,
+			type: 2,
 			order: 3,
 		},
 		'@': {
 			name: "Moderator (@)",
-			group: 1,
+			type: 1,
 			order: 4,
 		},
 		'%': {
 			name: "Driver (%)",
-			group: 1,
+			type: 1,
 			order: 5,
 		},
 		'*': {
 			name: "Bot (*)",
-			group: 0,
+			type: 0,
 			order: 6,
 		},
 		'\u2606': {
 			name: "Player (\u2606)",
-			group: 0,
+			type: 0,
 			order: 7,
 		},
 		'\u2605': {
 			name: "Player (\u2605)",
-			group: 0,
+			type: 0,
 			order: 8,
 		},
 		'+': {
 			name: "Voice (+)",
-			group: 0,
+			type: 0,
 			order: 9,
 		},
 		' ': {
-			group: 0,
+			type: 0,
 			order: 10,
 		},
 		'!': {
 			name: "<span style='color:#777777'>Muted (!)</span>",
-			group: 0,
+			type: 0,
 			order: 11,
 		},
 		'✖': {
 			name: "<span style='color:#777777'>Namelocked (✖)</span>",
-			group: 0,
+			type: 0,
 			order: 12,
 		},
 		'‽': {
 			name: "<span style='color:#777777'>Locked (‽)</span>",
-			group: 0,
+			type: 0,
 			order: 13,
 		}
 	};
@@ -2364,8 +2364,8 @@
 			var userid = data.userid;
 			var name = data.name;
 			var avatar = data.avatar || '';
-			var group = ((GroupDetails[name.substr(0, 1)] || {}).name || '');
-			var globalgroup = ((GroupDetails[(data.group || app.defaultGroup || ' ')] || {}).name || '');
+			var group = ((Config.groups[name.substr(0, 1)] || {}).name || '');
+			var globalgroup = ((Config.groups[(data.group || Config.defaultGroup || ' ')] || {}).name || '');
 			if (globalgroup) {
 				if (!group || group === globalgroup) {
 					group = "Global " + globalgroup;

--- a/js/client.js
+++ b/js/client.js
@@ -869,13 +869,13 @@
 			}
 
 			switch (parts[0]) {
-			case 'groups':
+			case 'customgroups':
 				var nlIndex = data.indexOf('\n');
 				if (nlIndex > 0) {
 					this.receive(data.substr(nlIndex + 1));
 				}
 
-				var tarRow = data.slice(8, nlIndex);
+				var tarRow = data.slice(14, nlIndex);
 				this.parseGroups(tarRow);
 				break;
 

--- a/js/client.js
+++ b/js/client.js
@@ -768,7 +768,7 @@
 		receive: function (data) {
 			var roomid = '';
 			var autojoined = false;
-			if (data.substr(0, 1) === '>') {
+			if (data.charAt(0) === '>') {
 				var nlIndex = data.indexOf('\n');
 				if (nlIndex < 0) return;
 				roomid = toRoomid(data.substr(1, nlIndex - 1));
@@ -1028,7 +1028,7 @@
 			} catch (e) {}
 			if (!data) return; // broken JSON - keep default ranks
 
-			Config.groups = {};
+			var groups = {};
 			// process the data and sort into the three auth tiers, 0, 1, and 2
 			for (var i = 0; i < data.length; i++) {
 				var entry = data[i];
@@ -1038,15 +1038,17 @@
 				var groupName = entry.name;
 				var groupType = entry.type || 'user';
 
-				if (groupType === 'user' && !Config.defaultOrder) Config.defaultOrder = i; // this is where any undeclared groups will be positioned in userlist
+				if (groupType === 'user' && !Config.defaultOrder) Config.defaultOrder = i + 0.5; // this is where any undeclared groups will be positioned in userlist
 				if (!groupName) Config.defaultGroup = symbol;
 
-				Config.groups[symbol] = {
+				groups[symbol] = {
 					name: groupName ? Tools.escapeHTML(groupName + ' (' + symbol + ')') : null,
 					type: groupType,
 					order: i + 1,
 				};
 			}
+
+			Config.groups = groups; // if nothing from above crashes (malicious json), then the client will use the new custom groups
 		},
 		parseFormats: function (formatsList) {
 			var isSection = false;
@@ -2328,7 +2330,7 @@
 			var userid = data.userid;
 			var name = data.name;
 			var avatar = data.avatar || '';
-			var group = ((Config.groups[name.substr(0, 1)] || {}).name || '');
+			var group = ((Config.groups[name.charAt(0)] || {}).name || '');
 			var globalgroup = ((Config.groups[(data.group || Config.defaultGroup || ' ')] || {}).name || '');
 			if (globalgroup) {
 				if (!group || group === globalgroup) {

--- a/js/client.js
+++ b/js/client.js
@@ -1,5 +1,4 @@
 (function ($) {
-	let timer = 0;
 
 	Config.sockjsprefix = '/showdown';
 	Config.root = '/';

--- a/js/client.js
+++ b/js/client.js
@@ -869,6 +869,24 @@
 			}
 
 			switch (parts[0]) {
+			case 'authconfig':
+				var nlIndex = data.indexOf('\n');
+				if (nlIndex > 0) {
+					this.receive(data.substr(nlIndex + 1));
+				}
+
+				var tarRow = data.slice(12, nlIndex).split(/(?:\b|\B)\|(?:\B)/);
+				for (var i = 0; i < tarRow.length; i++) {
+					var entry = tarRow[i];
+					if (!entry) continue;
+
+					var symbol = entry.charAt(0);
+					var rank = entry.slice(1);
+
+					groupDetails[symbol] = rank + ' (' + symbol + ')'; // override the default symbol.
+				}
+				break;
+
 			case 'challstr':
 				if (parts[2]) {
 					this.user.receiveChallstr(parts[1] + '|' + parts[2]);
@@ -2199,6 +2217,21 @@
 		}
 	});
 
+	var groupDetails = this.groupDetails = {
+		'#': "Room Owner (#)",
+		'~': "Administrator (~)",
+		'&': "Leader (&amp;)",
+		'@': "Moderator (@)",
+		'%': "Driver (%)",
+		'*': "Bot (*)",
+		'\u2606': "Player (\u2606)",
+		'\u2605': "Player (\u2605)",
+		'+': "Voice (+)",
+		'‽': "<span style='color:#777777'>Locked (‽)</span>",
+		'✖': "<span style='color:#777777'>Namelocked (✖)</span>",
+		'!': "<span style='color:#777777'>Muted (!)</span>"
+	};
+
 	var UserPopup = this.UserPopup = Popup.extend({
 		initialize: function (data) {
 			data.userid = toId(data.name);
@@ -2224,20 +2257,6 @@
 			var userid = data.userid;
 			var name = data.name;
 			var avatar = data.avatar || '';
-			var groupDetails = {
-				'#': "Room Owner (#)",
-				'~': "Administrator (~)",
-				'&': "Leader (&amp;)",
-				'@': "Moderator (@)",
-				'%': "Driver (%)",
-				'*': "Bot (*)",
-				'\u2606': "Player (\u2606)",
-				'\u2605': "Player (\u2605)",
-				'+': "Voice (+)",
-				'‽': "<span style='color:#777777'>Locked (‽)</span>",
-				'✖': "<span style='color:#777777'>Namelocked (✖)</span>",
-				'!': "<span style='color:#777777'>Muted (!)</span>"
-			};
 			var group = (groupDetails[name.substr(0, 1)] || '');
 			var globalgroup = (groupDetails[(data.group || '').charAt(0)] || '');
 			if (globalgroup) {

--- a/js/client.js
+++ b/js/client.js
@@ -2242,66 +2242,66 @@
 		'~': {
 			name: "Administrator (~)",
 			type: 2,
-			order: 1,
+			order: 10001,
 		},
 		'#': {
 			name: "Room Owner (#)",
 			type: 2,
-			order: 2,
+			order: 10002,
 		},
 		'&': {
 			name: "Leader (&amp;)",
 			type: 2,
-			order: 3,
+			order: 10003,
 		},
 		'@': {
 			name: "Moderator (@)",
 			type: 1,
-			order: 4,
+			order: 10004,
 		},
 		'%': {
 			name: "Driver (%)",
 			type: 1,
-			order: 5,
+			order: 10005,
 		},
 		'*': {
 			name: "Bot (*)",
 			type: 0,
-			order: 6,
+			order: 10006,
 		},
 		'\u2606': {
 			name: "Player (\u2606)",
 			type: 0,
-			order: 7,
+			order: 10007,
 		},
 		'\u2605': {
 			name: "Player (\u2605)",
 			type: 0,
-			order: 8,
+			order: 10008,
 		},
 		'+': {
 			name: "Voice (+)",
 			type: 0,
-			order: 9,
+			order: 10009,
 		},
 		' ': {
 			type: 0,
-			order: 10,
+			order: 10010,
 		},
 		'!': {
 			name: "<span style='color:#777777'>Muted (!)</span>",
 			type: 0,
-			order: 10001,
+			order: 10011,
 		},
 		'✖': {
 			name: "<span style='color:#777777'>Namelocked (✖)</span>",
 			type: 0,
-			order: 10002,
+			order: 10012,
 		},
 		'‽': {
 			name: "<span style='color:#777777'>Locked (‽)</span>",
 			type: 0,
-			order: 10003,
+			order: 10013,
 		}
 	};
 

--- a/js/client.js
+++ b/js/client.js
@@ -1021,7 +1021,7 @@
 				break;
 			}
 		},
-		parseGroups: function(groupsList) {
+		parseGroups: function (groupsList) {
 			var tarRow = groupsList.split(/(?:\b|\B)\|(?:\B)/);
 
 			var authTiers = [[], [], []]; // we will be splitting them into three tiers, before compiling them back into the main tree
@@ -1034,7 +1034,7 @@
 				// use slice instead of simple [0], [1], [2] in case someone finds it fun to put a comma in the name of the rank.
 				var symbol = entry[0];
 				var groupName = entry.slice(1, entry.length - 1).join(",").trim();
-				var groupRank = parseInt(entry[entry.length - 1]) || 0;
+				var groupRank = parseInt(entry[entry.length - 1], 10) || 0;
 
 				if (!groupName) this.defaultGroup = symbol;
 

--- a/js/client.js
+++ b/js/client.js
@@ -1022,19 +1022,22 @@
 			}
 		},
 		parseGroups: function (groupsList) {
-			var tarRow = groupsList.split(/(?:\b|\B)\|(?:\B)/);
+			var data = null;
+			try {
+				data = JSON.parse(groupsList);
+			} catch (e) {}
+			if (!data) return; // broken JSON - keep default ranks
 
 			var authTiers = [[], [], []]; // we will be splitting them into three tiers, before compiling them back into the main tree
 
 			// process the data and sort into the three auth tiers, 0, 1, and 2
-			for (var i = 0; i < tarRow.length; i++) {
-				var entry = tarRow[i].split(/(?:\b|\B)(?!\,{2,})\,/);
-				if (!entry || entry.length < 3) continue;
+			for (var i = 0; i < data.length; i++) {
+				var entry = data[i];
+				if (!entry) continue;
 
-				// use slice instead of simple [0], [1], [2] in case someone finds it fun to put a comma in the name of the rank.
-				var symbol = entry[0];
-				var groupName = entry.slice(1, entry.length - 1).join(",").trim();
-				var groupType = parseInt(entry[entry.length - 1], 10) || 0;
+				var symbol = entry.symbol || ' ';
+				var groupName = entry.name;
+				var groupType = entry.type || 0;
 
 				if (!groupName) this.defaultGroup = symbol;
 

--- a/js/client.js
+++ b/js/client.js
@@ -1028,8 +1028,7 @@
 			} catch (e) {}
 			if (!data) return; // broken JSON - keep default ranks
 
-			var authTiers = [[], [], []]; // we will be splitting them into three tiers, before compiling them back into the main tree
-
+			Config.groups = {};
 			// process the data and sort into the three auth tiers, 0, 1, and 2
 			for (var i = 0; i < data.length; i++) {
 				var entry = data[i];
@@ -1037,54 +1036,16 @@
 
 				var symbol = entry.symbol || ' ';
 				var groupName = entry.name;
-				var groupType = entry.type || 0;
+				var groupType = entry.type || 'user';
 
-				if (!groupName) this.defaultGroup = symbol;
+				if (groupType === 'user' && !Config.defaultOrder) Config.defaultOrder = i; // this is where any undeclared groups will be positioned in userlist
+				if (!groupName) Config.defaultGroup = symbol;
 
-				authTiers[groupType].push({
-					symbol: symbol,
-					data: {
-						name: groupName ? Tools.escapeHTML(groupName + ' (' + symbol + ')') : null,
-						type: groupType,
-					},
-				});
-			}
-
-			// add the 3 last groups: muted, namelocked and locked
-			authTiers[0] = authTiers[0].concat([
-				{
-					symbol: '!',
-					data: {
-						name: "<span style='color:#777777'>Muted (!)</span>",
-						type: 0,
-					},
-				},
-				{
-					symbol: '✖',
-					data: {
-						name: "<span style='color:#777777'>Namelocked (✖)</span>",
-						type: 0,
-					},
-				},
-				{
-					symbol: '‽',
-					data: {
-						name: "<span style='color:#777777'>Locked (‽)</span>",
-						type: 0,
-					},
-				}
-			]);
-
-			// now determine the order for sorting of the auth
-			Config.groups = {};
-			var index = 0;
-			for (var t = 2; t >= 0; t--) {
-				var tier = authTiers[t];
-				for (var g = 0; g < tier.length; g++) {
-					var tarGroup = tier[g];
-					Config.groups[tarGroup.symbol] = tarGroup.data;
-					Config.groups[tarGroup.symbol].order = ++index;
-				}
+				Config.groups[symbol] = {
+					name: groupName ? Tools.escapeHTML(groupName + ' (' + symbol + ')') : null,
+					type: groupType,
+					order: i + 1,
+				};
 			}
 		},
 		parseFormats: function (formatsList) {


### PR DESCRIPTION
- add a new ``|authconfig|`` message which will merge the new data with the default groups provided in ``groupDetails``
In tandem with https://github.com/Zarel/Pokemon-Showdown/pull/3529