### PR TITLE
Fix reference from tools.js to sim/dex.js which exports Tools

### DIFF
--- a/githooks/build-indexes
+++ b/githooks/build-indexes
@@ -14,7 +14,7 @@ child_process.execSync('git pull', {
 });
 console.log("DONE");
 
-const Tools = require('../data/Pokemon-Showdown/tools');
+const Tools = require('../data/Pokemon-Showdown/sim/dex');
 const toId = Tools.getId;
 process.stdout.write("Loading gen 6 data... ");
 Tools.includeData();

--- a/githooks/build-minidex
+++ b/githooks/build-minidex
@@ -5,7 +5,7 @@ const fs = require("fs");
 process.chdir(__dirname);
 const imageSize = require('image-size');
 
-const Tools = require('./../data/Pokemon-Showdown/tools').includeData();
+const Tools = require('./../data/Pokemon-Showdown/sim/dex').includeData();
 const toId = Tools.getId;
 
 let buf = `/*

--- a/githooks/update
+++ b/githooks/update
@@ -20,7 +20,7 @@ const thisFile = __filename;
 const thisDir = __dirname;
 const rootDir = path.resolve(thisDir, '..');
 
-const Tools = require('../data/Pokemon-Showdown/tools').includeData();
+const Tools = require('../data/Pokemon-Showdown/sim/dex').includeData();
 const toId = Tools.getId;
 
 // update version


### PR DESCRIPTION
tools.js doesn't exist after a fresh clone of Pokemon-Showdown from GitHub, but Pokemon-Showdown's sim/dex.js does and exports the Tools that the Pokemon-Showdown-Client githooks scripts are looking for.