### PR TITLE
Fixed message when changing to invalid nick

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -254,7 +254,7 @@
 			}
 			var userid = toUserid(name);
 			if (!userid) {
-				app.addPopupMessage("Usernames must contain at least one letter or number.");
+				app.addPopupMessage("Usernames must contain at least one letter.");
 				return;
 			}
 


### PR DESCRIPTION
Usernames must contain at least one letter or the auth server will reject them; a number isn't enough.