### PR TITLE
Dark mode CSS – Fix Teambuilder Results (hover)

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -3384,11 +3384,13 @@ a.ilink.yours {
 .dark .teambuilder-results .result a:hover {
 	border-color: #555555;
 	background: rgba(47, 47, 47, 0.8);
+	color: #FFFFFF;
 }
 
 .dark .teambuilder-results .result a.cur:hover {
 	border-color: #8A8A8A;
 	background: rgba(47, 47, 47, 0.8);
+	color: #FFFFFF;
 }
 
 .dark .setmenu button,

--- a/style/client.css
+++ b/style/client.css
@@ -3381,6 +3381,16 @@ a.ilink.yours {
 
 /* teambuilder set */
 
+.dark .teambuilder-results .result a:hover {
+	border-color: #555555;
+	background: rgba(47, 47, 47, 0.8);
+}
+
+.dark .teambuilder-results .result a.cur:hover {
+	border-color: #8A8A8A;
+	background: rgba(47, 47, 47, 0.8);
+}
+
 .dark .setmenu button,
 .dark .teamlist button,
 .dark .folder.cur .selectFolder,
@@ -3397,7 +3407,7 @@ a.ilink.yours {
 	color: #FFF;
 }
 .dark .utilichart .col {
-	color: #999;
+	color: #DDD;
 }
 .dark .utilichart .cur .col {
 	color: #FFF;
@@ -3407,7 +3417,7 @@ a.ilink.yours {
 .dark .utilichart a:hover .namecol,
 .dark .utilichart a:hover .pokemonnamecol,
 .dark .utilichart a:hover .movenamecol {
-	color: #555;
+	color: #DDD;
 }
 
 .dark .setchart,


### PR DESCRIPTION
really hard to read and shouldn't be that white in darkmode, as a consequence it should be updated like this;
screenshot : before/after 

![](https://image.prntscr.com/image/VsdtE5ANTRuqhGNvfmkLzw.png)
