### PR TITLE
fix species clause checking for gen7randombattle

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -6443,7 +6443,7 @@ var Battle = (function () {
 			for (var i in kwargs) args[1] += '[' + i + '] ' + kwargs[i];
 			this.log('<div style="padding:5px 0"><small>Format:</small> <br /><strong>' + Tools.escapeHTML(args[1]) + '</strong></div>');
 			this.tier = args[1];
-			if (this.tier === 'Random Battle') {
+			if (this.tier.endsWith('Random Battle')) {
 				this.speciesClause = true;
 			}
 			break;


### PR DESCRIPTION
@Zarel I think I understand what you meant for the other comment: the real bug is that the Random Battle gametype checking failed, everything else works as normal.

Sorry, I wasn't sure how to handle updating a pull request, so I did a hard reset to upstream and recreated the commit.