### PR TITLE
Suppress crash in trick room

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -5997,9 +5997,6 @@ var Battle = (function () {
 				this.addPseudoWeather(effect.name, 5, maxTimeLeft);
 
 				switch (effect.id) {
-				case 'trickroom':
-					actions += "" + poke.getName() + ' twisted the dimensions!';
-					break;
 				case 'wonderroom':
 					actions += "It created a bizarre area in which Defense and Sp. Def stats are swapped!";
 					break;
@@ -6037,6 +6034,12 @@ var Battle = (function () {
 				case 'psychicterrain':
 					actions += "The battlefield got weird!";
 					break;
+				case 'trickroom':
+					if (poke) {
+						actions += "" + poke.getName() + ' twisted the dimensions!';
+						break;
+					}
+					// falls through
 				default:
 					actions += effect.name + " started!";
 					break;


### PR DESCRIPTION
Something I noticed when setting trick room with `/editbattle`

I'm not sure if this is an issue in un-edited battles, so feel free to reject this if you don't care about protecting against this issue from `/editbattle` or `/evalbattle`.