### PR TITLE
Add client command to disable AFD sprites

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -888,6 +888,17 @@
 				}
 				return text; // Send the /avatar command through to the server.
 
+			case 'afd':
+				var cleanedTarget = toId(target);
+				if (cleanedTarget === 'off' || cleanedTarget === 'disable') {
+					Config.server.afd = false;
+					this.add('April Fools\' day mode disabled.');
+				} else {
+					Config.server.afd = true;
+					this.add('April Fools\' day mode enabled.');
+				}
+				return false;
+
 			// documentation of client commands
 			case 'help':
 				switch (toId(target)) {
@@ -961,6 +972,10 @@
 				case 'ladder':
 					this.add('/rating - Get your own rating.');
 					this.add('/rating [username] - Get user [username]\'s rating.');
+					return false;
+				case 'afd':
+					this.add('/afd - Enable April Fools\' Day sprites.');
+					this.add('/afd disable - Disable April Fools\' Day sprites.');
 					return false;
 				}
 			}


### PR DESCRIPTION
As described by Zarel.
However, currently the preference would not last beyond a refresh, which would be quite annoying if someone really doesn't like the afd sprites. We could add a setting, and then have the value of Config.server.afd be `!settingToDisable && valueSetByZarelDuringAfd`? That would stop people from enabling them when it's not AFD though. Otherwise we'd need 3 values - "always off", "always on" and "only on during AFD".

Also, currently this requires opening/closing the battle room to have it take effect. There is a `Site.updateSprites()`, but that will have all sprites hidden and not properly positioned. Is that intentional or can the method be modified to properly display the active mon?