### PR TITLE
-anim should only animate

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1193,12 +1193,6 @@ class Battle {
 			pokemon.removeTurnstatus('focuspunch' as ID);
 		}
 		this.scene.updateStatbar(pokemon);
-		if (!target) {
-			target = pokemon.side.foe.active[0];
-		}
-		if (!target) {
-			target = pokemon.side.foe.missedPokemon;
-		}
 		if (fromeffect.id === 'sleeptalk') {
 			pokemon.rememberMove(move.name, 0);
 		} else if (!fromeffect.id || fromeffect.id === 'pursuit') {
@@ -1218,6 +1212,19 @@ class Battle {
 			}
 			let pp = (target && target.side !== pokemon.side && toId(target.ability) === 'pressure' ? 2 : 1);
 			pokemon.rememberMove(moveName, pp);
+		}
+		pokemon.lastMove = move.id;
+		this.lastMove = move.id;
+		if (move.id === 'wish' || move.id === 'healingwish') {
+			pokemon.side.wisher = pokemon;
+		}
+	}
+	animateMove(pokemon: Pokemon, move: Move, target: Pokemon | null, kwArgs: {[k: string]: string}) {
+		if (!target) {
+			target = pokemon.side.foe.active[0];
+		}
+		if (!target) {
+			target = pokemon.side.foe.missedPokemon;
 		}
 		if (!this.fastForward && !kwArgs.still) {
 			// skip
@@ -1249,11 +1256,6 @@ class Battle {
 					this.scene.runMoveAnim(usedMove.id, [pokemon, target]);
 				}
 			}
-		}
-		pokemon.lastMove = move.id;
-		this.lastMove = move.id;
-		if (move.id === 'wish' || move.id === 'healingwish') {
-			pokemon.side.wisher = pokemon;
 		}
 	}
 	cantUseMove(pokemon: Pokemon, effect: Effect, move: Move, kwArgs: {[k: string]: string}) {
@@ -2608,8 +2610,7 @@ class Battle {
 			if (this.checkActive(poke)) return;
 			let poke2 = this.getPokemon(args[3]);
 			this.scene.beforeMove(poke);
-			kwArgs.silent = '.';
-			this.useMove(poke, move, poke2, kwArgs);
+			this.animateMove(poke, move, poke2, kwArgs);
 			this.scene.afterMove(poke);
 			break;
 		}
@@ -3125,6 +3126,7 @@ class Battle {
 			let poke2 = this.getPokemon(args[3]);
 			this.scene.beforeMove(poke);
 			this.useMove(poke, move, poke2, kwArgs);
+			this.animateMove(poke, move, poke2, kwArgs);
 			this.log(args, kwArgs);
 			this.scene.afterMove(poke);
 			break;


### PR DESCRIPTION
As part of commit fc603c0 the `useMove` code so that used to actually log the message got refactored out. As such, the `kwArgs.silent` guard was also removed. However, the `-anim` code was relying on the side effect of setting `kwArgs.silent` to suppress the other bookkeeping that `useMove` does, such as deducting PP. As such, `-anim` now causes a deduction of PP. This is particularly noticeable in Super Staff Bros Brawl but also anywhere `-anim` is used such as for Solar Beam in Sun.

To simplify the code, I've split the bookkeeping away from the animation so that `useMove` now calls both (and also the message logging) while `-anim` now just invokes the animation.