### PR TITLE
Teambuilder: Prevent some instances of duplicate search results

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -265,6 +265,8 @@
 			if ((qType === 'ability' || qType === 'item') && typeIndex !== qTypeIndex) continue;
 			// Query was a type name followed 'type'; only show types
 			if (qFilterType === 'type' && typeIndex !== 2) continue;
+			// hardcode cases of duplicate non-consecutive aliases
+			if ((id === 'megax' || id === 'megay') && 'mega'.startsWith(query)) continue;
 
 			var matchStart = 0;
 			var matchLength = 0;


### PR DESCRIPTION
In particular, this is so that when you search "mega" in the teambuilder, you don't get Megazard/Mega Mewtwo twice. These have two aliases each (like megacharizardx/megax) which are not consecutive, so they were not caught by the previous duplicate check.