### PR TITLE
Stop battles from scrolling to the bottom constantly

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -4881,7 +4881,7 @@ class Battle {
 		let animations;
 		while (!animations) {
 			if (this.activityStep >= this.activityQueue.length) {
-				this.fastForwardOff();
+				if (this.fastForward) this.fastForwardOff();
 				if (this.ended) {
 					this.paused = true;
 					this.scene.soundStop();


### PR DESCRIPTION
`fastForwardOff()` calls `animationOn()`, which scrolls to the bottom based on a field set by `animationOff()`. During a normal, non-replay battle, this field is permanently set to true, because `animationOff ` is not called again after initialization (where it is called to fast forward to the start of the battle). `nextActivity` is called every turn and after every received message I think, hence the constant scolling.
This way, it only scrolls in replays when the user is actually fast forwarding to somewhere.