### PR TITLE
Dark mode CSS – Fix Teambuilder Results (color)

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -3382,8 +3382,8 @@ a.ilink.yours {
 /* teambuilder set */
 
 .dark .teambuilder-results .result a.cur {
-	border-color: #999999;
-	background: rgba(40, 43, 45, 0.7);
+	border-color: rgb(158, 158, 158);
+	background: rgba(115, 115, 115, 0.6);
 	color: #FFFFFF;
 }
 

--- a/style/client.css
+++ b/style/client.css
@@ -3381,6 +3381,18 @@ a.ilink.yours {
 
 /* teambuilder set */
 
+.dark .teambuilder-results .result a {
+	border-color: #999999;
+	background: rgba(40, 43, 45, 0.7);
+	color: #FFFFFF;
+}
+
+.dark .teambuilder-results .result a.cur {
+	border-color: #999999;
+	background: rgba(40, 43, 45, 0.7);
+	color: #FFFFFF;
+}
+
 .dark .teambuilder-results .result a:hover {
 	border-color: #555555;
 	background: rgba(47, 47, 47, 0.8);

--- a/style/client.css
+++ b/style/client.css
@@ -3381,12 +3381,6 @@ a.ilink.yours {
 
 /* teambuilder set */
 
-.dark .teambuilder-results .result a {
-	border-color: #999999;
-	background: rgba(40, 43, 45, 0.7);
-	color: #FFFFFF;
-}
-
 .dark .teambuilder-results .result a.cur {
 	border-color: #999999;
 	background: rgba(40, 43, 45, 0.7);


### PR DESCRIPTION
this teambuilder result in darkmode is also unreadable and should be fixed (the background should be black with a white text-color);
![](https://image.prntscr.com/image/n_Zt_e_kSSGb4fNtJtmtmg.png)
