### PR TITLE
Teambuilder: Fix no moves displayed for visual formes

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -632,8 +632,11 @@
 	Search.prototype.nextLearnsetid = function (learnsetid, speciesid) {
 		if (!speciesid) {
 			if (learnsetid in BattleTeambuilderTable.learnsets) return learnsetid;
-			learnsetid = toId(BattlePokedex[learnsetid].baseSpecies);
-			if (learnsetid in BattleTeambuilderTable.learnsets) return learnsetid;
+			var baseLearnsetid = BattlePokedex[learnsetid] && toId(BattlePokedex[learnsetid].baseSpecies);
+			if (!baseLearnsetid) {
+				baseLearnsetid = toId(BattleAliases[learnsetid]);
+			}
+			if (baseLearnsetid in BattleTeambuilderTable.learnsets) return baseLearnsetid;
 			return '';
 		}
 


### PR DESCRIPTION
No moves were being displayed for stuff like Sawsbuck-Autumn or Gastrodon-East, since they don't have entries in pokedex.js, so we need to check the aliases as well.