### PR TITLE
Parse HTML time

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -858,7 +858,7 @@ var Tools = {
 
 				var formattedTime;
 				// Try using Intl API if it exists
-				if (window.Intl) {
+				if (window.Intl && window.Intl.DateTimeFormat) {
 					formattedTime = new Intl.DateTimeFormat(undefined, {month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric'}).format(parsedTime);
 				} else {
 					// toLocaleString even exists in ECMAScript 1, so no need to check

--- a/js/battledata.js
+++ b/js/battledata.js
@@ -706,7 +706,7 @@ var Tools = {
 		return str;
 	},
 
-	sanitizeHTML: (function () {
+	sanitizeHTMLReturningTree: (function () {
 		if (!('html4' in window)) {
 			return function () {
 				throw new Error('sanitizeHTML requires caja');
@@ -826,10 +826,65 @@ var Tools = {
 			}
 			return {tagName: tagName, attribs: attribs};
 		};
+		var localizeTimes = function (tree) {
+			var times = tree.getElementsByTagName('time');
+			for (var i = 0; i < times.length; i++) {
+				var timeElement = times[i];
+				var time = timeElement.textContent;
+
+				// Require ISO 8601 time. While more time formats are supported by
+				// most JavaScript implementations, it isn't required, and how to
+				// exactly enforce ignoring user agent timezone setting is not obvious.
+				// As dates come from the server which isn't aware of client timezone,
+				// a particular timezone is required.
+				//
+				// This regular expression is split into three groups.
+				//
+				// Group 1 - date
+				// Group 2 - time (seconds and milliseconds are optional)
+				// Group 3 - optional timezone
+				//
+				// Group 1 and group 2 are split to allow using space as a separator
+				// instead of T. Stricly speaking ECMAScript 5 specification only
+				// allows T, however it's more practical to also allow spaces.
+				var parts = /^\s*([+-]?\d{4,}-\d{2}-\d{2})[T ](\d{2}:\d{2}(?::\d{2}(?:\.\d{3})?)?)(Z|[+-]\d{2}:\d{2})?\s*$/i.exec(time);
+				if (!parts) continue;
+
+				var parsedTime = new Date(parts[1] + 'T' + parts[2] + (parts[3] || 'Z').toUpperCase());
+				// Very old (pre-ES5) web browsers may be incapable of parsing ISO 8601
+				// dates. In such a case, gracefully continue without replacing the date
+				// format.
+				if (!parsedTime.getTime()) continue;
+
+				var formattedTime;
+				// Try using Intl API if it exists
+				if (window.Intl) {
+					formattedTime = new Intl.DateTimeFormat(undefined, {month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric'}).format(parsedTime);
+				} else {
+					// toLocaleString even exists in ECMAScript 1, so no need to check
+					// if it exists.
+					formattedTime = parsedTime.toLocaleString();
+				}
+				timeElement.textContent = formattedTime;
+			}
+		};
 		return function (input) {
-			return html.sanitizeWithPolicy(getString(input), tagPolicy);
+			var sanitized = html.sanitizeWithPolicy(getString(input), tagPolicy);
+			// Unfortunately Caja doesn't support modifying tags in case of <time> tag,
+			// so Caja's output is converted into DOM just to modify it. Element name
+			// <div> is arbitrary, however it doesn't have an effect by itself which
+			// is why it was picked, and it's needed to have some container to use
+			// innerHTML assignment on.
+			var tree = document.createElement('div');
+			tree.innerHTML = sanitized;
+			localizeTimes(tree);
+			return tree;
 		};
 	})(),
+
+	sanitizeHTML: function (input) {
+		return Tools.sanitizeHTMLReturningTree(input).innerHTML;
+	},
 
 	interstice: (function () {
 		var patterns = (function (whitelist) {

--- a/js/battledata.js
+++ b/js/battledata.js
@@ -706,7 +706,7 @@ var Tools = {
 		return str;
 	},
 
-	sanitizeHTMLReturningTree: (function () {
+	htmlToSafeDOM: (function () {
 		if (!('html4' in window)) {
 			return function () {
 				throw new Error('sanitizeHTML requires caja');
@@ -883,7 +883,7 @@ var Tools = {
 	})(),
 
 	sanitizeHTML: function (input) {
-		return Tools.sanitizeHTMLReturningTree(input).innerHTML;
+		return Tools.htmlToSafeDOM(input).innerHTML;
 	},
 
 	interstice: (function () {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1251,9 +1251,7 @@
 
 				case 'raw':
 				case 'html':
-					var sanitized = Tools.htmlToSafeDOM(row.slice(1).join('|'));
-					sanitized.setAttribute('class', 'notice');
-					this.$chat.append(sanitized);
+					this.$chat.append('<div class="notice">' + Tools.sanitizeHTML(row.slice(1).join('|')) + '</div>');
 					break;
 
 				case 'notify':

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1251,7 +1251,9 @@
 
 				case 'raw':
 				case 'html':
-					this.$chat.append('<div class="notice">' + Tools.sanitizeHTML(row.slice(1).join('|')) + '</div>');
+					var sanitized = Tools.htmlToSafeDOM(row.slice(1).join('|'));
+					sanitized.setAttribute('class', 'notice');
+					this.$chat.append(sanitized);
 					break;
 
 				case 'notify':


### PR DESCRIPTION
This is supposed to allow for locale aware implementation of /roomevents. Timezones are confusing, and can be misread causing some people coming for an event in wrong time. This is client-side part of locale aware /roomevents.

`<time>` element is part of HTML5 and is already parsed by Caja. Reusing already existing element doesn't appear to be a practical issue, as it's pretty much meant to do stuff like that.