### PR TITLE
Fix stat copying

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1560,6 +1560,7 @@ class Battle {
 				poke.boosts[stat] = frompoke.boosts[stat];
 				if (!poke.boosts[stat]) delete poke.boosts[stat];
 			}
+			this.scene.resultAnim(poke, 'Stats copied', 'neutral');
 
 			this.log(args, kwArgs);
 			break;


### PR DESCRIPTION
The animation (and stat bar update) got lost as part of f6c03e0.

I happened to noticed this because I was watching [turn 6](https://replay.pokemonshowdown.com/gen7doublesou-824109348).