### PR TITLE
Fix Ignore Nicknames setting not applying to messagebar

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -2665,6 +2665,8 @@ var Battle = (function () {
 		if (this.ignoreNicks) {
 			var $log = $('.battle-log .inner');
 			if ($log.length) $log.addClass('hidenicks');
+			var $message = $('.battle .message');
+			if ($message.length) $message.addClass('hidenicks');
 		}
 
 		// activity queue state

--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -1343,25 +1343,30 @@
 			this.toggleNicknames(this.battle.yourSide);
 
 			var $log = $('.battle-log .inner');
-			if (!$log.length) return;
+			var $message = $('.battle .message');
 			if (this.battle.ignoreNicks) {
 				$log.addClass('hidenicks');
+				$message.addClass('hidenicks');
 			} else {
 				$log.removeClass('hidenicks');
+				$message.removeClass('hidenicks');
 			}
 		},
 		toggleIgnoreOpponent: function (e) {
 			this.battle.ignoreOpponent = !!e.currentTarget.checked;
 			this.battle.add('Opponent ' + (this.battle.ignoreOpponent ? '' : 'no longer ') + 'ignored.');
 			var $log = $('.battle-log .inner');
+			var $message = $('.battle .message');
 			var $messages = $log.find('.chatmessage-' + this.battle.yourSide.id);
 			if (!$messages.length) return;
 			if (this.battle.ignoreOpponent) {
 				$messages.hide();
 				$log.addClass('hidenicks');
+				$message.addClass('hidenicks');
 			} else {
 				$messages.show();
 				$log.removeClass('hidenicks');
+				$message.removeClass('hidenicks');
 			}
 		},
 		toggleNicknames: function (side) {


### PR DESCRIPTION
Since removing the nicknames is done by adding a CSS class, add the same class to the messagebar.
(is there a better name for that temporary move/switch popup message thingie than "message(bar)"?)