### PR TITLE
Teambuilder: Make Trick Room first result for 'TR'

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -164,7 +164,7 @@
 		// the alias text before any other passes.
 		var queryAlias;
 		if (query in BattleAliases) {
-			if (query === 'sub' || toId(BattleAliases[query]).slice(0, query.length) !== query) {
+			if (['sub', 'tr'].includes(query) || toId(BattleAliases[query]).slice(0, query.length) !== query) {
 				queryAlias = toId(BattleAliases[query]);
 				var aliasPassType = (queryAlias === 'hiddenpower' ? 4 : 1);
 				searchPasses.unshift([aliasPassType, Search.getClosest(queryAlias), queryAlias]);


### PR DESCRIPTION
"TR" is an alias of Trick Room, but it was being skipped because Trick Room itself starts with these letters and it wasn't included in the exceptions.
The second condition is apparently needed to prevent duplicate results, but move results don't get duplicated and that's why we can do this? I'm not sure I understand how it works exactly but this seems to work.