### PR TITLE
Headless client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ package-lock.json
 /js/battle-dex-data.js
 /js/battle-animations-moves.js
 /js/battle-animations.js
+/js/battle-scene-stub.js
+
+.vscode

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "image-size": "^0.6.2"
   },
   "devDependencies": {
+    "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.7",
     "eslint": "^4.11.0",
+    "mocha": "^5.2.0",
     "testcafe": "^0.18.4"
   },
   "private": true

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -31,6 +31,80 @@ This license DOES NOT extend to any other files in this repository.
 */
 
 class BattleScene {
+	setFrameHTML(html: any) {
+		this.$frame.html(html);
+	}
+	setControlsHTML(html: any) {
+		let $controls = this.$frame.parent().children('.battle-controls');
+		$controls.html(html);
+	}
+
+	// Methods defined in PokemonSprite but need to be called through BattleScene
+	removeEffect(pokemon: Pokemon, id: ID, instant?: boolean) {
+		return pokemon.sprite.removeEffect(id, instant);
+	}
+	addEffect(pokemon: Pokemon, id: ID, instant?: boolean) {
+		return pokemon.sprite.addEffect(id, instant);
+	}
+	animSummon(pokemon: Pokemon, slot: number, instant?: boolean) {
+		return pokemon.sprite.animSummon(pokemon, slot, instant);
+	}
+	animUnsummon(pokemon: Pokemon, instant?: boolean) {
+		return pokemon.sprite.animUnsummon(pokemon, instant);
+	}
+	animDragIn(pokemon: Pokemon, slot: number) {
+		return pokemon.sprite.animDragIn(pokemon, slot);
+	}
+	animDragOut(pokemon: Pokemon) {
+		return pokemon.sprite.animDragOut(pokemon);
+	}
+	updateStatbar(pokemon: Pokemon, updatePrevhp?: boolean, updateHp?: boolean) {
+		return pokemon.sprite.updateStatbar(pokemon, updatePrevhp, updateHp);
+	}
+	updateStatbarIfExists(pokemon: Pokemon, updatePrevhp?: boolean, updateHp?: boolean) {
+		return pokemon.sprite.updateStatbarIfExists(pokemon, updatePrevhp, updateHp);
+	}
+	animTransform(pokemon: Pokemon, isCustomAnim?: boolean, isPermanent?: boolean) {
+		return pokemon.sprite.animTransform(pokemon, isCustomAnim, isPermanent);
+	}
+	clearEffects(pokemon: Pokemon) {
+		return pokemon.sprite.clearEffects();
+	}
+	removeTransform(pokemon: Pokemon) {
+		return pokemon.sprite.removeTransform();
+	}
+	animFaint(pokemon: Pokemon) {
+		return pokemon.sprite.animFaint(pokemon);
+	}
+	animReset(pokemon: Pokemon) {
+		return pokemon.sprite.animReset();
+	}
+	anim(pokemon: Pokemon, end: ScenePos, transition?: string) {
+		return pokemon.sprite.anim(end, transition);
+	}
+	beforeMove(pokemon: Pokemon) {
+		return pokemon.sprite.beforeMove();
+	}
+	afterMove(pokemon: Pokemon) {
+		return pokemon.sprite.afterMove();
+	}
+	updateSpritesForSide(side: Side) {
+		if (side.missedPokemon && side.missedPokemon.sprite) {
+			side.missedPokemon.sprite.destroy();
+		}
+
+		side.missedPokemon = {
+			sprite: new PokemonSprite(null, {
+				x: side.leftof(-100),
+				y: side.y,
+				z: side.z,
+				opacity: 0,
+			}, this, side.n)
+		} as Pokemon;
+
+		side.missedPokemon.sprite.isMissedPokemon = true;
+	}
+
 	battle: Battle;
 	animating = true;
 	acceleration = 1;
@@ -2221,6 +2295,12 @@ class PokemonSprite extends Sprite {
 				top: this.statbarTop,
 				opacity: 1,
 			});
