### PR TITLE
Update tooltips

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -881,7 +881,7 @@ var BattleTooltips = (function () {
 		}
 		// Other abilities that change the move type.
 		if ('sound' in move.flags && ability === 'Liquid Voice') moveType = 'Water';
-		if (moveType === 'Normal' && move.category && move.category !== 'Status' && !(move.id in {judgment:1, multiattack:1, naturalgift:1, revelationdance:1, technoblast:1, weatherball:1})) {
+		if (moveType === 'Normal' && move.category && move.category !== 'Status' && !(move.id in {judgment: 1, multiattack: 1, naturalgift: 1, revelationdance: 1, struggle: 1, technoblast: 1, weatherball: 1})) {
 			if (ability === 'Aerilate') moveType = 'Flying';
 			if (ability === 'Galvanize') moveType = 'Electric';
 			if (ability === 'Pixilate') moveType = 'Fairy';
@@ -1165,8 +1165,8 @@ var BattleTooltips = (function () {
 				abilityBoost = 0.75;
 			}
 		} else if (move.type === 'Normal' && move.category !== 'Status' &&
-			ability in {'Aerilate': 1, 'Galvanize':1, 'Pixilate': 1, 'Refrigerate': 1} &&
-			!(move.id in {judgment:1, multiattack:1, naturalgift:1, revelationdance:1, technoblast:1, weatherball:1})) {
+			ability in {'Aerilate': 1, 'Galvanize': 1, 'Pixilate': 1, 'Refrigerate': 1} &&
+			!(move.id in {judgment: 1, multiattack: 1, naturalgift: 1, revelationdance: 1, struggle: 1, technoblast: 1, weatherball: 1})) {
 			abilityBoost = (this.battle.gen > 6 ? 1.2 : 1.3);
 		} else if ((ability === 'Iron Fist' && move.flags['punch']) ||
 			(ability === 'Reckless' && (move.recoil || move.hasCustomRecoil)) ||

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -792,7 +792,7 @@ var BattleTooltips = (function () {
 			if (overrideStats && 'spe' in overrideStats) baseSpe = overrideStats['spe'];
 		}
 
-		var nature = (tier.indexOf('Random Battle') >= 0 || (tier.indexOf('Random') >= 0 && tier.indexOf('Battle') >= 0 && gen >= 7) || gen < 3) ? 1 : 0.9;
+		var nature = (tier.indexOf('Random Battle') >= 0 || (tier.indexOf('Random') >= 0 && tier.indexOf('Battle') >= 0 && gen >= 6) || gen < 3) ? 1 : 0.9;
 		return Math.floor(Math.floor(2 * baseSpe * level / 100 + 5) * nature);
 	};
 	BattleTooltips.prototype.getTemplateMaxSpeed = function (template, level) {
@@ -805,8 +805,9 @@ var BattleTooltips = (function () {
 		}
 
 		var iv = (gen < 3) ? 30 : 31;
-		var value = iv + (((tier.indexOf('Random') >= 0 && tier.indexOf('Battle') >= 0 && gen >= 7) || (tier.indexOf('Random Battle') >= 0 && gen >= 3)) ? 21 : 63);
-		var nature = (this.battle.tier.indexOf('Random Battle') >= 0 || gen < 3) ? 1 : 1.1;
+		var isRandomBattle = tier.indexOf('Random Battle') >= 0 || (tier.indexOf('Random') >= 0 && tier.indexOf('Battle') >= 0 && gen >= 6);
+		var value = iv + ((isRandomBattle && gen >= 3) ? 21 : 63);
+		var nature = (isRandomBattle || gen < 3) ? 1 : 1.1;
 		return Math.floor(Math.floor(Math.floor(2 * baseSpe + value) * level / 100 + 5) * nature);
 	};
 

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -1151,11 +1151,7 @@ var BattleTooltips = (function () {
 			(ability === 'Mega Launcher' && move.flags['pulse']) ||
 			(ability === 'Strong Jaw' && move.flags['bite']) ||
 			(ability === 'Technician' && basePower <= 60) ||
-			(ability === 'Toxic Boost' && (pokemon.status === 'psn' || pokemon.status === 'tox') && move.category === 'Physical') ||
-			(ability === 'Overgrow' && moveType === 'Grass' && pokemonData.hp * 3 <= pokemonData.maxhp) ||
-			(ability === 'Blaze' && moveType === 'Fire' && pokemonData.hp * 3 <= pokemonData.maxhp) ||
-			(ability === 'Torrent' && moveType === 'Water' && pokemonData.hp * 3 <= pokemonData.maxhp) ||
-			(ability === 'Swarm' && moveType === 'Bug' && pokemonData.hp * 3 <= pokemonData.maxhp)) {
+			(ability === 'Toxic Boost' && (pokemon.status === 'psn' || pokemon.status === 'tox') && move.category === 'Physical')) {
 			abilityBoost = 1.5;
 		} else if ((ability === 'Sand Force' && this.battle.weather === 'sandstorm' && (moveType === 'Rock' || moveType === 'Ground' || move.type === 'Steel')) ||
 			(ability === 'Sheer Force' && move.secondaries) ||

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -1148,11 +1148,8 @@ var BattleTooltips = (function () {
 
 		// Other ability boosts.
 		var abilityBoost = 0;
-		if (ability === 'Water Bubble' && moveType === 'Water') {
-			abilityBoost = 2;
-		} else if ((ability === 'Flare Boost' && pokemon.status === 'brn' && move.category === 'Special') ||
+		if ((ability === 'Flare Boost' && pokemon.status === 'brn' && move.category === 'Special') ||
 			(ability === 'Mega Launcher' && move.flags['pulse']) ||
-			(ability === 'Steelworker' && moveType === 'Steel') ||
 			(ability === 'Strong Jaw' && move.flags['bite']) ||
 			(ability === 'Technician' && basePower <= 60) ||
 			(ability === 'Toxic Boost' && (pokemon.status === 'psn' || pokemon.status === 'tox') && move.category === 'Physical') ||
@@ -1255,8 +1252,9 @@ var BattleTooltips = (function () {
 			isGrounded = false;
 		} else if (!(terrainBuffed.volatiles && terrainBuffed.volatiles['roost'])) {
 			// If a Fire/Flying type uses Burn Up and Roost, it becomes ???/Flying-type, but it's still grounded.
-			if (this.pokemonHasType(terrainBuffed, 'Flying');
+			if (this.pokemonHasType(terrainBuffed, 'Flying')) isGrounded = false;
 		}
+
 		if (isGrounded) {
 			if ((this.battle.hasPseudoWeather('Electric Terrain') && moveType === 'Electric') ||
 				(this.battle.hasPseudoWeather('Grassy Terrain') && moveType === 'Grass') ||
@@ -1396,9 +1394,9 @@ var BattleTooltips = (function () {
 	BattleTooltips.prototype.pokemonHasType = function (pokemon, type, types) {
 		if (!types) types = this.getPokemonTypes(pokemon);
 		for (var i = 0; i < types.length; i++) {
-			if (types[i] === type) return true
+			if (types[i] === type) return true;
 		}
 		return false;
-	}
+	};
 	return BattleTooltips;
 })();

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -1240,7 +1240,7 @@ var BattleTooltips = (function () {
 
 		// Field Effects
 		var terrainBuffed = this.battle.hasPseudoWeather('Misty Terrain') ? target : pokemonData;
-		var types = this.getPokemonTypes(this.battle.hasPseudoWeather('Misty Terrain') ? target : pokemon);
+		var types = this.getPokemonTypes(terrainBuffed);
 		var isGrounded = true;
 		var noItem = !terrainBuffed.item || this.battle.hasPseudoWeather('Magic Room') || terrainBuffed.volatiles && terrainBuffed.volatiles['embargo'];
 		if (this.battle.hasPseudoWeather('Gravity')) {

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -880,7 +880,7 @@ var BattleTooltips = (function () {
 		}
 		// Other abilities that change the move type.
 		if ('sound' in move.flags && ability === 'Liquid Voice') moveType = 'Water';
-		if (moveType === 'Normal' && move.category && move.category !== 'Status' && !(move.id in {'naturalgift': 1, 'struggle': 1})) {
+		if (moveType === 'Normal' && move.category && move.category !== 'Status' && !(move.id in {judgment:1, multiattack:1, naturalgift:1, revelationdance:1, technoblast:1, weatherball:1})) {
 			if (ability === 'Aerilate') moveType = 'Flying';
 			if (ability === 'Galvanize') moveType = 'Electric';
 			if (ability === 'Pixilate') moveType = 'Fairy';
@@ -1165,11 +1165,7 @@ var BattleTooltips = (function () {
 			}
 		} else if (move.type === 'Normal' && move.category !== 'Status' &&
 			ability in {'Aerilate': 1, 'Galvanize':1, 'Pixilate': 1, 'Refrigerate': 1} &&
-			!(move.id in {'naturalgift': 1, 'struggle': 1} ||
-				move.id === 'weatherball' && thereIsWeather ||
-				move.id === 'multiattack' && item.onMemory ||
-				move.id === 'judgment' && item.onPlate ||
-				move.id === 'technoblast' && item.onDrive)) {
+			!(move.id in {judgment:1, multiattack:1, naturalgift:1, revelationdance:1, technoblast:1, weatherball:1})) {
 			abilityBoost = (this.battle.gen > 6 ? 1.2 : 1.3);
 		} else if ((ability === 'Iron Fist' && move.flags['punch']) ||
 			(ability === 'Reckless' && (move.recoil || move.hasCustomRecoil)) ||

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -1003,7 +1003,7 @@ var BattleTooltips = (function () {
 		}
 		if (move.id === 'brine' && target.hp * 2 <= target.maxhp) {
 			basePower *= 2;
-			basePowerComment = this.makePercnetageChangeText(2, 'Brine + target below half HP');
+			basePowerComment = this.makePercentageChangeText(2, 'Brine + target below half HP');
 		}
 		if (move.id === 'eruption' || move.id === 'waterspout') {
 			basePower = Math.floor(150 * pokemon.hp / pokemon.maxhp) || 1;
@@ -1154,7 +1154,7 @@ var BattleTooltips = (function () {
 			(ability === 'Technician' && basePower <= 60) ||
 			(ability === 'Toxic Boost' && (pokemon.status === 'psn' || pokemon.status === 'tox') && move.category === 'Physical')) {
 			abilityBoost = 1.5;
-		} else if ((ability === 'Sand Force' && this.battle.weather === 'sandstorm' && (moveType === 'Rock' || moveType === 'Ground' || move.type === 'Steel')) ||
+		} else if ((ability === 'Sand Force' && this.battle.weather === 'sandstorm' && (moveType === 'Rock' || moveType === 'Ground' || moveType === 'Steel')) ||
 			(ability === 'Sheer Force' && move.secondaries) ||
 			(ability === 'Tough Claws' && move.flags['contact'])) {
 			abilityBoost = 1.3;

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -541,6 +541,7 @@ var BattleTooltips = (function () {
 
 		var ability = toId(pokemonData.ability || pokemon.ability || pokemonData.baseAbility);
 		if ('gastroacid' in pokemon.volatiles) ability = '';
+		var pokemonTypes = this.getPokemonTypes(pokemon);
 
 		// check for burn, paralysis, guts, quick feet
 		if (pokemon.status) {
@@ -647,7 +648,7 @@ var BattleTooltips = (function () {
 					}
 				}
 			}
-			if (this.battle.gen >= 4 && (pokemon.types[0] === 'Rock' || pokemon.types[1] === 'Rock') && weather === 'sandstorm') {
+			if (this.battle.gen >= 4 && this.pokemonHasType('Rock') && weather === 'sandstorm') {
 				stats.spd = Math.floor(stats.spd * 1.5);
 			}
 			if (ability === 'chlorophyll' && (weather === 'sunnyday' || weather === 'desolateland')) {
@@ -815,6 +816,7 @@ var BattleTooltips = (function () {
 		var pokemonData = this.room.myPokemon[pokemon.slot] || pokemon;
 		var ability = Tools.getAbility(pokemonData.ability || pokemon.ability || pokemonData.baseAbility).name;
 		var moveType = move.type;
+		var pokemonTypes = this.getPokemonTypes(pokemon);
 		// Normalize is the first move type changing effect.
 		if (ability === 'Normalize') {
 			moveType = 'Normal';
@@ -826,7 +828,7 @@ var BattleTooltips = (function () {
 			moveType = 'Normal';
 		}
 		if (move.id === 'revelationdance') {
-			moveType = pokemon.types[0];
+			moveType = pokemonTypes[0];
 		}
 		// Moves that require an item to change their type.
 		if (!this.battle.hasPseudoWeather('Magic Room') && (!pokemon.volatiles || !pokemon.volatiles['embargo'])) {
@@ -915,12 +917,7 @@ var BattleTooltips = (function () {
 		if (move.ohko) {
 			if (this.battle.gen === 1) return accuracy + '% (Will fail if target\'s speed is higher)';
 			if (move.id === 'sheercold' && this.battle.gen >= 7) {
-				accuracy = 20;
-				var types = this.getPokemonTypes(pokemon);
-				for (var i = 0; i < types.length; i++) {
-					if (types[i] === 'Ice') accuracy = 30;
-					break;
-				}
+				if (!this.pokemonHasType(pokemon, 'Ice')) accuracy = 20;
 			}
 			return accuracy + '% (Will fail if target\'s level is higher, increases 1% per each level above target)';
 		}
@@ -1240,7 +1237,6 @@ var BattleTooltips = (function () {
 
 		// Field Effects
 		var terrainBuffed = this.battle.hasPseudoWeather('Misty Terrain') ? target : pokemonData;
-		var types = this.getPokemonTypes(terrainBuffed);
 		var isGrounded = true;
 		var noItem = !terrainBuffed.item || this.battle.hasPseudoWeather('Magic Room') || terrainBuffed.volatiles && terrainBuffed.volatiles['embargo'];
 		if (this.battle.hasPseudoWeather('Gravity')) {
@@ -1259,10 +1255,7 @@ var BattleTooltips = (function () {
 			isGrounded = false;
 		} else if (!(terrainBuffed.volatiles && terrainBuffed.volatiles['roost'])) {
 			// If a Fire/Flying type uses Burn Up and Roost, it becomes ???/Flying-type, but it's still grounded.
-			for (var i = 0; i < types.length; i++) {
-				if (types[i] === 'Flying') isGrounded = false;
-				break;
-			}
+			if (this.pokemonHasType(terrainBuffed, 'Flying');
 		}
 		if (isGrounded) {
 			if ((this.battle.hasPseudoWeather('Electric Terrain') && moveType === 'Electric') ||
@@ -1400,5 +1393,12 @@ var BattleTooltips = (function () {
 		}
 		return types;
 	};
+	BattleTooltips.prototype.pokemonHasType = function (pokemon, type, types) {
+		if (!types) types = this.getPokemonTypes(pokemon);
+		for (var i = 0; i < types.length; i++) {
+			if (types[i] === type) return true
+		}
+		return false;
+	}
 	return BattleTooltips;
 })();

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -541,7 +541,6 @@ var BattleTooltips = (function () {
 
 		var ability = toId(pokemonData.ability || pokemon.ability || pokemonData.baseAbility);
 		if ('gastroacid' in pokemon.volatiles) ability = '';
-		var pokemonTypes = this.getPokemonTypes(pokemon);
 
 		// check for burn, paralysis, guts, quick feet
 		if (pokemon.status) {

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -647,7 +647,7 @@ var BattleTooltips = (function () {
 					}
 				}
 			}
-			if (this.battle.gen >= 4 && this.pokemonHasType('Rock') && weather === 'sandstorm') {
+			if (this.battle.gen >= 4 && this.pokemonHasType(pokemonData, 'Rock') && weather === 'sandstorm') {
 				stats.spd = Math.floor(stats.spd * 1.5);
 			}
 			if (ability === 'chlorophyll' && (weather === 'sunnyday' || weather === 'desolateland')) {
@@ -1366,9 +1366,7 @@ var BattleTooltips = (function () {
 	BattleTooltips.prototype.getPokemonTypes = function (pokemon) {
 		var template = pokemon;
 		if (!pokemon.types) template = Tools.getTemplate(pokemon.species);
-		if (pokemon.volatiles && pokemon.volatiles.transform && pokemon.volatiles.formechange) {
-			template = Tools.getTemplate(pokemon.volatiles.formechange[2]);
-		} else if (pokemon.volatiles && pokemon.volatiles.formechange) {
+		if (pokemon.volatiles && pokemon.volatiles.formechange) {
 			template = Tools.getTemplate(pokemon.volatiles.formechange[2]);
 		}
 


### PR DESCRIPTION
- Show Sheer Cold's real accuracy in gen 7
- Show Brine's BP
- Use the real move type when determining base power (except when checking for -ate boosts)
- Misty Terrain checks whether the target is grounded, not the user
- Use the Pokemon's real type when checking for Sandstorm's spd boost
- Steelworker, Water Bubble, Blaze, Overgrow, Swarm, and Torrent boost attacking stats, not base power
- Aerilate, Galvanize, Pixilate, and Refrigerate do not affect the moves Judgment, Multi-Attack, Techno Blast, or Weather Ball, regardless of item held.
- Gen 6 and 7 randdubs use the same ev spreads as their singles counterparts

I can't help but feel like all those `move.id` checks in the base power check should be an else if chain.