### PR TITLE
Fix Gen 1 partial trapping message

### DIFF
--- a/data/text.js
+++ b/data/text.js
@@ -35,6 +35,7 @@ exports.BattleText = {
 		// is that the `cant` message REPLACES "Pokemon used Move!", while the `fail`
 		// message happens AFTER "Pokemon used Move!"
 		cant: "[POKEMON] can't use [MOVE]!",
+		cantNoMove: "[POKEMON] can't move!",
 		fail: "  But it failed!",
 
 		// n.b. this is the default message for in-battle forme changes

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -327,7 +327,7 @@ class BattleTextParser {
 				[pokemon, kwArgs.of] = [kwArgs.of, pokemon];
 				break;
 			}
-			const template = this.template('cant', effect);
+			const template = this.template(move ? 'cant' : 'cantNoMove', effect);
 			const line1 = this.maybeAbility(effect, kwArgs.of || pokemon);
 			return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[MOVE]', move);
 		}


### PR DESCRIPTION
In Gen 1, partial trapping prevents you from moving. The old code used to check whether a move had been provided and if so display "can't move" instead of "can't use " + move. However I guess the right way to do this is to add a "partiallytrapped" effect template instead.