### PR TITLE
Dispatch fragment after processing autojoins

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -411,6 +411,9 @@
 						}
 					}
 					app.send('/autojoin ' + autojoinIds.join(','));
+
+					// HTML5 history throws exceptions when running on file://
+					Backbone.history.start({pushState: !Config.testclient});
 				});
 			}
 
@@ -614,9 +617,6 @@
 			Storage.whenAppLoaded.load(this);
 
 			this.initializeConnection();
-
-			// HTML5 history throws exceptions when running on file://
-			Backbone.history.start({pushState: !Config.testclient});
 		},
 		/**
 		 * Start up the client, including loading teams and preferences,


### PR DESCRIPTION
Currently fragment dispatching happens before autojoins. This means that if you're in a battle but need to reload (e.g. due to an interrupted connection) you rejoin the battle before attempting autojoins and they fail because they're now too late.