### PR TITLE
Accessibility improvements to the battle UI

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -2479,7 +2479,7 @@ var Battle = (function () {
 		} else {
 			this.logFrameElem.html('<div class="battle-options"></div>');
 			this.optionsElem = this.logFrameElem.children().last();
-			this.logFrameElem.append('<div class="inner" role="log" aria-label="Battle Log"></div>');
+			this.logFrameElem.append('<div class="inner" role="log"></div>');
 			this.logElem = this.logFrameElem.children().last();
 			this.logFrameElem.append('<div class="inner-preempt"></div>');
 			this.logPreemptElem = this.logFrameElem.children().last();

--- a/js/battle.js
+++ b/js/battle.js
@@ -2479,7 +2479,7 @@ var Battle = (function () {
 		} else {
 			this.logFrameElem.html('<div class="battle-options"></div>');
 			this.optionsElem = this.logFrameElem.children().last();
-			this.logFrameElem.append('<div class="inner"></div>');
+			this.logFrameElem.append('<div class="inner" role="log"></div>');
 			this.logElem = this.logFrameElem.children().last();
 			this.logFrameElem.append('<div class="inner-preempt"></div>');
 			this.logPreemptElem = this.logFrameElem.children().last();

--- a/js/battle.js
+++ b/js/battle.js
@@ -2479,7 +2479,7 @@ var Battle = (function () {
 		} else {
 			this.logFrameElem.html('<div class="battle-options"></div>');
 			this.optionsElem = this.logFrameElem.children().last();
-			this.logFrameElem.append('<div class="inner" role="log"></div>');
+			this.logFrameElem.append('<div class="inner" role="log" title="Battle Log"></div>');
 			this.logElem = this.logFrameElem.children().last();
 			this.logFrameElem.append('<div class="inner-preempt"></div>');
 			this.logPreemptElem = this.logFrameElem.children().last();
@@ -2511,16 +2511,16 @@ var Battle = (function () {
 		this.spriteElem.append('<div></div>');
 		this.spriteElems[0] = this.spriteElem.children().last();
 
-		this.elem.append('<div></div>');
+		this.elem.append('<div role="complementary" title="Active Pokemon"></div>');
 		this.statElem = this.elem.children().last();
 
 		this.elem.append('<div></div>');
 		this.fxElem = this.elem.children().last();
 
-		this.elem.append('<div class="leftbar"></div>');
+		this.elem.append('<div class="leftbar" role="complementary" title="Your Team"></div>');
 		this.leftbarElem = this.elem.children().last();
 
-		this.elem.append('<div class="rightbar"></div>');
+		this.elem.append('<div class="rightbar" role="complementary" title="Opponent\'s Team"></div>');
 		this.rightbarElem = this.elem.children().last();
 
 		this.elem.append('<div></div>');

--- a/js/battle.js
+++ b/js/battle.js
@@ -2479,7 +2479,7 @@ var Battle = (function () {
 		} else {
 			this.logFrameElem.html('<div class="battle-options"></div>');
 			this.optionsElem = this.logFrameElem.children().last();
-			this.logFrameElem.append('<div class="inner" role="log" title="Battle Log"></div>');
+			this.logFrameElem.append('<div class="inner" role="log" aria-label="Battle Log"></div>');
 			this.logElem = this.logFrameElem.children().last();
 			this.logFrameElem.append('<div class="inner-preempt"></div>');
 			this.logPreemptElem = this.logFrameElem.children().last();
@@ -2511,16 +2511,16 @@ var Battle = (function () {
 		this.spriteElem.append('<div></div>');
 		this.spriteElems[0] = this.spriteElem.children().last();
 
-		this.elem.append('<div role="complementary" title="Active Pokemon"></div>');
+		this.elem.append('<div role="complementary" aria-label="Active Pokemon"></div>');
 		this.statElem = this.elem.children().last();
 
 		this.elem.append('<div></div>');
 		this.fxElem = this.elem.children().last();
 
-		this.elem.append('<div class="leftbar" role="complementary" title="Your Team"></div>');
+		this.elem.append('<div class="leftbar" role="complementary" aria-label="Your Team"></div>');
 		this.leftbarElem = this.elem.children().last();
 
-		this.elem.append('<div class="rightbar" role="complementary" title="Opponent\'s Team"></div>');
+		this.elem.append('<div class="rightbar" role="complementary" aria-label="Opponent\'s Team"></div>');
 		this.rightbarElem = this.elem.children().last();
 
 		this.elem.append('<div></div>');

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -104,8 +104,11 @@ var BattleTooltips = (function () {
 		' ontouchleave="BattleTooltips._handleTouchLeaveFor(event)"' +
 		' ontouchcancel="BattleTooltips._handleTouchLeaveFor(event)"' +
 		' onmouseover="BattleTooltips.showTooltipFor(\'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')"' +
+		' onfocus="BattleTooltips.showTooltipFor(\'' + roomid + '\', \'' + Tools.escapeHTML('' + thing, true) + '\',\'' + type + '\', this, ' + (ownHeight ? 'true' : 'false') + ')"' +
 		' onmouseout="BattleTooltips.hideTooltip()"' +
-		' onmouseup="BattleTooltips._handleMouseUpFor()"';
+		' onblur="BattleTooltips.hideTooltip()"' +
+		' onmouseup="BattleTooltips._handleMouseUpFor()"' +
+		' aria-describedby="tooltipwrapper"';
 	};
 	BattleTooltips.prototype.showTooltip = function (thing, type, elem, ownHeight) {
 		var room = this.room;
@@ -156,7 +159,7 @@ var BattleTooltips = (function () {
 		if (y < 140) y = 140;
 		if (x > $(window).width() - 303) x = Math.max($(window).width() - 303, 0);
 
-		if (!$('#tooltipwrapper').length) $(document.body).append('<div id="tooltipwrapper" onclick="$(\'#tooltipwrapper\').html(\'\');"></div>');
+		if (!$('#tooltipwrapper').length) $(document.body).append('<div id="tooltipwrapper" onclick="$(\'#tooltipwrapper\').html(\'\');" role="tooltip"></div>');
 		$('#tooltipwrapper').css({
 			left: x,
 			top: y

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -11,7 +11,7 @@
 
 			this.isSideRoom = Tools.prefs('rightpanelbattles');
 
-			this.$el.addClass('ps-room-opaque').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" role="complementary" aria-label="Battle Log"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" aria-label="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
+			this.$el.addClass('ps-room-opaque').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" role="complementary"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" aria-label="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
 
 			this.$battle = this.$el.find('.battle');
 			this.$controls = this.$el.find('.battle-controls');

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -11,7 +11,7 @@
 
 			this.isSideRoom = Tools.prefs('rightpanelbattles');
 
-			this.$el.addClass('ps-room-opaque').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
+			this.$el.addClass('ps-room-opaque').attr('role', 'main').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" role="complementary" title="Battle Log"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" title="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
 
 			this.$battle = this.$el.find('.battle');
 			this.$controls = this.$el.find('.battle-controls');

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -11,7 +11,7 @@
 
 			this.isSideRoom = Tools.prefs('rightpanelbattles');
 
-			this.$el.addClass('ps-room-opaque').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" role="complementary"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" aria-label="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
+			this.$el.addClass('ps-room-opaque').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" aria-label="Battle Log" role="complementary"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" aria-label="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
 
 			this.$battle = this.$el.find('.battle');
 			this.$controls = this.$el.find('.battle-controls');

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -11,7 +11,7 @@
 
 			this.isSideRoom = Tools.prefs('rightpanelbattles');
 
-			this.$el.addClass('ps-room-opaque').attr('role', 'main').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" role="complementary" title="Battle Log"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" title="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
+			this.$el.addClass('ps-room-opaque').attr('role', 'main').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" role="complementary" aria-label="Battle Log"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" aria-label="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
 
 			this.$battle = this.$el.find('.battle');
 			this.$controls = this.$el.find('.battle-controls');

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -11,7 +11,7 @@
 
 			this.isSideRoom = Tools.prefs('rightpanelbattles');
 
-			this.$el.addClass('ps-room-opaque').attr('role', 'main').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" role="complementary" aria-label="Battle Log"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" aria-label="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
+			this.$el.addClass('ps-room-opaque').html('<div class="battle">Battle is here</div><div class="foehint"></div><div class="battle-log" role="complementary" aria-label="Battle Log"></div><div class="battle-log-add">Connecting...</div><div class="battle-controls" role="complementary" aria-label="Battle Controls"></div><button class="battle-chat-toggle button" name="showChat"><i class="fa fa-caret-left"></i> Chat</button>');
 
 			this.$battle = this.$el.find('.battle');
 			this.$controls = this.$el.find('.battle-controls');

--- a/testclient.html
+++ b/testclient.html
@@ -48,7 +48,7 @@
 				<div class="activitymenu">
 					<div class="pmbox">
 						<div class="pm-window news-embed">
-							<h3><button class="closebutton" tabindex="-1"><i class="fa fa-times-circle"></i></button><button class="minimizebutton" tabindex="-1"><i class="fa fa-minus-circle"></i></button>Latest News</h3>
+							<h3><button class="closebutton" aria-label="Close"><i class="fa fa-times-circle"></i></button><button class="minimizebutton" aria-label="Minimize"><i class="fa fa-minus-circle"></i></button>Latest News</h3>
 							<div class="pm-log" style="max-height:none">
 								<div class="newsentry"><h4>Test client</h4><p>Welcome to the test client! You can test client changes here!</p><p>&mdash;<strong>Zarel</strong> <small class="date">on Sep 25, 2015</small></p></div>
 							</div>

--- a/testclient.html
+++ b/testclient.html
@@ -48,7 +48,7 @@
 				<div class="activitymenu">
 					<div class="pmbox">
 						<div class="pm-window news-embed">
-							<h3><button class="closebutton" aria-label="Close"><i class="fa fa-times-circle"></i></button><button class="minimizebutton" aria-label="Minimize"><i class="fa fa-minus-circle"></i></button>Latest News</h3>
+							<h3><button class="closebutton" tabindex="-1" aria-label="Close"><i class="fa fa-times-circle"></i></button><button class="minimizebutton" tabindex="-1" aria-label="Minimize"><i class="fa fa-minus-circle"></i></button>Latest News</h3>
 							<div class="pm-log" style="max-height:none">
 								<div class="newsentry"><h4>Test client</h4><p>Welcome to the test client! You can test client changes here!</p><p>&mdash;<strong>Zarel</strong> <small class="date">on Sep 25, 2015</small></p></div>
 							</div>


### PR DESCRIPTION
Fixes battle UI-related issues in #954 

* [x] Use role="log" to enable automatic reding of incoming battle log text.
* [ ] There are 2 edit boxes in the DOM when on the battle and chat room screens. One of them is not meant for use, so should be marked aria-hidden.
* [x] Add WAI-ARIA landmarks to divide the UI into logical regions for faster navigation. E.g, to quickly check the health of the opponent.
* [ ] Make information conveyed by tooltips read out automatically, as well as being triggered when gaining keyboard focus.