### PR TITLE
Fix activation of Mummy

### DIFF
--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -735,6 +735,13 @@ class BattleTextParser {
 				return line1 + template.replace('[POKEMON]', this.pokemon(kwArgs.of)).replace('[SOURCE]', this.pokemon(pokemon));
 			}
 
+			if (id === 'mummy') {
+				line1 += this.ability(kwArgs.ability, target);
+				line1 += this.ability('Mummy', target);
+				const template = this.template('changeAbility', 'mummy');
+				return line1 + template.replace('[TARGET]', this.pokemon(target));
+			}
+
 			let templateId = 'activate';
 			if (id === 'forewarn' && pokemon === target) {
 				templateId = 'activateNoTarget';
@@ -754,10 +761,6 @@ class BattleTextParser {
 			}
 			if (kwArgs.ability2) {
 				line1 += this.ability(kwArgs.ability2, target);
-			}
-			if (id === 'mummy') {
-				line1 += this.ability("Mummy", target);
-				template = this.template('changeAbility', "Mummy");
 			}
 			if (kwArgs.move || kwArgs.number || kwArgs.item) {
 				template = template.replace('[MOVE]', kwArgs.move).replace('[NUMBER]', kwArgs.number).replace('[ITEM]', kwArgs.item);


### PR DESCRIPTION
Report: https://www.smogon.com/forums/posts/8050534

As I understand it, the log should look as follows:

[POKEMON's Mummy]  
[TARGET's ABILITY]  
[TARGET's MUMMY]  
TARGET's Ability became Mummy!

However this never happens because Mummy doesn't have an activation message and so the code early returns before it can reach the special case for Mummy, and the code also activates the abilities on the wrong target anyway (because that's really for Skill Swap which works differently).