### PR TITLE
Add Ctrl+` as a keyboard shortcut for ``code``

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -129,6 +129,11 @@
 					e.preventDefault();
 					e.stopPropagation();
 				}
+			} else if (e.keyCode === 192 && cmdKey) { // Ctrl + ` key
+				if (ConsoleRoom.toggleFormatChar(textbox, '`')) {
+					e.preventDefault();
+					e.stopPropagation();
+				}
 			} else if (e.keyCode === 33) { // Pg Up key
 				this.$chatFrame.scrollTop(this.$chatFrame.scrollTop() - this.$chatFrame.height() + 60);
 			} else if (e.keyCode === 34) { // Pg Dn key

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -612,7 +612,7 @@
 			var ctrlPlus = '<kbd>' + (navigator.platform === 'MacIntel' ? 'Cmd' : 'Ctrl') + '</kbd> + ';
 			buf += '<p class="optlabel">**<strong>bold</strong>** (' + ctrlPlus + '<kbd>B</kbd>)</p>';
 			buf += '<p class="optlabel">__<em>italics</em>__ (' + ctrlPlus + '<bkd>I</kbd>)</p>';
-			buf += '<p class="optlabel">``<code>code formatting</code>`` (' + ctrlPlus + '<bkd>`</kbd>)</p>';
+			buf += '<p class="optlabel">``<code>code formatting</code>`` (<kbd>Ctrl</kbd> + <kbd>`</kbd>)</p>';
 			buf += '<p class="optlabel">~~<s>strikethrough</s>~~</p>';
 			buf += '<p class="optlabel">^^<sup>superscript</sup>^^</p>';
 			buf += '<p class="optlabel">\\\\<sub>subscript</sub>\\\\</p>';

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -612,7 +612,7 @@
 			var ctrlPlus = '<kbd>' + (navigator.platform === 'MacIntel' ? 'Cmd' : 'Ctrl') + '</kbd> + ';
 			buf += '<p class="optlabel">**<strong>bold</strong>** (' + ctrlPlus + '<kbd>B</kbd>)</p>';
 			buf += '<p class="optlabel">__<em>italics</em>__ (' + ctrlPlus + '<bkd>I</kbd>)</p>';
-			buf += '<p class="optlabel">``<code>code formatting</code>``</p>';
+			buf += '<p class="optlabel">``<code>code formatting</code>`` (' + ctrlPlus + '<bkd>`</kbd>)</p>';
 			buf += '<p class="optlabel">~~<s>strikethrough</s>~~</p>';
 			buf += '<p class="optlabel">^^<sup>superscript</sup>^^</p>';
 			buf += '<p class="optlabel">\\\\<sub>subscript</sub>\\\\</p>';


### PR DESCRIPTION
One misleading thing is the 'Usable Formatting' information says to use `Cmd + <X>` because I'm on a Mac, but both `Cmd + <X>` and `Ctrl + <X>` (for `X = B or I`) work on my machine, but the 'grave accent' (I don't know how to escape it in GH markdown! :P) only works with `Ctrl`