### PR TITLE
Clear statbar of lingering expired turn statuses

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -294,6 +294,7 @@ class Pokemon {
 			this.removeTurnstatus(id as ID);
 		}
 		this.turnstatuses = {};
+		this.side.battle.scene.updateStatbar(this);
 	}
 	removeMovestatus(volatile: ID) {
 		this.side.battle.scene.removeEffect(this, volatile);


### PR DESCRIPTION
The statbar wasn't actually being updated immediately, so the status marker only disappeared during the animations of the next turn.