### PR TITLE
Stringify PM target

### DIFF
--- a/js/client-mainmenu.js
+++ b/js/client-mainmenu.js
@@ -310,7 +310,7 @@
 			var text = $.trim($target.val());
 			if (!text) return;
 			var $pmWindow = $target.closest('.pm-window');
-			var userid = $pmWindow.data('userid');
+			var userid = $pmWindow.data('userid').toString();
 			var $chat = $pmWindow.find('.inner');
 			// this.tabComplete.reset();
 			this.chatHistories[userid].push(text);


### PR DESCRIPTION
A userid should be a string, `.data` can return values other than strings, for example if the userid is `false` it returns the boolean `false`. This may also happen with names that are all numbers.

This fixes a bug where trying to PM a user with a name that resolves to a falsey value causes you to PM `~` instead.