### PR TITLE
Add tie requests

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -6377,6 +6377,10 @@ var Battle = (function () {
 			break;
 		case 'timer':
 			break;
+		case 'tierequest':
+			this.requestingTie = args[1];
+			this.requestingTieTurn = parseInt(args[2], 10);
+			break;
 		case 'join':
 		case 'j':
 			if (this.roomid) app.rooms[this.roomid].users[toUserid(args[1])] = ' ' + args[1];

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -250,7 +250,7 @@
 					this.$controls.html('<p><button class="button" name="instantReplay"><i class="fa fa-undo"></i><br />First turn</button> <button class="button" name="rewindTurn"><i class="fa fa-step-backward"></i><br />Last turn</button><button class="button" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>');
 				} else {
 					// is a player
-					this.$controls.html('<p>' + this.getTimerHTML() + '<button class="button" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>');
+					this.$controls.html('<p>' + this.getTieHTML() + ' ' + this.getTimerHTML() + '<button class="button" name="skipTurn"><i class="fa fa-step-forward"></i><br />Skip turn</button> <button class="button" name="goToEnd"><i class="fa fa-fast-forward"></i><br />Skip to end</button></p>');
 				}
 				return;
 
@@ -277,6 +277,7 @@
 					// don't update controls (and, therefore, side) if `this.choice === null`: causes damage miscalculations
 					this.updateControlsForPlayer();
 				} else {
+					this.updateTie();
 					this.updateTimer();
 				}
 
@@ -446,6 +447,11 @@
 			}
 			return '<button name="openTimer" class="button timerbutton' + timerTicking + '"><i class="fa fa-hourglass-start"></i> ' + time + '</button>';
 		},
+		getTieHTML: function () {
+			var canRequest = this.battle.requestingTie !== app.user.get('userid') ? '' : 'disabled ';
+			var canAccept = !canRequest && this.battle.turn === this.battle.requestingTieTurn ? 'tiebutton-offer ' : '';
+			return '<button ' + (!canRequest ? 'name="openTie"' : '') + ' class="button ' + canRequest + canAccept + 'tiebutton"><i class="fa fa-handshake-o"></i> ' + (canAccept ? 'Accept Tie' : 'Tie') + '</button>';
+		},
 		updateZMove: function () {
 			var zChecked = this.$('input[name=zmove]')[0].checked;
 			if (zChecked) {
@@ -459,8 +465,14 @@
 		updateTimer: function () {
 			this.$('.timerbutton').replaceWith(this.getTimerHTML());
 		},
+		updateTie: function () {
+			this.$('.tiebutton').replaceWith(this.getTieHTML());
+		},
 		openTimer: function () {
 			app.addPopup(TimerPopup, {room: this});
+		},
+		openTie: function () {
+			app.addPopup(TiePopup, {room: this});
 		},
 		updateMoveControls: function (type) {
 			var switchables = this.request && this.request.side ? this.myPokemon : [];
@@ -551,7 +563,7 @@
 
 				this.$controls.html(
 					'<div class="controls">' +
-					'<div class="whatdo">' + requestTitle + this.getTimerHTML() + '</div>' +
+					'<div class="whatdo">' + requestTitle + this.getTieHTML() + ' ' + this.getTimerHTML() + '</div>' +
 					'<div class="switchmenu" style="display:block">' + targetMenus[0] + '<div style="clear:both"></div> </div>' +
 					'<div class="switchmenu" style="display:block">' + targetMenus[1] + '</div>' +
 					'</div>'
@@ -650,7 +662,7 @@
 
 				this.$controls.html(
 					'<div class="controls">' +
-					'<div class="whatdo">' + requestTitle + this.getTimerHTML() + '</div>' +
+					'<div class="whatdo">' + requestTitle + this.getTieHTML() + ' ' + this.getTimerHTML() + '</div>' +
 					moveControls + shiftControls + switchControls +
 					'</div>'
 				);
@@ -691,7 +703,7 @@
 				controls += '</div>';
 				this.$controls.html(
 					'<div class="controls">' +
-					'<div class="whatdo">' + requestTitle + this.getTimerHTML() + '</div>' +
+					'<div class="whatdo">' + requestTitle + this.getTieHTML() + ' ' + this.getTimerHTML() + '</div>' +
 					controls +
 					'</div>'
 				);
@@ -721,7 +733,7 @@
 				);
 				this.$controls.html(
 					'<div class="controls">' +
-					'<div class="whatdo">' + requestTitle + this.getTimerHTML() + '</div>' +
+					'<div class="whatdo">' + requestTitle + this.getTieHTML() + ' ' + this.getTimerHTML() + '</div>' +
 					controls +
 					'</div>'
 				);
@@ -758,7 +770,7 @@
 			);
 			this.$controls.html(
 				'<div class="controls">' +
-				'<div class="whatdo">' + requestTitle + this.getTimerHTML() + '</div>' +
+				'<div class="whatdo">' + requestTitle + this.getTieHTML() + ' ' + this.getTimerHTML() + '</div>' +
 				controls +
 				'</div>'
 			);
@@ -778,7 +790,7 @@
 		},
 
 		getPlayerChoicesHTML: function () {
-			var buf = '<p>' + this.getTimerHTML();
+			var buf = '<p>' + this.getTieHTML() + ' ' + this.getTimerHTML();
 			if (!this.choice || !this.choice.waiting) {
 				return buf + '<em>Waiting for opponent...</em></p>';
 			}
@@ -936,6 +948,9 @@
 		},
 		setTimer: function (setting) {
 			this.send('/timer ' + setting);
+		},
+		requestTie: function () {
+			this.send('/requesttie');
 		},
 		forfeit: function () {
 			this.send('/forfeit');
@@ -1327,6 +1342,17 @@
 		},
 		timerOn: function () {
 			this.room.setTimer('on');
+			this.close();
+		}
+	});
+
+	var TiePopup = this.TiePopup = Popup.extend({
+		initialize: function (data) {
+			this.room = data.room;
+			this.$el.html('<p><button name="requestTie"><strong>' + (this.room.battle.requestingTie !== app.user.get('userid') && this.room.battle.requestingTieTurn === this.battle.turn ? 'Accept' : 'Request') + ' Tie</strong></button></p>');
+		},
+		requestTie: function () {
+			this.room.requestTie();
 			this.close();
 		}
 	});

--- a/style/client.css
+++ b/style/client.css
@@ -1809,6 +1809,20 @@ a.ilink.yours {
 	text-shadow: none;
 }
 
+.tiebutton {
+	float: right;
+}
+.tiebutton-offer,
+.tiebutton-offer:hover {
+	color: #992222;
+	border-color: #992222;
+}
+.dark .tiebutton-offer,
+.dark .tiebutton-offer:hover {
+	color: #EE6666;
+	border-color: #EE6666;
+}
+
 .battle-controls p {
 	margin: 2px 0 8px 0;
 	padding: 0 8px;


### PR DESCRIPTION
In collaboration with @panpawn https://github.com/Zarel/Pokemon-Showdown/pull/3665

Adds a tie request button next to the timer button in battle. The button will show a countdown when the foe has requested a tie, and the button will be disabled when you are requesting a tie, or if you were the last user to request a tie. I've sent panpawn code changes for the server side PR that will handle these changes.  Currently the tie button has the same coloration as the timer button, i'm interested in changing it from red to a different color, any suggestions?