### PR TITLE
Add https://randbatscalc.github.io/ to URL whitelist

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -68,6 +68,7 @@ Config.whitelist = [
 	'gamepress\\.gg',
 	'trainertower\\.com',
 	'pokepast\\.es',
+	'randbatscalc\\.github\\.io',
 
 	// personal sites
 	'breakdown\\.forumotion\\.com',


### PR DESCRIPTION
Smoochyena: /rcalc brings up a link to the randbats damage calc
Smoochyena: but when you click on the link it puts you through the interstice
Smoochyena: any way that could be removed to go directly to the calc?