### PR TITLE
Fix multi-hitcount message

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -877,7 +877,7 @@ class BattleTextParser {
 		}
 
 		case '-hitcount': {
-			const [, num] = args;
+			const [, , num] = args;
 			if (num === '1') {
 				return this.template('hitCountSingular');
 			}


### PR DESCRIPTION
The number of hits is the 3rd argument rather than the 2nd which is the Pokemon that was hit.