### PR TITLE
Adding commands for a friends list

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -168,19 +168,16 @@
 		clickRemoveFriend: function (e) {
 			e.stopPropagation();
 			e.preventDefault();
-				var self = this;
-				$.get(app.user.getActionPHP(), {
-					act: 'removefriend',
-					player: toUserid(e.currentTarget.name)
-				}, 
-				
-				//return code here
-				function(data) {
-					if (data.charAt(0) == "]") { data = data.substr(1); }
-					self.add('|raw|' + data);
-					
-				}
-				, 'text');
+			var self = this;
+			$.get(app.user.getActionPHP(), {
+				act: 'removefriend',
+				player: toUserid(e.currentTarget.name)
+			},
+			//return code here
+			function (data) {
+				if (data.charAt(0) == "]") { data = data.substr(1); }
+				self.add('|raw|' + data);
+			}, 'text');
 			return;
 		},
 		clickAddFriend: function (e) {
@@ -190,10 +187,9 @@
 				$.get(app.user.getActionPHP(), {
 					act: 'addfriend',
 					player: toUserid(e.currentTarget.name)
-				}, 
-				
+				},
 				//return code here
-				function(data) {
+				function (data) {
 					if (data.charAt(0) == "]") { data = data.substr(1); }
 					self.add('|raw|' + data);
 					
@@ -798,57 +794,49 @@
 			case 'friendslist':
 			case 'getfriends':
 				if (!target) target = app.user.get('userid');
-
 				var targets = target.split(',');
-
 				var self = this;
 				$.get(app.user.getActionPHP(), {
 					act: 'getfriends',
 					user: targets[0]
-				}, 
-				
+				},
 				//return code here
-				function(data) {
+				function (data) {
 					if (data.charAt(0) == "]") { data = data.substr(1); }
 					var friendslist = data.split("|");
 					var friends = [];
 					var sent_pending = [];
 					var pending = [];
 					for (var i = 0; i < friendslist.length; i++) {
-						friend = friendslist[i];
+						var friend = friendslist[i];
 						if (friend.charAt(0) == "#") { sent_pending.push(friend.substr(1)); } else
 						if (friend.charAt(0) == ",") { pending.push(friend.substr(1)); } else
 						if (friend.length > 0) {friends.push(friend);}
 					}
-					
 					var buffer = '<div class="ladder"><table><tr><td colspan="8"><strong>Your friends:</strong></td></tr>';
 					if (friends.length === 0) { buffer += '<tr><td colspan="3">You have no friends. How sad.</td></tr>'; } else {
 					for (var i = 0; i < friends.length; i++) {
-							buffer += '<tr><td>'+friends[i]+'</td>';
-							buffer += '<td><button class="button removefriend" style="text-align: left" name="'+friends[i]+'" title="Remove friend"><strong>Remove</strong></button></td>';
-							buffer += '<td><button class="button pm-friend" style="text-align: left" name=" '+friends[i]+'" title="Private message"><strong>Message</strong></button></td></tr>';
+							buffer += '<tr><td>' + friends[i] + '</td>';
+							buffer += '<td><button class="button removefriend" style="text-align: left" name="' + friends[i] + '" title="Remove friend"><strong>Remove</strong></button></td>';
+							buffer += '<td><button class="button pm-friend" style="text-align: left" name=" ' + friends[i] + '" title="Private message"><strong>Message</strong></button></td></tr>';
 					}}
-					
 					if (sent_pending.length > 0) { buffer += '<tr><td colspan="8"><strong>Pending requests:</strong></td></tr>'; }
 					for (var i = 0; i < sent_pending.length; i++) {
-							buffer += '<tr><td>'+sent_pending[i]+'</td>';
-							buffer += '<td colspan="2"><button class="button removefriend" style="text-align: left" name="'+sent_pending[i]+'" title="Cancel request"><strong>Cancel</strong></button></td></tr>';
+							buffer += '<tr><td>' + sent_pending[i] + '</td>';
+							buffer += '<td colspan="2"><button class="button removefriend" style="text-align: left" name="' + sent_pending[i] + '" title="Cancel request"><strong>Cancel</strong></button></td></tr>';
 					}
-					
 					if (pending.length > 0) { buffer += '<tr><td colspan="8"><strong>Requests:</strong></td></tr>'; }
 					for (var i = 0; i < pending.length; i++) {
-							buffer += '<tr><td>'+pending[i]+'</td>';
-							buffer += '<td><button class="button removefriend" style="text-align: left" name="'+pending[i]+'" title="Reject request"><strong>Reject</strong></button></td>';
-							buffer += '<td><button class="button addfriend" style="text-align: left" name="'+pending[i]+'" title="Accept request"><strong>Accept</strong></button></td></tr>';
+							buffer += '<tr><td>' + pending[i] + '</td>';
+							buffer += '<td><button class="button removefriend" style="text-align: left" name="' + pending[i] + '" title="Reject request"><strong>Reject</strong></button></td>';
+							buffer += '<td><button class="button addfriend" style="text-align: left" name="' + pending[i] + '" title="Accept request"><strong>Accept</strong></button></td></tr>';
 					}
 					
 					buffer += '</table></div>';
 					self.add('|raw|' + buffer);
-					
-				}
-				, 'text');
+				}, 'text');
 				return false;
-				
+
 			case 'removefriend':
 				if (!target) {this.add('|raw|' + "This command requires a target."); return false;}
 				var targets = target.split(',');
@@ -860,12 +848,11 @@
 				}, 
 				
 				//return code here
