### PR TITLE
Tooltips: fix wrong base power being displayed for Extreme Evoboost

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -203,7 +203,6 @@ var BattleTooltips = (function () {
 
 	BattleTooltips.prototype.showMoveTooltip = function (move, isZ) {
 		var text = '';
-		var basePower = move.basePower;
 		var basePowerText = '';
 		var additionalInfo = '';
 		var yourActive = this.battle.yourSide.active;
@@ -227,6 +226,8 @@ var BattleTooltips = (function () {
 				// TODO: Weather Ball type-changing shenanigans
 			}
 		}
+
+		var basePower = move.basePower;
 
 		// Check if there are more than one active Pokémon to check for multiple possible BPs.
 		if (yourActive.length > 1) {


### PR DESCRIPTION
This way, it's made sure that `basePower` actually reflects the power of the Z move (if applicable), not just always the base move.
Calling `this.getMoveBasePower(move, pokemon, activeTarget) || basePower` is usually enough for all moves, except for Extreme Evoboost, because its BP is both 0 and different from its base move's BP, so Last Resort's 140 were incorrectly shown.