### PR TITLE
No target uses generic fail message in Gen 5 or later

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -859,7 +859,7 @@ class BattleTextParser {
 		}
 
 		case '-notarget': {
-			return this.template('noTarget');
+			return this.template(this.gen >= 5 ? 'fail' : 'noTarget');
 		}
 
 		case '-mega': case '-primal': {


### PR DESCRIPTION
This quirk got lost in the text parser rewrite.