### PR TITLE
Build process: Don't crash when no config found

### DIFF
--- a/build-tools/update
+++ b/build-tools/update
@@ -28,7 +28,12 @@ process.stdout.write("Updating version... ");
 
 let version = require('../package.json').version;
 
-let configBuf = fs.readFileSync('config/config.js', {encoding: 'utf8'});
+let configBuf = '';
+try {
+	configBuf = fs.readFileSync('config/config.js', {encoding: 'utf8'});
+} catch (err) {
+	process.stdout.write("no config file found... ");
+}
 configBuf = configBuf.replace(/\/\* version \*\/[^;\n]*;/, `/* version */ Config.version = ${JSON.stringify(version)};`);
 
 fs.writeFileSync('config/config.js', configBuf);


### PR DESCRIPTION
I know you mentioned an init script, but since update already writes to the config file, stopping it from erroring out while reading first seemed more straightforward.
I think all other files can reasonably assumed to be present, unless the TS compliation doesn't work.