### PR TITLE
Fix crash on browser console when typing "/r "

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -159,7 +159,7 @@
 				e.stopPropagation();
 				var val = '/pm ' + app.user.lastPM + ', ';
 				textbox.value = val;
-				e.setSelectionRange(val.length, val.length);
+				textbox.setSelectionRange(val.length, val.length);
 			}
 		},
 		clickUsername: function (e) {


### PR DESCRIPTION
`e.setSelectionRange` is a typo, `setSelectionRange` is a method of the textbox element.

Results in `Uncaught TypeError: e.setSelectionRange is not a function` when the user types in ``"/r "``.