### PR TITLE
Refactor Battle constructor

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -22,7 +22,7 @@
 			this.$foeHint = this.$el.find('.foehint');
 
 			BattleSound.setMute(Tools.prefs('mute'));
-			this.battle = new Battle(this.$battle, this.$chatFrame, this.id);
+			this.battle = Battle.create(this.$battle, this.$chatFrame, this.id);
 			this.tooltips = new BattleTooltips(this.battle, this);
 
 			this.battle.roomid = this.id;

--- a/js/replay-embed.js
+++ b/js/replay-embed.js
@@ -25,7 +25,7 @@ var Replays = {
 			if (action) self[action]();
 		});
 
-		this.battle = new Battle(this.$('.battle'), this.$('.battle-log'));
+		this.battle = Battle.create(this.$('.battle'), this.$('.battle-log'));
 		//this.battle.preloadCallback = updateProgress;
 		this.battle.errorCallback = this.errorCallback.bind(this);
 		this.battle.resumeButton = this.resume.bind(this);

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -86,12 +86,17 @@ class BattleScene {
 	/** jQuery objects that need to finish animating */
 	activeAnimations = $();
 
-	constructor(battle: Battle, $frame: JQuery<HTMLElement>, $logFrame: JQuery<HTMLElement>) {
-		this.battle = battle;
+	constructor($frame: JQuery<HTMLElement>, $logFrame: JQuery<HTMLElement>) {
 		$frame.addClass('battle');
 		this.$frame = $frame;
 		this.$logFrame = $logFrame;
 
+		this.preloadEffects();
+		// reset() is called during battle initialization, so it doesn't need to be called here
+	}
+
+	setBattle(battle: Battle) {
+		this.battle = battle;
 		let numericId = 0;
 		if (battle.id) {
 			numericId = parseInt(battle.id.slice(battle.id.lastIndexOf('-') + 1));
@@ -100,9 +105,6 @@ class BattleScene {
 			numericId = Math.floor(Math.random() * 1000000);
 		}
 		this.numericId = numericId;
-
-		this.preloadEffects();
-		// reset() is called during battle initialization, so it doesn't need to be called here
 	}
 
 	reset() {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1045,11 +1045,18 @@ class Battle {
 	// external
 	resumeButton: JQuery.EventHandler<HTMLElement, null> | null = null;
 
-	constructor($frame: JQuery<HTMLElement>, $logFrame: JQuery<HTMLElement>, id = '') {
-		this.id = id;
-		this.scene = new BattleScene(this, $frame, $logFrame);
+	static create($frame: JQuery<HTMLElement>, $logFrame: JQuery<HTMLElement>, id = ''): Battle {
+		let scene = new BattleScene($frame, $logFrame);
+		let battle = new Battle(scene, id);
+		scene.setBattle(battle);
+		battle.init();
 
-		this.init();
+		return battle;
+	}
+
+	constructor(scene: BattleScene, id = '') {
+		this.id = id;
+		this.scene = scene;
 	}
 
 	removePseudoWeather(weather: string) {


### PR DESCRIPTION
This change makes it possible to initialize a `Battle` object with a
different implementation of `BattleScene`.

Sites where `new Battle()` was used are now replaced with
`Battle.create`.