-				function(data) {
+				function (data) {
 					if (data.charAt(0) == "]") { data = data.substr(1); }
 					self.add('|raw|' + data);
 					
-				}
-				, 'text');
+				}, 'text');
 				return false;		
 
 			case 'addfriend':
@@ -877,13 +864,13 @@
 					player: toUserid(targets[0])
 				}, 
 				//return code here
-				function(data) {
+				function (data) {
 					if (data.charAt(0) == "]") { data = data.substr(1); }
 					self.add('|raw|' + data);
 				}
 				, 'text');
 				return false;
-				
+
 			case 'rank':
 			case 'ranking':
 			case 'rating':

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -183,17 +183,16 @@
 		clickAddFriend: function (e) {
 			e.stopPropagation();
 			e.preventDefault();
-				var self = this;
-				$.get(app.user.getActionPHP(), {
-					act: 'addfriend',
-					player: toUserid(e.currentTarget.name)
-				},
-				//return code here
-				function (data) {
-					if (data.charAt(0) == "]") { data = data.substr(1); }
-					self.add('|raw|' + data);
-					
-				}
+			var self = this;
+			$.get(app.user.getActionPHP(), {
+				act: 'addfriend',
+				player: toUserid(e.currentTarget.name)
+			},
+			//return code here
+			function (data) {
+				if (data.charAt(0) == "]") { data = data.substr(1); }
+				self.add('|raw|' + data);
+			}
 				, 'text');
 			return;
 		},
@@ -815,23 +814,23 @@
 					}
 					var buffer = '<div class="ladder"><table><tr><td colspan="8"><strong>Your friends:</strong></td></tr>';
 					if (friends.length === 0) { buffer += '<tr><td colspan="3">You have no friends. How sad.</td></tr>'; } else {
-					for (var i = 0; i < friends.length; i++) {
+						for (var i = 0; i < friends.length; i++) {
 							buffer += '<tr><td>' + friends[i] + '</td>';
 							buffer += '<td><button class="button removefriend" style="text-align: left" name="' + friends[i] + '" title="Remove friend"><strong>Remove</strong></button></td>';
 							buffer += '<td><button class="button pm-friend" style="text-align: left" name=" ' + friends[i] + '" title="Private message"><strong>Message</strong></button></td></tr>';
-					}}
+						}
+					}
 					if (sent_pending.length > 0) { buffer += '<tr><td colspan="8"><strong>Pending requests:</strong></td></tr>'; }
 					for (var i = 0; i < sent_pending.length; i++) {
-							buffer += '<tr><td>' + sent_pending[i] + '</td>';
-							buffer += '<td colspan="2"><button class="button removefriend" style="text-align: left" name="' + sent_pending[i] + '" title="Cancel request"><strong>Cancel</strong></button></td></tr>';
+						buffer += '<tr><td>' + sent_pending[i] + '</td>';
+						buffer += '<td colspan="2"><button class="button removefriend" style="text-align: left" name="' + sent_pending[i] + '" title="Cancel request"><strong>Cancel</strong></button></td></tr>';
 					}
 					if (pending.length > 0) { buffer += '<tr><td colspan="8"><strong>Requests:</strong></td></tr>'; }
 					for (var i = 0; i < pending.length; i++) {
-							buffer += '<tr><td>' + pending[i] + '</td>';
-							buffer += '<td><button class="button removefriend" style="text-align: left" name="' + pending[i] + '" title="Reject request"><strong>Reject</strong></button></td>';
-							buffer += '<td><button class="button addfriend" style="text-align: left" name="' + pending[i] + '" title="Accept request"><strong>Accept</strong></button></td></tr>';
+						buffer += '<tr><td>' + pending[i] + '</td>';
+						buffer += '<td><button class="button removefriend" style="text-align: left" name="' + pending[i] + '" title="Reject request"><strong>Reject</strong></button></td>';
+						buffer += '<td><button class="button addfriend" style="text-align: left" name="' + pending[i] + '" title="Accept request"><strong>Accept</strong></button></td></tr>';
 					}
