### PR TITLE
Fix Fairy Lock for replays

### DIFF
--- a/data/text.js
+++ b/data/text.js
@@ -456,7 +456,7 @@ exports.BattleText = {
 		activate: "  [POKEMON] endured the hit!",
 	},
 	fairylock: {
-		start: "  No one will be able to run away during the next turn!",
+		activate: "  No one will be able to run away during the next turn!",
 	},
 	feint: {
 		activate: "  [TARGET] fell for the feint!",

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -77,9 +77,13 @@ class BattleTextParser {
 			}
 
 			if ([
-				'bind', 'wrap', 'clamp', 'whirlpool', 'firespin', 'magmastorm', 'sandtomb', 'infestation', 'charge', 'fairylock', 'trapped',
+				'bind', 'wrap', 'clamp', 'whirlpool', 'firespin', 'magmastorm', 'sandtomb', 'infestation', 'charge', 'trapped',
 			].includes(id)) {
 				return {args: ['-start', pokemon, effect], kwArgs: {of: target}};
+			}
+
+			if (id === 'fairylock') {
+				return {args: ['-fieldactivate', effect], kwArgs: {}};
 			}
 
 			if (id === 'symbiosis') {


### PR DESCRIPTION
Reported [here](https://www.smogon.com/forums/posts/8010364), with [replay](https://replay.pokemonshowdown.com/gen7metronomebattle-847846848).

Fairy Lock is a field effect, so it shouldn't be using `-activate` or `-start`.

I'll file a PR to fix the server to use `-fieldactivate` directly.

(Trying to use `-fieldstart` would be awkward, as that's designed for 5-turn effects.)