### PR TITLE
Do not change URL for HTML rooms

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -1412,9 +1412,8 @@
 				}
 				this.curRoom = window.room = room;
 				this.updateLayout();
-				if (this.curRoom.id === id) {
+				if (this.curRoom.id === id && room.type !== 'html') {
 					this.fragment = id;
-					this.navigate(id);
 					this.updateTitle(this.curRoom);
 				}
 			}
@@ -1443,7 +1442,7 @@
 			}
 			this.curRoom = room;
 			this.updateLayout();
-			if (this.curRoom.id === id) this.navigate(id);
+			if (this.curRoom.id === id && room.type !== 'html') this.navigate(id);
 
 			room.focus();
 			return;


### PR DESCRIPTION
- atm when you do /modlog the url of the entire page changes to the modlog tab, mainly because it's focused and on the left side of the page.  This causes some inconveniences because when you refresh, the changed URL causes a "blank page" to show.
- (also rather annoying for people using an external pm logging script, if checking logs causes the url to change, but this is just a trivial detail for me)