### PR TITLE
Tooltips: Fix item boosts not showing up

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -1442,6 +1442,9 @@ class BattleTooltips {
 			}
 		}
 
+		// Item
+		value = this.getItemBoost(move, value, moveType);
+
 		return value;
 	}
 


### PR DESCRIPTION
`getItemBoost()` existed, but was never actually called.