### PR TITLE
Fix Doubles UU showing DNU in teambuilder

### DIFF
--- a/githooks/build-indexes
+++ b/githooks/build-indexes
@@ -312,13 +312,13 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 					}
 					banlist = Tools.getFormat(genPrefix + 'doublesuu').banlist;
 					if (!banlist) {
-						defaultTier = "DOU";
+						defaultTier = "DUU";
 					} else if (banlist.indexOf(template.species) >= 0 || banlist.indexOf(template.baseSpecies) >= 0) {
 						return "DOU";
 					}
 					banlist = Tools.getFormat(genPrefix + 'doublesnu').banlist;
 					if (!banlist) {
-						defaultTier = "DUU";
+						defaultTier = "DNU";
 					} else if (banlist.indexOf(template.species) >= 0 || banlist.indexOf(template.baseSpecies) >= 0) {
 						return "DUU";
 					}


### PR DESCRIPTION
It was returning that Pokemon not banned by the duu banlist were still dou, and the same for the dnu banlist, i think.