### PR TITLE
Avoid floating point error in health parse

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -224,7 +224,7 @@ class Pokemon {
 			oldmaxhp = oldhp = this.maxhp;
 		}
 
-		let oldnum = oldhp ? (Math.floor(oldhp / oldmaxhp * this.maxhp) || 1) : 0;
+		let oldnum = oldhp ? (Math.floor(this.maxhp * oldhp / oldmaxhp) || 1) : 0;
 		let delta = this.hp - oldnum;
 		let deltawidth = this.hpWidth(100) - oldwidth;
 		return [delta, this.maxhp, deltawidth, oldnum, oldcolor];
@@ -545,7 +545,7 @@ class Pokemon {
 	}
 	hpDisplay(precision = 1) {
 		if (this.maxhp === 100) return this.hp + '%';
-		if (this.maxhp !== 48) return (this.hp / this.maxhp * 100).toFixed(precision) + '%';
+		if (this.maxhp !== 48) return (100 * this.hp / this.maxhp).toFixed(precision) + '%';
 		let range = this.getPixelRange(this.hp, this.hpcolor);
 		return this.getFormattedRange(range, precision, '–');
 	}


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/7892468). This is caused by a floating-point error; `58 / 100` is slightly less than `0.58` so when you `* 100` the result is slightly less than `58` and gets floored to `57`; performing the multiplication first makes floating-point errors less likely. I also changed one other place that divides first although that then rounds the result so the problem may be less apparent there anyway.