### PR TITLE
Fix crash in team selection for tournaments

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -989,6 +989,7 @@
 
 			this.team = data.team;
 			this.format = data.format;
+			this.room = data.room;
 
 			var format = BattleFormats[data.format];
 
@@ -1046,8 +1047,9 @@
 			var sourceEl = this.sourceEl;
 			var team = this.team;
 			var format = this.format;
+			var room = this.room;
 			this.close();
-			app.addPopup(TeamPopup, {team: team, format: format, sourceEl: sourceEl, moreTeams: true});
+			app.addPopup(TeamPopup, {team: team, format: format, sourceEl: sourceEl, room: room, moreTeams: true});
 		},
 		teambuilder: function () {
 			var teamFormat = this.teamFormat;
@@ -1066,8 +1068,7 @@
 				app.rooms[''].curTeamIndex = i;
 				app.rooms[''].curTeamFormat = formatid;
 			} else if (this.sourceEl[0].offsetParent.className === 'tournament-box active') {
-				var room = app.dispatchingPopup.options.room;
-				app.rooms[room].tournamentBox.curTeamIndex = i;
+				app.rooms[this.room].tournamentBox.curTeamIndex = i;
 			}
 			this.close();
 		}


### PR DESCRIPTION
Fixes this crash:
```
Uncaught TypeError: Cannot read property 'room' of undefined
    at child.selectTeam (client-mainmenu.js?097feaf9:1069)
    at child.dispatchClickButton (client.js?a487c6d5:2147)
    at HTMLButtonElement.wrapper (lodash.core.js?66b6d754:1157)
    at HTMLDivElement.dispatch (jquery-2.1.4.min.js:3)
    at HTMLDivElement.r.handle (jquery-2.1.4.min.js:3)
```
Side note: did someone refactor out the `options` from `dispatchingPopup` at some point? This clearly worked before but doesn't anymore.