### PR TITLE
Fix some specific failure text cases

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -821,7 +821,7 @@ class BattleTextParser {
 			if (kwArgs.heavy) templateId = 'failTooHeavy';
 			if (kwArgs.weak) templateId = 'fail';
 			if (kwArgs.forme) templateId = 'failWrongForme';
-			template = this.template(templateId);
+			template = this.template(templateId, id);
 			return line1 + template.replace('[POKEMON]', this.pokemon(pokemon));
 		}
 


### PR DESCRIPTION
At the very least this fixes Substitute when a Substitute is already up, but probably also fixes other cases such as reapplying status or as Sky Drop's too heavy to be lifted.