### PR TITLE
Fix remaining timer not being displayed properly

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -6352,16 +6352,16 @@ var Battle = (function () {
 			break;
 		case 'inactive':
 			if (!this.kickingInactive) this.kickingInactive = true;
-			if (args[0].slice(0, 9) === "You have ") {
+			if (args[1].slice(0, 9) === "You have ") {
 				// this is ugly but parseInt is documented to work this way
 				// so I'm going to be lazy and not chop off the rest of the
 				// sentence
-				this.kickingInactive = parseInt(args[0].slice(9), 10) || true;
+				this.kickingInactive = parseInt(args[1].slice(9), 10) || true;
 				return;
-			} else if (args[0].slice(-14) === ' seconds left.') {
-				var hasIndex = args[0].indexOf(' has ');
-				if (toId(args[0].slice(0, hasIndex)) === app.user.get('userid')) {
-					this.kickingInactive = parseInt(args[0].slice(hasIndex + 5), 10) || true;
+			} else if (args[1].slice(-14) === ' seconds left.') {
+				var hasIndex = args[1].indexOf(' has ');
+				if (toId(args[1].slice(0, hasIndex)) === app.user.get('userid')) {
+					this.kickingInactive = parseInt(args[1].slice(hasIndex + 5), 10) || true;
 				}
 			}
 			this.log('<div class="chat message-error">' + Tools.escapeHTML(args[1]) + '</div>', preempt);


### PR DESCRIPTION
https://github.com/Zarel/Pokemon-Showdown-Client/commit/76690a5001f8b2a7092938af7899c672f5a3c6d1 changed argument parsing behavior so that `args` will no longer get shifted. Due to this, `args[0]` in timer messages is no longer "You have x seconds left", but "inactive".