-					
 					buffer += '</table></div>';
 					self.add('|raw|' + buffer);
 				}, 'text');
@@ -840,20 +839,17 @@
 			case 'removefriend':
 				if (!target) {this.add('|raw|' + "This command requires a target."); return false;}
 				var targets = target.split(',');
-
 				var self = this;
 				$.get(app.user.getActionPHP(), {
 					act: 'removefriend',
 					player: toUserid(targets[0])
-				}, 
-				
+				},
 				//return code here
 				function (data) {
 					if (data.charAt(0) == "]") { data = data.substr(1); }
 					self.add('|raw|' + data);
-					
 				}, 'text');
-				return false;		
+				return false;
 
 			case 'addfriend':
 				if (!target) {this.add('|raw|' + "This command requires a target."); return false;}
@@ -862,13 +858,12 @@
 				$.get(app.user.getActionPHP(), {
 					act: 'addfriend',
 					player: toUserid(targets[0])
-				}, 
+				},
 				//return code here
 				function (data) {
 					if (data.charAt(0) == "]") { data = data.substr(1); }
 					self.add('|raw|' + data);
-				}
-				, 'text');
+				}, 'text');
 				return false;
 
 			case 'rank':

--- a/lib/dispatcher.lib.php
+++ b/lib/dispatcher.lib.php
@@ -491,7 +491,7 @@ class DefaultActionHandler {
 
 		$userid = $psdb->escape($curuser['userid']);
 		$player = $psdb->escape($reqData['player']);
-		$res = $psdb->query(
+		if($res = $psdb->query(
 			"DELETE FROM `ntbb_friendlist` " .
 			"WHERE (" .
 				"`p1`='" . $userid . "' AND `p2`='" . $player . "'" .
@@ -500,7 +500,7 @@ class DefaultActionHandler {
 			") " .
 			"LIMIT 1"
 		);
-		if (mysqli_affected_rows($psdb->db)) die(']' . $reqData['player'] . ' has been removed from your friend list.');
+		if (mysqli_affected_rows($psdb) == 1) die(']' . $reqData['player'] . ' has been removed from your friend list.');
 		die('Could not remove ' . $reqData['player'] . ' from your friend list.');
 	}
 }


### PR DESCRIPTION
These changes add commands for /fl, /friends, /friendslist, and /getfriends as well as /addfriend and /removefriend. The /friendslist command creates a table of existing friends (with buttons to remove or message the friend), outgoing (sent) pending requests, and incoming (received) pending requests with buttons to accept or reject.

When removing a friend, there is currently a bug where a "Could not remove PLAYER from your friend list." message will appear, though it will successfully remove the friend. I am not sure if my changes fix this. Friends list functionality is currently limited to the above and can be expanded on.