### PR TITLE
Fix Reflect Type copying types

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -2088,14 +2088,17 @@ class Battle {
 			this.activateAbility(ofpoke || poke, fromeffect);
 			switch (effect.id) {
 			case 'typechange':
-				const types = Tools.sanitizeName(args[3] || '???');
-				poke.removeVolatile('typeadd' as ID);
-				poke.addVolatile('typechange' as ID, types);
-				if (kwArgs.silent) {
-					this.scene.updateStatbar(poke);
-					break;
+				if (ofpoke && fromeffect.id == 'reflecttype') {
+					poke.copyTypesFrom(ofpoke);
+				} else {
+					const types = Tools.sanitizeName(args[3] || '???');
+					poke.removeVolatile('typeadd' as ID);
+					poke.addVolatile('typechange' as ID, types);
+					if (!kwArgs.silent) {
+						this.scene.typeAnim(poke, types);
+					}
 				}
-				this.scene.typeAnim(poke, types);
+				this.scene.updateStatbar(poke);
 				break;
 			case 'typeadd':
 				const type = Tools.sanitizeName(args[3]);


### PR DESCRIPTION
I'm not sure that Reflect Type ever animated the new types.

Example replay: [Turn 15](https://replay.pokemonshowdown.com/gen7hackmonscup-826853073).