### PR TITLE
Fix message for Jaboca and Rowap Berry

### DIFF
--- a/data/text.js
+++ b/data/text.js
@@ -63,7 +63,7 @@ exports.BattleText = {
 
 		damage: "  ([POKEMON] was hurt!)",
 		damagePercentage: "  ([POKEMON] lost [PERCENTAGE] of its health!)",
-		damageFromPokemon: "  [POKEMON] is hurt by [SOURCE]'s [EFFECT]!",
+		damageFromPokemon: "  [POKEMON] is hurt by [SOURCE]'s [ITEM]!", // Jaboca/Rowap Berry
 		damageFromItem: "  [POKEMON] is hurt by its [ITEM]!", // Sticky Barb
 		damageFromPartialTrapping: "  [POKEMON] is hurt by [MOVE]!",
 		heal: "  [POKEMON] restored its HP.",

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -689,8 +689,8 @@ class BattleTextParser {
 				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[PERCENTAGE]', percentage);
 			}
 			if (kwArgs.from.startsWith('item:')) {
-				template = this.template('damageFromItem');
-				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[ITEM]', this.effect(kwArgs.from));
+				template = this.template(kwArgs.of ? 'damageFromPokemon' : 'damageFromItem');
+				return line1 + template.replace('[POKEMON]', this.pokemon(pokemon)).replace('[ITEM]', this.effect(kwArgs.from)).replace('[SOURCE]', this.pokemon(kwArgs.of));
 			}
 			if (kwArgs.partiallytrapped || id === 'bind' || id === 'wrap') {
 				template = this.template('damageFromPartialTrapping');


### PR DESCRIPTION
Currently it's acting as if the victim of the damage was holding the berry.

I couldn't think of any other effects that should use that message.