### PR TITLE
Ignore location.search in the test client

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -743,7 +743,7 @@
 			};
 		},
 		dispatchFragment: function (fragment) {
-			if (location.search && window.history) {
+			if (!Config.testclient && location.search && window.history) {
 				history.replaceState(null, null, '/');
 			}
 			this.fragment = fragment = toRoomid(fragment || '');


### PR DESCRIPTION
The test client uses `location.search` to connect to private servers but it's not allowed to access history.