### PR TITLE
Display correct type of transformed Pokemon in old gens

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -689,7 +689,11 @@ var Pokemon = (function () {
 			var template = Tools.getTemplate(pokemon.volatiles.formechange[2]);
 			this.volatiles.typechange[2] = template.types ? template.types.join('/') : '';
 		} else {
-			this.volatiles.typechange[2] = pokemon.types ? pokemon.types.join('/') : '';
+			this.volatiles.typechange[2] = (
+				window.BattleTeambuilderTable &&
+				window.BattleTeambuilderTable['gen' + this.side.battle.gen] &&
+				window.BattleTeambuilderTable['gen' + this.side.battle.gen].overrideType[toId(pokemon.species)]
+			) || (pokemon.types ? pokemon.types.join('/') : '');
 		}
 		if (pokemon.volatiles.typeadd) {
 			this.addVolatile('typeadd');


### PR DESCRIPTION
This makes for instance Ditto transformed into Clefairy appear as Normal type instead of Fairy type. The battle with a bug can be seen on http://replay.pokemonshowdown.com/gen1ou-593692946

Pretty sure there is a cleaner way of doing this, I'm not really used to contributing to client, feel free to point out improvements.

BattleTeambuilderTable is checked before use because there is no requirement it's loaded (it's not loaded in replays for instance). The old version didn't work in replays either, so it's probably not a big deal?