### PR TITLE
Properly hide maximised user list

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1620,6 +1620,7 @@
 		},
 		hide: function () {
 			this.$el.scrollTop(0);
+			this.$el.removeClass('userlist-maximized');
 			this.$el.addClass('userlist-minimized');
 		},
 		updateUserCount: function () {


### PR DESCRIPTION
If the user list is maximised and then hidden (e.g. by switching rooms), it takes two clicks to maximise it again, because it hasn't been hidden properly.