### PR TITLE
Darkmode CSS - fix format and background select button

### DIFF
--- a/style/client.css
+++ b/style/client.css
@@ -3243,13 +3243,16 @@ a.ilink.yours {
 	color: #AAA;
 	box-shadow: none;
 }
+.dark .popupmenu button.sel {
+	border-color: #A9A9A9;
+}
 .dark .popupmenu button:hover,
 .dark .popupmenu button.sel:hover,
 .dark .bglist button:hover,
 .dark .avatarlist button:hover {
-	border-color: #AAAAAA;
-	background-color: #AAAAAA;
-	color: black;
+	border-color: #A9A9A9;
+	background-color: #010810;
+	color: #A9A9A9;
 }
 .dark .changeform i {
 	border-color: #bbb;


### PR DESCRIPTION


![](https://image.prntscr.com/image/NdJAMc7hRp28j4rlcj-ctg.png)

Darkmode CSS Update
These buttons should be updated for darkmode, I can provide more screenshots if needed

This pull request would update;
FormatSelect Button
AvatarlistSelect Button
BackgroundlistSelect Button
