### PR TITLE
Don't require boundary before http in links

### DIFF
--- a/js/battledata.js
+++ b/js/battledata.js
@@ -322,12 +322,11 @@ var baseSpeciesChart = [
 var domainRegex = '[a-z0-9\\-]+(?:[.][a-z0-9\\-]+)*';
 var parenthesisRegex = '[(](?:[^\\s()<>&]|&amp;)*[)]';
 var linkRegex = new RegExp(
-	'\\b' +
 	'(?:' +
 		'(?:' +
 			// When using www. or http://, allow any-length TLD (like .museum)
 			'(?:https?://|www[.])' + domainRegex +
-			'|' + domainRegex + '[.]' +
+			'|\\b' + domainRegex + '[.]' +
 				// Allow a common TLD, or any 2-3 letter TLD followed by : or /
 				'(?:com?|org|net|edu|info|us|jp|[a-z]{2,3}(?=[:/]))' +
 		')' +

--- a/js/battledata.js
+++ b/js/battledata.js
@@ -325,7 +325,7 @@ var linkRegex = new RegExp(
 	'(?:' +
 		'(?:' +
 			// When using www. or http://, allow any-length TLD (like .museum)
-			'(?:https?://|www[.])' + domainRegex +
+			'(?:https?://|\\bwww[.])' + domainRegex +
 			'|\\b' + domainRegex + '[.]' +
 				// Allow a common TLD, or any 2-3 letter TLD followed by : or /
 				'(?:com?|org|net|edu|info|us|jp|[a-z]{2,3}(?=[:/]))' +


### PR DESCRIPTION
It seems like forgetting spaces before links like `examplehttp://example.com` is common enough, and considering it's rather clear what this is supposed to do, no reason to force typing the link again for it to work. This only affects links having http, https or www at the start, no other links.