### PR TITLE
Prevent base move tracking from disabling Z move animation

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -3373,18 +3373,20 @@ var Battle = (function () {
 					this.message(pokemon.getName() + ' used <strong>' + move.name + '</strong>!');
 				}
 				if (!fromeffect.id || fromeffect.id === 'pursuit') {
+					var moveName = move.name;
 					if (move.isZ) {
 						pokemon.item = move.isZ;
 						var item = Tools.getItem(move.isZ);
-						if (item.zMoveFrom) move = Tools.getMove(item.zMoveFrom);
+						if (item.zMoveFrom) moveName = item.zMoveFrom;
 					} else if (move.name.slice(0, 2) === 'Z-') {
-						move = Tools.getMove(move.name.slice(2));
+						moveName = moveName.slice(2);
+						move = Tools.getMove(moveName);
 						for (var item in window.BattleItems) {
 							if (BattleItems[item].zMoveType === move.type) pokemon.item = item;
 						}
 					}
 					var pp = (target && target.side !== pokemon.side && toId(target.ability) === 'pressure' ? 2 : 1);
-					pokemon.markMove(move.name, pp);
+					pokemon.markMove(moveName, pp);
 				}
 				break;
 			}


### PR DESCRIPTION
PR #984 overwrote the `move` object with that of the base move, which meant that it stopped getting its animation, so I'm saving the name for move tracking separately.

Note that PR #978 isn't directly relevant since status Z-moves don't exist and the server overrides their animation anyway (although that might no longer be necessary?)