+		}
+	}
+
+	updateStatbarIfExists(pokemon: Pokemon, updatePrevhp?: boolean, updateHp?: boolean) {
+		if (this.$statbar) {
+			this.updateStatbar(pokemon, updatePrevhp, updateHp);
 		}
 	}
 

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -193,12 +193,12 @@ const Tools = {
 
 	resourcePrefix: (() => {
 		let prefix = '';
-		if (document.location!.protocol !== 'http:') prefix = 'https:';
+		if (!window.document || !document.location || document.location.protocol !== 'http:') prefix = 'https:';
 		return prefix + '//play.pokemonshowdown.com/';
 	})(),
 
 	fxPrefix: (() => {
-		if (document.location!.protocol === 'file:') {
+		if (window.document && document.location && document.location.protocol === 'file:') {
 			if (window.Replays) return 'https://play.pokemonshowdown.com/fx/';
 			return 'fx/';
 		}

--- a/src/battle-scene-stub.ts
+++ b/src/battle-scene-stub.ts
@@ -1,0 +1,68 @@
+class BattleSceneStub {
+	animating: boolean = false;
+	acceleration: number = NaN;
+	gen: number = NaN;
+	activeCount: number = NaN;
+	numericId: number = NaN;
+	timeOffset: number = NaN;
+	interruptionCount: number = NaN;
+	messagebarOpen: boolean = false;
+
+	abilityActivateAnim(pokemon: Pokemon, result: string): void { }
+	addPokemonSprite(pokemon: Pokemon) { return null!; }
+	addSideCondition(siden: number, id: ID, instant?: boolean | undefined): void { }
+	animationOff(): void { }
+	animationOn(): void { }
+	closeMessagebar(): void { }
+	damageAnim(pokemon: Pokemon, damage: string | number): void { }
+	destroy(): void { }
+	finishAnimations(): JQuery.Promise<JQuery<HTMLElement>, any, any> | undefined { return void(0); }
+	healAnim(pokemon: Pokemon, damage: string | number): void { }
+	hideJoinButtons(): void { }
+	incrementTurn(): void { }
+	log(html: string, preempt?: boolean | undefined): void { }
+	message(message: string, hiddenMessage?: string | undefined): void { }
+	pause(): void { }
+	preemptCatchup(): void { }
+	removeSideCondition(siden: number, id: ID): void { }
+	reset(): void { }
+	resultAnim(pokemon: Pokemon, result: string, type: "bad" | "good" | "neutral" | "par" | "psn" | "frz" | "slp" | "brn"): void { }
+	resume(): void { }
+	runMoveAnim(moveid: ID, participants: Pokemon[]): void { }
+	runOtherAnim(moveid: ID, participants: Pokemon[]): void { }
+	runPrepareAnim(moveid: ID, attacker: Pokemon, defender: Pokemon): void { }
+	runResidualAnim(moveid: ID, pokemon: Pokemon): void { }
+	runStatusAnim(moveid: ID, participants: Pokemon[]): void { }
+	soundStart(): void { }
+	soundStop(): void { }
+	startAnimations(): void { }
+	teamPreview(): void { }
+	teamPreviewEnd(): void { }
+	updateGen(): void { }
+	updateSidebar(side: Side): void { }
+	updateSidebars(): void { }
+	updateStatbars(): void { }
+	updateWeather(instant?: boolean | undefined): void { }
+	upkeepWeather(): void { }
+	wait(time: number): void { }
+	setFrameHTML(html: any): void { }
+	setControlsHTML(html: any): void { }
+	removeEffect(pokemon: Pokemon, id: ID, instant?: boolean) { }
+	addEffect(pokemon: Pokemon, id: ID, instant?: boolean) { }
+	animSummon(pokemon: Pokemon, slot: number, instant?: boolean) { }
+	animUnsummon(pokemon: Pokemon, instant?: boolean) { }
+	animDragIn(pokemon: Pokemon, slot: number) { }
+	animDragOut(pokemon: Pokemon) { }
+	updateStatbar(pokemon: Pokemon, updatePrevhp?: boolean, updateHp?: boolean) { }
+	updateStatbarIfExists(pokemon: Pokemon, updatePrevhp?: boolean, updateHp?: boolean) { }
+	animTransform(pokemon: Pokemon, isCustomAnim?: boolean, isPermanent?: boolean) { }
+	clearEffects(pokemon: Pokemon) { }
+	removeTransform(pokemon: Pokemon) { }
+	animFaint(pokemon: Pokemon) { }
+	animReset(pokemon: Pokemon) { }
+	anim(pokemon: Pokemon, end: ScenePos, transition?: string) { }
+	beforeMove(pokemon: Pokemon) { }
+	afterMove(pokemon: Pokemon) { }
+	updateSpritesForSide(side: Side) { }
+	unlink(userid: string, showRevealButton = false) { }
+}

--- a/test/battle-test.mocha.js
+++ b/test/battle-test.mocha.js
@@ -1,0 +1,94 @@
+const fs = require('fs');
+const assert = require('assert').strict;
+
+window = global;
+
+// Without making these modules, the best we can do is directly include them into this workspace.
+eval('' + fs.readFileSync(`${__dirname}/../js/battle-scene-stub.js`));
+eval('' + fs.readFileSync(`${__dirname}/../js/battle-dex.js`));
+eval('' + fs.readFileSync(`${__dirname}/../js/battle-dex-data.js`));
+eval('' + fs.readFileSync(`${__dirname}/../js/battle.js`));
+
+describe('Battle', function () {
+
+	it('should instantiate without issue', function () {
+		var battle = new Battle();
+	});
+
+	it('should process a bunch of messages properly', function () {
+		var battle = new Battle();
+		battle.debug = true;
+
+		battle.setQueue([
+			"|init|battle",
+			"|title|FOO vs. BAR",
+			"|j|FOO",
+			"|j|BAR",
+			"|request|",
+			"|player|p1|FOO|169",
+			"|player|p2|BAR|265",
+			"|teamsize|p1|6",
+			"|teamsize|p2|6",
+			"|gametype|singles",
+			"|gen|7",
+			"|tier|[Gen 7] Random Battle",
+			"|rated|",
+			"|seed|",
+			"|rule|Sleep Clause Mod: Limit one foe put to sleep",
+			"|rule|HP Percentage Mod: HP is shown in percentages",
+			"|",
+			"|start",
+			"|switch|p1a: Leafeon|Leafeon, L83, F|100/100",
+			"|switch|p2a: Gliscor|Gliscor, L77, F|242/242",
+			"|turn|1",
+		]);
+		battle.fastForwardTo(-1);
+
+		var p1 = battle.sides[0];
+		var p2 = battle.sides[1];
+
+		assert(p1.name === 'FOO');
+		var p1leafeon = p1.pokemon[0];
+		assert(p1leafeon.ident === 'p1: Leafeon');
+		assert(p1leafeon.details === 'Leafeon, L83, F');
+		assert(p1leafeon.hp === 100);
+		assert(p1leafeon.maxhp === 100);
+		assert(p1leafeon.isActive());
+		assert.deepEqual(p1leafeon.moveTrack, []);
+
+		assert(p2.name === 'BAR');
+		var p2gliscor = p2.pokemon[0];
+		assert(p2gliscor.ident === 'p2: Gliscor');
+		assert(p2gliscor.details === 'Gliscor, L77, F');
+		assert(p2gliscor.hp === 242);
+		assert(p2gliscor.maxhp === 242);
+		assert(p2gliscor.isActive());
+		assert.deepEqual(p2gliscor.moveTrack, []);
+
+		[
+			"|",
+			"|switch|p2a: Kyurem|Kyurem-White, L73|303/303",
+			"|-ability|p2a: Kyurem|Turboblaze",
+			"|move|p1a: Leafeon|Knock Off|p2a: Kyurem",
+			"|-damage|p2a: Kyurem|226/303",
+			"|-enditem|p2a: Kyurem|Leftovers|[from] move: Knock Off|[of] p1a: Leafeon",
+			"|",
+			"|upkeep",
+			"|turn|2",
+			"|inactive|Time left: 150 sec this turn | 740 sec total",
+		].forEach(msg => battle.add(msg));
+		battle.fastForwardTo(-1);
+
+		assert(!p2gliscor.isActive());
+		var p2kyurem = p2.pokemon[1];
+		assert(p2kyurem.ident === 'p2: Kyurem');
+		assert(p2kyurem.details === 'Kyurem-White, L73');
+		assert(p2kyurem.hp === 226);
+		assert(p2kyurem.maxhp === 303);
+		assert(p2kyurem.isActive());
+		assert(p2kyurem.item === '');
+		assert(p2kyurem.prevItem === 'Leftovers');
+
+		assert.deepEqual(p1leafeon.moveTrack, [['Knock Off', 1]]);
+	});
+});


### PR DESCRIPTION
Adds a way to instantiate a `Battle` object that works in non-browser environments (e.g. Node, V8) with minor modifications. Fixes #1148.

To do:
- [x] unit tests.
- [x] testclient.html