### PR TITLE
Dark mode CSS – Fix Notifications' color

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -117,7 +117,7 @@ select {
 	color: #F9F9F9;
 }
 .dark a.button.subtle-notifying {
-	color: #AA6600;
+	color: #61A3BB;
 }
 
 .dark .textbox {

--- a/style/client.css
+++ b/style/client.css
@@ -113,6 +113,17 @@ select {
 .dark a.button:active {
 	background: linear-gradient(to bottom,  #cfcfcf,  #f2f2f2);
 } */
+
+.dark .button.notifying {
+	background: #6BACC5;
+	border-color: #2C9CC1;
+}
+
+.dark .button.notifying:hover {
+	background: #6BACC5;
+	border-color: #FFFFFF;
+}
+
 .dark a.button:visited {
 	color: #F9F9F9;
 }


### PR DESCRIPTION
this color should be blue in darkmode 
screenshot : before/after 
![](https://image.prntscr.com/image/fWKgfjGhSkeKCf29XONxKA.png)

![](https://i.imgur.com/lMKPn6B.png)
