### PR TITLE
Distinguish between 0HP and 1HP when HP Percentage Mod is off

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -717,10 +717,7 @@ var Pokemon = (function () {
 	// This function is NOT used in the calculation of any other displayed
 	// percentages or ranges, which have their own, more complex, formulae.
 	Pokemon.prototype.hpWidth = function (maxWidth) {
-		if (this.fainted) return 0;
-
-		// special case for low health...
-		if (this.hp == 1 && this.maxhp > 10) return 1;
+		if (this.fainted || !this.hp) return 0;
 
 		if (this.maxhp === 48) {
 			// Draw the health bar to the middle of the range.


### PR DESCRIPTION
When HP Percentage Mod is off, 0HP and 1HP look too similar. This makes 0HP take 0 CSS pixels and 1HP take 3 CSS pixels.