### PR TITLE
Fix escaping HTML in localized time

### DIFF
--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -674,7 +674,7 @@ class BattleLog {
 			// if it exists.
 			formattedTime = parsedTime.toLocaleString();
 		}
-		return '<time>' + this.escapeHTML(formattedTime) + '</time>';
+		return '<time>' + BattleLog.escapeHTML(formattedTime) + '</time>';
 	}
 	static sanitizeHTML(input: string) {
 		this.initSanitizeHTML();


### PR DESCRIPTION
Something to note: battle-log.ts uses both `this.escapeHTML` and `BattleLog.escapeHTML`. I assume which is used depends on where in the code its being called from.

In this case, `this` refered to `window` when parsing HTML from !events, and subsequently crashed.
Let me know if this isn't the correct fix.