### PR TITLE
Don't merge normal move boosts in with the Z boost

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -3847,7 +3847,7 @@ var Battle = (function () {
 						break;
 					}
 				} else if (kwargs.zeffect) {
-					if (minors.length) {
+					if (minors.length && minors[0][1].zeffect) {
 						actions += "" + poke.getName() + " boosted its stats" + amountString + " using its Z-Power! ";
 						for (var i = 0; i < minors.length; i++) {
 							minors[i][1].silent = '.';


### PR DESCRIPTION
If you use e.g. Z-Cosmic Power, then you should get 'Clefable boosted its Special Defense using its Z-Power! Clefable's Defense rose! Clefable's Special Defense rose!'.