### PR TITLE
Ability activations have no default message

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -639,6 +639,7 @@ class BattleTextParser {
 			}
 			let template = this.template(templateId, effect, 'NODEFAULT');
 			if (!template) {
+				if (line1) return line1; // Abilities don't have a default template
 				template = this.template('activate');
 				return line1 + template.replace('[EFFECT]', this.effect(effect));
 			}


### PR DESCRIPTION
Of the 29 (if I counted correctly) Abilities that use '-activate', 15 of them have a custom message, while the other 14 only use it for the "[Pokémon's ability]" and don't want a default message.

For instance, suppose Gligar uses Toxic against Mew, then the expected battle log is as follows:

Gligar used **Toxic**!
The opposing Mew was badly poisoned!
[The opposing Mew's Synchronize]
[Gligar's Immunity]
It doesn't affect Gligar...

Here, Gligar's Immunity activates on an '-immune' rather than on '-activate', but Mew's Synchronize has to be an '-activate', since there's nothing for it to attach to.