### PR TITLE
Fix log of ability immunity text

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -826,8 +826,8 @@ class BattleTextParser {
 		}
 
 		case '-immune': {
-			let [, pokemon, effect] = args;
-			const line1 = this.maybeAbility(effect, kwArgs.of || pokemon);
+			const [, pokemon] = args;
+			const line1 = this.maybeAbility(kwArgs.from, kwArgs.of || pokemon);
 			let template = this.template('block', effect);
 			if (!template) {
 				const templateId = kwArgs.ohko ? 'immuneOHKO' : 'immune';


### PR DESCRIPTION
I wanted to test this but it turns out that testclient loads `graphics.js` from main, so it doesn't see the changes. Anyway, this just copies other messages such as `-fail`.