### PR TITLE
Dark mode CSS – Fix Select Icons (color)

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -3318,6 +3318,14 @@ a.ilink.yours {
 	border-color: #CCC;
 }
 
+.dark .select:after {
+	color: #000000;
+}
+
+.dark .select:disabled:after {
+	color: #000000;
+}
+
 /* chat */
 
 .dark .userlist strong,

--- a/style/client.css
+++ b/style/client.css
@@ -3323,7 +3323,7 @@ a.ilink.yours {
 }
 
 .dark .select:disabled:after {
-	color: #000000;
+	color: #DDDDDD;
 }
 
 /* chat */


### PR DESCRIPTION

The teambuilder folderlist update looks cool but I'd like to fix this select icon as it should be dark.

![](https://image.prntscr.com/image/sBTOudC7SZOnXOLTqn7kSQ.png)
