### PR TITLE
Team Preview: Don't hardcode team size for Illusion

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -397,7 +397,7 @@
 					// Request full team order if one of our Pokémon has Illusion
 					for (var i = 0; i < switchables.length && i < 6; i++) {
 						if (toId(switchables[i].baseAbility) === 'illusion') {
-							this.choice.count = 6;
+							this.choice.count = this.myPokemon.length;
 						}
 					}
 					if (this.battle.teamPreviewCount) {


### PR DESCRIPTION
The assumption that a team has 6 Pokemon in it isn't really true in every situation, especially now that 24 Pokemon teams are supported.