### PR TITLE
Don't throw errors when trying to animate Mummy activating but failing

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5766,6 +5766,7 @@ var Battle = (function () {
 					}
 					break;
 				case 'mummy':
+					if (!args[3]) break; // if Mummy activated but failed, no ability will have been sent
 					var ability = Tools.getAbility(args[3]);
 					this.resultAnim(ofpoke, ability.name, 'ability');
 					this.animationDelay += 700;


### PR DESCRIPTION
When Mummy activates but fails due to Protective Pads, it will send an -activate message, but not the old/new ability of the attacker. Previously, it would throw errors when trying to animate the ability change. Now it just shows this:
![grafik](https://user-images.githubusercontent.com/5814184/36941184-c27065f4-1f55-11e8-9106-5f73ed5e8123.png)

