### PR TITLE
Fix PP in tooltips (Trump Card, Pressure)

### DIFF
--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -823,7 +823,7 @@ var BattleTooltips = (function () {
 			if (!move.noPPBoosts) maxpp = Math.floor(maxpp * 8 / 5);
 		}
 		if (ppUsed === Infinity) return move.name + ' <small>(0/' + maxpp + ')</small>';
-		if (ppUsed || moveName.charAt(0) === '*') return move.name + ' <small>(' + (maxpp - ppUsed) + '/' + maxpp + ')</small>';
+		if (ppUsed || moveName.charAt(0) === '*') return move.name + ' <small>(' + Math.max(maxpp - ppUsed, 0) + '/' + maxpp + ')</small>';
 		return move.name + (showKnown ? ' <small>(revealed)</small>' : '');
 	};
 

--- a/js/client-battle-tooltips.js
+++ b/js/client-battle-tooltips.js
@@ -820,7 +820,7 @@ var BattleTooltips = (function () {
 				var table = BattleTeambuilderTable['gen' + this.battle.gen];
 				if (move.id in table.overridePP) maxpp = table.overridePP[move.id];
 			}
-			maxpp = Math.floor(maxpp * 8 / 5);
+			if (!move.noPPBoosts) maxpp = Math.floor(maxpp * 8 / 5);
 		}
 		if (ppUsed === Infinity) return move.name + ' <small>(0/' + maxpp + ')</small>';
 		if (ppUsed || moveName.charAt(0) === '*') return move.name + ' <small>(' + (maxpp - ppUsed) + '/' + maxpp + ')</small>';


### PR DESCRIPTION
- Trump Card now shows as having 5 PP in tooltips as it does on the simulator
- Pressure won't cause tooltips to show -1 PP anymore