### PR TITLE
Storage: Don't bleed over set data

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -793,7 +793,7 @@ Storage.fastUnpackTeam = function (buf) {
 
 		// happiness
 		j = buf.indexOf(']', i);
-		var misc;
+		var misc = undefined;
 		if (j < 0) {
 			if (i < buf.length) misc = buf.substring(i).split(',', 3);
 		} else {
@@ -908,7 +908,7 @@ Storage.unpackTeam = function (buf) {
 
 		// happiness
 		j = buf.indexOf(']', i);
-		var misc;
+		var misc = undefined;
 		if (j < 0) {
 			if (i < buf.length) misc = buf.substring(i).split(',', 3);
 		} else {


### PR DESCRIPTION
Since the packed teams now store Hidden Power type and Pokéball type, there's certain situations where data from the previous set bleeds over to the next one, notably in the case of Return/Frustration but it's not completely localized to that.

For an example, currently if you import something like the following into the teambuilder:
```
Chansey  
Ability: Natural Cure  
Happiness: 0  
- Frustration  

Chansey  
Ability: Natural Cure  
- Return  
```
Then close the teambuilder and reopen the team again you end up with the following instead:
```
Chansey  
Ability: Natural Cure  
Happiness: 0  
- Frustration  

Chansey  
Ability: Natural Cure  
Happiness: 0  
- Return  
```