### PR TITLE
Support custom colors

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -70,6 +70,7 @@ var colorCache = {};
 
 function hashColor(name) {
 	if (colorCache[name]) return colorCache[name];
+	if (Config.serverCustomColors && Config.serverCustomColors[name]) return Config.serverCustomColors[name];
 	var hash;
 	if (window.Config && Config.customcolors && Config.customcolors[name]) {
 		if (Config.customcolors[name].color) {

--- a/js/client.js
+++ b/js/client.js
@@ -1069,13 +1069,13 @@
 
 			var colors = {};
 
-			for (let user in data) {
+			for (var user in data) {
 				var entry = data[user];
 				if (!entry) continue;
 
 				if (isNaN(entry[0]) || isNaN(entry[1]) || isNaN(entry[2])) continue; // should receive an array of 3 numbers
 
-				colors[user] = 'color:hsl(' + Math.round(entry[0]) + ',' + parseInt(entry[1]) + '%,' + parseInt(entry[2]) + '%);';
+				colors[user] = 'color:hsl(' + Math.round(entry[0]) + ',' + parseInt(entry[1], 10) + '%,' + parseInt(entry[2], 10) + '%);';
 			}
 
 			Config.serverCustomColors = colors;

--- a/js/client.js
+++ b/js/client.js
@@ -879,6 +879,16 @@
 				this.parseGroups(tarRow);
 				break;
 
+			case 'customcolors':
+				var nlIndex = data.indexOf('\n');
+				if (nlIndex > 0) {
+					this.receive(data.substr(nlIndex + 1));
+				}
+
+				var tarRow = data.slice(14, nlIndex);
+				this.parseColors(tarRow);
+				break;
+
 			case 'challstr':
 				if (parts[2]) {
 					this.user.receiveChallstr(parts[1] + '|' + parts[2]);
@@ -1049,6 +1059,15 @@
 			}
 
 			Config.groups = groups; // if nothing from above crashes (malicious json), then the client will use the new custom groups
+		},
+		parseColors: function (colorList) {
+			var data = null;
+			try {
+				data = JSON.parse(colorList);
+			} catch (e) {}
+			if (!data) return;
+
+			Config.serverCustomColors = data;
 		},
 		parseFormats: function (formatsList) {
 			var isSection = false;

--- a/js/client.js
+++ b/js/client.js
@@ -1067,7 +1067,18 @@
 			} catch (e) {}
 			if (!data) return;
 
-			Config.serverCustomColors = data;
+			var colors = {};
+
+			for (let user in data) {
+				var entry = data[user];
+				if (!entry) continue;
+
+				if (isNaN(entry[0]) || isNaN(entry[1]) || isNaN(entry[2])) continue; // should receive an array of 3 numbers
+
+				colors[user] = 'color:hsl(' + Math.round(entry[0]) + ',' + parseInt(entry[1]) + '%,' + parseInt(entry[2]) + '%);';
+			}
+
+			Config.serverCustomColors = colors;
 		},
 		parseFormats: function (formatsList) {
 			var isSection = false;


### PR DESCRIPTION
Allows side servers to send a dictionary of userids and a color value. Right now we have to handle custom colors through css, which isn't a pretty solution. This would also improve the speed of the css sanitizer!
_Nii Sama_