### PR TITLE
Add activation message for the Protective Pads

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5683,6 +5683,10 @@ var Battle = (function () {
 					poke.item = 'Safety Goggles';
 					actions += '' + poke.getName() + " is not affected by " + Tools.escapeHTML(args[3]) + " thanks to its Safety Goggles!";
 					break;
+				case 'protectivepads':
+					poke.item = 'Protective Pads';
+					actions += '' + poke.getName() + " protected itself with the Protective Pads!";
+					break;
 				default:
 					if (kwargs.broken) { // for custom moves that break protection
 						this.resultAnim(poke, 'Protection broken', 'bad');


### PR DESCRIPTION
As seen in https://www.youtube.com/watch?v=YmLzeSB0xK0 the Protective Pads have an activation message when blocking the effects of the target's Ability, be it Iron Barbs, Aftermath, or Tangling Hair, but not for other effects such as Spiky Shield. At the very least we'll need a client-side message for this, and then we can think about implementing the server-side behaviour.