### PR TITLE
Don't faint a newly created Pokemon to reduce the team size

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -1761,6 +1761,7 @@ var Side = (function () {
 					var illusionFound = null;
 					for (var i = 0; i < this.pokemon.length; i++) {
 						var curPoke = this.pokemon[i];
+						if (curPoke === poke) continue;
 						if (curPoke.fainted) continue;
 						if (this.active.indexOf(curPoke) >= 0) continue;
 						if (curPoke.speciesid === 'zoroark' || curPoke.speciesid === 'zorua' || curPoke.ability === 'Illusion') {
@@ -1775,6 +1776,7 @@ var Side = (function () {
 						// and reguessed.
 						for (var i = 0; i < this.pokemon.length; i++) {
 							var curPoke = this.pokemon[i];
+							if (curPoke === poke) continue;
 							if (curPoke.fainted) continue;
 							if (this.active.indexOf(curPoke) >= 0) continue;
 							illusionFound = curPoke;


### PR DESCRIPTION
DG9 had challenged Quantum Tesseract to a Balanced Hackmons battle. His team was two Rayquaza-Megas, a Gengar, a Palkia, a Mega Tyranitar, and a Registeel. On turn 11, he mega-evolved his Rayquaza-Mega, although it was really his Illusion Gengar. Then when he later switched his (now Mega) Gengar back in, the client started to get confused, because this was a Pokemon that it hadn't seen in the Team Preview. But this is just standard for Hackmons.
The problem arises when one of his Rayquaza-Megas fainted. Later, he wanted to bring in his other Rayquaza-Mega. The client duly started to created a second Rayquaza-Mega because it had seen two in the team preview. But, the client was still confused by Gengar's Illusion, so in order to reduce the team size, it looked for a random unfainted Pokémon (as per the comment on line 1773). What did it choose? None other but the very Rayquaza-Mega that it was trying to create at the time...
I don't know whether the change on line 1764 is correct but I thought it should match 1779.