### PR TITLE
Fix toxicTurns counter for Magic Guard/Poison Heal

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -3032,6 +3032,14 @@ var Battle = (function () {
 		this.turnsSinceMoved = 0;
 		this.acceleration = (this.messageFadeTime < 150 ? 2 : 1);
 	};
+	Battle.prototype.updateToxicTurns = function () {
+		for (var i = 0; i < this.sides.length; i++) {
+			for (var slot = 0; slot < this.sides[i].active.length; slot++) {
+				var poke = this.sides[i].active[slot];
+				if (poke.statusData.toxicTurns) poke.statusData.toxicTurns++;
+			}
+		}
+	};
 	Battle.prototype.changeWeather = function (weather, poke, isUpkeep, ability) {
 		weather = toId(weather);
 		var weatherTable = {
@@ -3709,7 +3717,6 @@ var Battle = (function () {
 						break;
 					case 'psn':
 						if (!this.fastForward) BattleStatusAnims['psn'].anim(this, [poke.sprite]);
-						if (poke.statusData.toxicTurns) poke.statusData.toxicTurns++;
 						actions += "" + poke.getName() + " was hurt by poison! ";
 						break;
 					case 'lifeorb':
@@ -6440,6 +6447,7 @@ var Battle = (function () {
 		case 'upkeep':
 			this.usesUpkeep = true;
 			this.updatePseudoWeatherLeft();
+			this.updateToxicTurns();
 			break;
 		case 'turn':
 			if (this.endPrevAction()) return;


### PR DESCRIPTION
Issue: If a Magic Guard/Poison Heal Pokemon is badly poisoned, the
tooltip will always say, "Next damage:/Would take if ability removed:
6%”. If the ability is removed, the forecasted poison damage will be
one turn behind. The reason for this is that currently, the Toxic
counter only increments if the client receives a message indicating
that the Pokemon has taken Poison damage.

Proposed fix: The Toxic counter is now handled under upkeep; at the end
of every turn, all active Pokemon are checked for Toxic status, and
their counters are each incremented accordingly.