### PR TITLE
Teambuilder: fix teams disappearing when dragging within folder

### DIFF
--- a/js/client-teambuilder.js
+++ b/js/client-teambuilder.js
@@ -842,16 +842,8 @@
 					team.format = format;
 				}
 				edited = true;
-				this.updateTeamList();
-			} else {
-				if (format.slice(-1) === '/') {
-					format = format.slice(0, -1);
-					if (format && format.slice(0, 3) !== 'gen') format = 'gen6' + format;
-					team.folder = format;
-					edited = true;
-				}
-				this.updateTeamList();
 			}
+			this.updateTeamList();
 
 			if (edited) {
 				Storage.saveTeam(team);


### PR DESCRIPTION
When trying to drag and drop teams in a user-created folder, the team would have "gen6" prepended to its folder name, which made it disappear (since it's in a different folder now). I assume this was originally meant for *format* folders, but even there the same problem remains - it would unexpectedly move to a different format folder.
I think that the proper way to deal with the issue is to do any renaming when loading the teams from storage (and importing). That already happens (``storage.js:574``), so I this should be fine.

On an unrelated note, the comment on line 822 seems unfinished. It works around an issue in what?