### PR TITLE
Power Lens and co should now correctly show Speed halved.

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -737,7 +737,7 @@ var BattleTooltips = (function () {
 		if (item === 'choicescarf') {
 			stats.spe = Math.floor(stats.spe * 1.5);
 		}
-		if (item === 'ironball' || item === 'machobrace') {
+		if (item === 'ironball' || item === 'machobrace' || /power(?!herb)/.test(item) ) {
 			stats.spe = Math.floor(stats.spe * 0.5);
 		}
 		if (ability === 'furcoat') {

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -737,7 +737,7 @@ var BattleTooltips = (function () {
 		if (item === 'choicescarf') {
 			stats.spe = Math.floor(stats.spe * 1.5);
 		}
-		if (item === 'ironball' || item === 'machobrace' || /power(?!herb)/.test(item) ) {
+		if (item === 'ironball' || item === 'machobrace' || /power(?!herb)/.test(item)) {
 			stats.spe = Math.floor(stats.spe * 0.5);
 		}
 		if (ability === 'furcoat') {


### PR DESCRIPTION
Right now, when using items such as Power Anklet, the speed is not shown as being halved.