### PR TITLE
Fix Transform of female Smeargle into Rotom

### DIFF
--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -976,10 +976,11 @@ const Tools = {
 		if (pokemon instanceof Pokemon) {
 			if (pokemon.volatiles.transform) {
 				options.shiny = pokemon.volatiles.transform[2];
+				options.gender = pokemon.volatiles.transform[3];
 			} else {
 				options.shiny = pokemon.shiny;
+				options.gender = pokemon.gender;
 			}
-			options.gender = pokemon.gender;
 			pokemon = pokemon.getSpecies();
 		}
 		const template = Tools.getTemplate(pokemon);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2864,7 +2864,8 @@ class Battle {
 				const species = (tpoke.volatiles.formechange ? tpoke.volatiles.formechange[1] : tpoke.species);
 				const pokemon = tpoke;
 				const shiny = tpoke.shiny;
-				poke.addVolatile('transform' as ID, pokemon, shiny);
+				const gender = tpoke.gender;
+				poke.addVolatile('transform' as ID, pokemon, shiny, gender);
 				poke.addVolatile('formechange' as ID, species);
 				for (const trackedMove of tpoke.moveTrack) {
 					poke.markMove(trackedMove[0], 0);


### PR DESCRIPTION
See this [replay](https://replay.pokemonshowdown.com/gen7hackmonscup-773575134) although given that this is Hackmons Cup it's actually a (female) Salandit that impostors Rotom, but I assume female Smeargle using Transform on Rotom would exhibit the same bug. Since Salandit is female, the client tries to look for a female Rotom sprite but actually finds the Rotom-Frost sprite instead.

I'm assuming here that Transform copies the visual appearance of any gender the target has, so apologies if that is in fact incorrect mechanics.