### PR TITLE
Fix teambuilder showing current gen base stats for gen 6 teams

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -1754,7 +1754,7 @@
 		getBaseStats: function (template) {
 			var baseStats = template.baseStats;
 			var gen = this.curTeam.gen;
-			if (gen < 6) {
+			if (gen < 7) {
 				var overrideStats = BattleTeambuilderTable['gen' + gen].overrideStats[template.id];
 				if (overrideStats || gen === 1) {
 					baseStats = {


### PR DESCRIPTION
Would it be a good idea to have some global "current gen" constant so we don't have to hunt down all the outdated gen numbers every time a new one comes out? Where would it go? battledata.js?