### PR TITLE
Use current type in tooltip calculations

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -1391,6 +1391,7 @@ var BattleTooltips = (function () {
 			if (template.speciesid in table.overrideType) types = table.overrideType[template.speciesid].split('/');
 		}
 
+		if (pokemon.volatiles && pokemon.volatiles.typechange) types = pokemon.volatiles.typechange[2].split('/');
 		if (pokemon.volatiles && pokemon.volatiles.typeadd) {
 			if (types && types.indexOf(pokemon.volatiles.typeadd[2]) === -1) types = types.concat(pokemon.volatiles.typeadd[2]);
 		}


### PR DESCRIPTION
Although the tooltips show the added type they don't show a changed type (e.g. Soak, Color Change).