### PR TITLE
Fix Pokemon being shown as having their current abilities in older gens

### DIFF
--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -762,6 +762,8 @@ class ModdedDex {
 			}
 			if (this.gen < 5) delete abilities['H'];
 			if (this.gen < 7) delete abilities['S'];
+
+			data.abilities = abilities;
 		}
 		if (id in table.overrideStats) {
 			data.baseStats = {...data.baseStats, ...table.overrideStats[id]};


### PR DESCRIPTION
After being run through `overrideAbility `and `removeSecondAbility`, the updated abilities were never actually written back into the data.