### PR TITLE
Fix Forewarn and Symbiosis

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -599,7 +599,7 @@ class BattleTextParser {
 			} else if (!arg4 && [
 				'grudge', 'forewarn', 'magnitude', 'sketch', 'persistent', 'symbiosis', 'safetygoggles', 'matblock', 'safetygoggles', 'leppaberry',
 			].includes(id)) {
-				[target, arg4] = [pokemon, target];
+				[target, arg4] = [kwArgs.of, target];
 			} else if (!target && ['hyperspacefury', 'hyperspacehole', 'phantomforce', 'shadowforce', 'feint'].includes(id)) {
 				[pokemon, target] = [kwArgs.of, pokemon];
 				if (!pokemon) pokemon = target;


### PR DESCRIPTION
Both currently send the target in `kwArgs.of`; `pokemon` is definitely not the target here! (The other effects listed don't use `[TARGET]` anyway so they don't care.)