### PR TITLE
Restore Mind Blown recoil message

### DIFF
--- a/data/text.js
+++ b/data/text.js
@@ -943,6 +943,9 @@ exports.BattleText = {
 	magicbounce: {
 		move: '#magiccoat',
 	},
+	mindblown: {
+		damage: "  ([POKEMON] cut its own HP to power up its move!)",
+	},
 	moldbreaker: {
 		start: "  [POKEMON] breaks the mold!",
 	},


### PR DESCRIPTION
The old code actually used "because of [effect.name]" but I'm not sure how that would be implemented.