### PR TITLE
Don't be so confused when an Illusion faints

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -192,7 +192,6 @@ var Pokemon = (function () {
 		this.prevItemEffect = '';
 		this.species = species;
 		this.fainted = false;
-		this.zerohp = false;
 
 		this.status = '';
 		this.statusStage = 0;
@@ -322,7 +321,7 @@ var Pokemon = (function () {
 			hpstring = hpstring.substr(parenIndex + 1, hpstring.length - parenIndex - 2);
 		}
 
-		var oldhp = (this.zerohp || this.fainted) ? 0 : (this.hp || 1);
+		var oldhp = this.fainted ? 0 : (this.hp || 1);
 		var oldmaxhp = this.maxhp;
 		var oldwidth = this.hpWidth(100);
 		var oldcolor = this.hpcolor;
@@ -705,7 +704,6 @@ var Pokemon = (function () {
 	Pokemon.prototype.reset = function () {
 		this.clearVolatile();
 		this.hp = this.maxhp;
-		this.zerohp = false;
 		this.fainted = false;
 		this.needsReplace = (this.details.indexOf('-*') >= 0);
 		this.status = '';
@@ -719,7 +717,7 @@ var Pokemon = (function () {
 	// This function is NOT used in the calculation of any other displayed
 	// percentages or ranges, which have their own, more complex, formulae.
 	Pokemon.prototype.hpWidth = function (maxWidth) {
-		if (this.fainted || this.zerohp) return 0;
+		if (this.fainted) return 0;
 
 		// special case for low health...
 		if (this.hp == 1 && this.maxhp > 10) return 1;
@@ -2118,7 +2116,6 @@ var Side = (function () {
 		this.battle.message('' + pokemon.getName() + ' fainted!');
 
 		pokemon.fainted = true;
-		pokemon.zerohp = true;
 		pokemon.hp = 0;
 		pokemon.side.updateStatbar(pokemon, false, true);
 		pokemon.side.updateSidebar();
@@ -6014,7 +6011,6 @@ var Battle = (function () {
 		output.hpcolor = '';
 		if (hp === '0' || hp === '0.0') {
 			output.hp = 0;
-			output.zerohp = true;
 		} else if (hp.indexOf('/') > 0) {
 			var hp = hp.split('/');
 			if (isNaN(parseFloat(hp[0])) || isNaN(parseFloat(hp[1]))) {
@@ -6026,9 +6022,6 @@ var Battle = (function () {
 			var colorchar = hp[1].substr(hp[1].length - 1);
 			if ((colorchar === 'y') || (colorchar === 'g')) {
 				output.hpcolor = colorchar;
-			}
-			if (!output.hp) {
-				output.zerohp = true;
 			}
 		} else if (!isNaN(parseFloat(hp))) {
 			output.hp = output.maxhp * parseFloat(hp) / 100;
@@ -6043,7 +6036,6 @@ var Battle = (function () {
 			output.status = status;
 		} else if (status === 'fnt') {
 			output.hp = 0;
-			output.zerohp = true;
 			output.fainted = true;
 		}
 		return output;

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -932,7 +932,7 @@ var BattleTooltips = (function () {
 			accuracyComment += this.makePercentageChangeText(1.3, 'Compound Eyes');
 		}
 		for (var i = 0; i < pokemon.side.active.length; i++) {
-			if (!pokemon.side.active[i] || pokemon.side.active[i].zerohp) continue;
+			if (!pokemon.side.active[i] || pokemon.side.active[i].fainted) continue;
 			ability = Tools.getAbility(pokemon.side.pokemon[i].ability).name;
 			if (ability === 'Victory Star') {
 				accuracy *= 1.1;

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -367,7 +367,7 @@
 
 					if (this.request.forceSwitch !== true) {
 						var faintedLength = _.filter(this.request.forceSwitch, function (fainted) {return fainted;}).length;
-						var freedomDegrees = faintedLength - _.filter(switchables.slice(this.battle.mySide.active.length), function (mon) {return !mon.zerohp;}).length;
+						var freedomDegrees = faintedLength - _.filter(switchables.slice(this.battle.mySide.active.length), function (mon) {return !mon.fainted;}).length;
 						this.choice.freedomDegrees = Math.max(freedomDegrees, 0);
 						this.choice.canSwitch = faintedLength - this.choice.freedomDegrees;
 					}
@@ -540,7 +540,7 @@
 
 					if (disabled) {
 						targetMenus[0] += '<button disabled="disabled"></button> ';
-					} else if (!pokemon || pokemon.zerohp) {
+					} else if (!pokemon || pokemon.fainted) {
 						targetMenus[0] += '<button name="chooseMoveTarget" value="' + (i + 1) + '"><span class="picon" style="' + Tools.getPokemonIcon('missingno') + '"></span></button> ';
 					} else {
 						targetMenus[0] += '<button name="chooseMoveTarget" value="' + (i + 1) + '"' + this.tooltips.tooltipAttrs("your" + i, 'pokemon', true) + '><span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + (this.battle.ignoreOpponent || this.battle.ignoreNicks ? pokemon.species : Tools.escapeHTML(pokemon.name)) + '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') + '</button> ';
@@ -559,7 +559,7 @@
 
 					if (disabled) {
 						targetMenus[1] += '<button disabled="disabled" style="visibility:hidden"></button> ';
-					} else if (!pokemon || pokemon.zerohp) {
+					} else if (!pokemon || pokemon.fainted) {
 						targetMenus[1] += '<button name="chooseMoveTarget" value="' + (-(i + 1)) + '"><span class="picon" style="' + Tools.getPokemonIcon('missingno') + '"></span></button> ';
 					} else {
 						targetMenus[1] += '<button name="chooseMoveTarget" value="' + (-(i + 1)) + '"' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '><span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') + '</button> ';
@@ -648,8 +648,8 @@
 					for (var i = 0; i < switchables.length; i++) {
 						var pokemon = switchables[i];
 						pokemon.name = pokemon.ident.substr(4);
-						if (pokemon.zerohp || i < this.battle.mySide.active.length || this.choice.switchFlags[i]) {
-							switchMenu += '<button class="disabled" name="chooseDisabled" value="' + Tools.escapeHTML(pokemon.name) + (pokemon.zerohp ? ',fainted' : i < this.battle.mySide.active.length ? ',active' : '') + '"' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '><span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + (!pokemon.zerohp ? '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') : '') + '</button> ';
+						if (pokemon.fainted || i < this.battle.mySide.active.length || this.choice.switchFlags[i]) {
+							switchMenu += '<button class="disabled" name="chooseDisabled" value="' + Tools.escapeHTML(pokemon.name) + (pokemon.fainted ? ',fainted' : i < this.battle.mySide.active.length ? ',active' : '') + '"' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '><span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + (pokemon.hp ? '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') : '') + '</button> ';
 						} else {
 							switchMenu += '<button name="chooseSwitch" value="' + i + '"' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '><span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') + '</button> ';
 						}
@@ -697,8 +697,8 @@
 				var controls = '<div class="switchmenu" style="display:block">';
 				for (var i = 0; i < myActive.length; i++) {
 					var pokemon = this.myPokemon[i];
-					if (pokemon && !pokemon.zerohp || this.choice.switchOutFlags[i]) {
-						controls += '<button disabled' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '><span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + (!pokemon.zerohp ? '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') : '') + '</button> ';
+					if (pokemon && !pokemon.fainted || this.choice.switchOutFlags[i]) {
+						controls += '<button disabled' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '><span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + (!pokemon.fainted ? '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') : '') + '</button> ';
 					} else if (!pokemon) {
 						controls += '<button disabled></button> ';
 					} else {
@@ -722,12 +722,12 @@
 				var switchMenu = '';
 				for (var i = 0; i < switchables.length; i++) {
 					var pokemon = switchables[i];
-					if (pokemon.zerohp || i < this.battle.mySide.active.length || this.choice.switchFlags[i]) {
-						switchMenu += '<button class="disabled" name="chooseDisabled" value="' + Tools.escapeHTML(pokemon.name) + (pokemon.zerohp ? ',fainted' : i < this.battle.mySide.active.length ? ',active' : '') + '"' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '>';
+					if (pokemon.fainted || i < this.battle.mySide.active.length || this.choice.switchFlags[i]) {
+						switchMenu += '<button class="disabled" name="chooseDisabled" value="' + Tools.escapeHTML(pokemon.name) + (pokemon.fainted ? ',fainted' : i < this.battle.mySide.active.length ? ',active' : '') + '"' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '>';
 					} else {
 						switchMenu += '<button name="chooseSwitch" value="' + i + '"' + this.tooltips.tooltipAttrs(i, 'sidepokemon') + '>';
 					}
-					switchMenu += '<span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + (!pokemon.zerohp ? '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') : '') + '</button> ';
+					switchMenu += '<span class="picon" style="' + Tools.getPokemonIcon(pokemon) + '"></span>' + Tools.escapeHTML(pokemon.name) + (!pokemon.fainted ? '<span class="hpbar' + pokemon.getHPColorClass() + '"><span style="width:' + (Math.round(pokemon.hp * 92 / pokemon.maxhp) || 1) + 'px"></span></span>' + (pokemon.status ? '<span class="status ' + pokemon.status + '"></span>' : '') : '') + '</button> ';
 				}
 
 				var controls = (


### PR DESCRIPTION
If Zoroark is KO'd while its Illusion is up, the following happens:

- The server updates the Illusion's condition to be `0 fnt`
- The server breaks the Illusion
- The server faints Zoroark

Unfortunately once the client has seen the Illusory Pokémon's condition as `0 fnt` it treats it as fainted and zero HP for the rest of the battle, so even when it switches in for real the client either says that it's fainted or a duplicate.

The `zerohp` flag seems to be a complete waste of time here as everything it does is already covered by the `fainted` flag except in the case of KO'ing Zoroark under Illusion, so removing that is the first step to a solution.

Note that it then remains to decide what to do with the `fainted` flag. There are two approaches here:

 - Don't set the `fainted` flag when the condition is `0 fnt`. This might cause confusion with requests, which can only send the fainted state as `0 fnt`, although presumably the relevant `faint` major would already have been sent.
- Don't send `0 fnt` until after the `faint` major (server-side change).

Note that even after the latter is complete, the client will still show the Illusory Pokémon as having 0% health in the sidebar until it switches in for real, at which point it will return to normal health. (But presumably Illusory Pokémon can show unusual amounts of health anyway.)