### PR TITLE
Fix target of future sight message

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -382,7 +382,7 @@ class BattleTextParser {
 			let id = this.effectId(effect);
 			if (id === 'doomdesire' || id === 'futuresight') {
 				const template = this.template('activate', effect);
-				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[TARGET]', this.pokemon(kwArgs.of));
+				return line1 + template.replace('[TARGET]', this.pokemon(pokemon));
 			}
 			let templateId = 'end';
 			let template = '';


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/7977870). The message only appears to have one placeholder, which is fortunate since the server only sends the target anyway.