### PR TITLE
Tooltips: don't report Toxic Boost as Atk boost

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -633,9 +633,6 @@ var BattleTooltips = (function () {
 		if (item === 'choiceband') {
 			stats.atk = Math.floor(stats.atk * 1.5);
 		}
-		if (ability === 'toxicboost' && (pokemon.status === 'tox' || pokemon.status === 'psn')) {
-			stats.atk = Math.floor(stats.atk * 1.5);
-		}
 		if (ability === 'purepower' || ability === 'hugepower') {
 			stats.atk *= 2;
 		}


### PR DESCRIPTION
It boosts move base power, not atk, plus the bp boost is already being displayed separately as well so this was redundant anyway.