### PR TITLE
Fix missing message for Queenly Majesty blocking a move

### DIFF
--- a/data/text.js
+++ b/data/text.js
@@ -1019,6 +1019,9 @@ exports.BattleText = {
 	pressure: {
 		start: "  [POKEMON] is exerting its pressure!",
 	},
+	queenlymajesty: {
+		block: "#damp",
+	},
 	rebound: {
 		move: '#magiccoat',
 	},


### PR DESCRIPTION
Example reply: https://replay.pokemonshowdown.com/gen7balancedhackmons-867946763 (turn 10).

Commit 2b14006 seems to have accidentally completely removed the message for Queenly Majesty.