### PR TITLE
Refactor custom icons to a single element <psicon> and use Caja

### DIFF
--- a/style/battle.css
+++ b/style/battle.css
@@ -680,12 +680,12 @@ License: GPLv2
 }
 
 .itemicon {
-	display: block;
+	display: inline-block;
 	width: 24px;
 	height: 24px;
 }
 .picon {
-	display: block;
+	display: inline-block;
 	width: 40px;
 	height: 30px;
 }

--- a/style/client.css
+++ b/style/client.css
@@ -2456,6 +2456,9 @@ a.ilink.yours {
 	opacity: .5;
 	cursor: default;
 }
+.teambar .picon {
+	display: block;
+}
 .teamchart,
 .teamchart li {
 	list-style-type: none;


### PR DESCRIPTION
Since real custom elements still have very limited availability, this is the most proper way to do it,
and results in a more predictable HTML parsing.
Adds support for custom styles and classes.

Example:
``<psicon pokemon="meloetta" class="pixelated" style="opacity:0.4" />``


Alternative to #944 