### PR TITLE
Custom CSS: Increase max execution time

### DIFF
--- a/customcss.php
+++ b/customcss.php
@@ -1,5 +1,7 @@
 <?php
 
+ini_set('max_execution_time', 600); //600 seconds = 10 minutes
+
 include '../pokemonshowdown.com/config/servers.inc.php';
 
 spl_autoload_register(function ($class) {


### PR DESCRIPTION
The sanitizer isn't able to execute within php's default max execution time for a css file that is a little bigger.
http://php.net/manual/en/function.ini-set.php