### PR TITLE
Track moves from Transform more accurately

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -508,7 +508,10 @@ var Pokemon = (function () {
 		if (pp === undefined) pp = 1;
 		moveName = Tools.getMove(moveName).name;
 		if (moveName === 'Struggle') return;
-		if (this.volatiles.transform) moveName = '*' + moveName;
+		if (this.volatiles.transform) {
+			this.volatiles.transform[2].markMove(moveName, 0);
+			moveName = '*' + moveName;
+		}
 		for (var i = 0; i < this.moveTrack.length; i++) {
 			if (moveName === this.moveTrack[i][0]) {
 				this.moveTrack[i][1] += pp;
@@ -4684,6 +4687,10 @@ var Battle = (function () {
 				poke.copyTypesFrom(tpoke);
 				poke.ability = tpoke.ability;
 				poke.volatiles.formechange[2] = (tpoke.volatiles.formechange ? tpoke.volatiles.formechange[2] : tpoke.species);
+				poke.volatiles.transform[2] = tpoke;
+				for (var i = 0; i < tpoke.moveTrack.length; i++) {
+					poke.moveTrack.push(['*' + tpoke.moveTrack[i][0], 0]);
+				}
 				this.resultAnim(poke, 'Transformed', 'good');
 				break;
 			case '-formechange':

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -772,8 +772,7 @@ var BattleTooltips = (function () {
 		var ppUsed = moveTrackRow[1];
 		var move, maxpp;
 		if (moveName.charAt(0) === '*') {
-			moveName = moveName.substr(1);
-			move = Tools.getMove(moveName);
+			move = Tools.getMove(moveName.substr(1));
 			maxpp = 5;
 		} else {
 			move = Tools.getMove(moveName);
@@ -785,8 +784,8 @@ var BattleTooltips = (function () {
 			maxpp = Math.floor(maxpp * 8 / 5);
 		}
 		if (ppUsed === Infinity) return move.name + ' <small>(0/' + maxpp + ')</small>';
-		if (!ppUsed) return move.name + (showKnown ? ' <small>(revealed)</small>' : '');
-		return move.name + ' <small>(' + (maxpp - ppUsed) + '/' + maxpp + ')</small>';
+		if (ppUsed || moveName.charAt(0) === '*') return move.name + ' <small>(' + (maxpp - ppUsed) + '/' + maxpp + ')</small>';
+		return move.name + (showKnown ? ' <small>(revealed)</small>' : '');
 	};
 
 	// Functions to calculate speed ranges of an opponent.


### PR DESCRIPTION
- After Transform/Imposter, automatically add any known moves from the target with 5/5 PP
- When a Transformed Pokémon uses a move, note that the target also knows it

This is mostly useful for spectators of Balanced Hackmons battle I guess...