### PR TITLE
Fix battle playback state after using /afd

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -917,9 +917,11 @@
 					var battle = app.rooms[roomid] && app.rooms[roomid].battle;
 					if (!battle) continue;
 					var turn = battle.turn;
+					var oldState = battle.playbackState;
+					if (oldState === 4) turn = -1;
 					battle.reset(true);
 					battle.fastForwardTo(turn);
-					if (battle.playbackState !== 3) {
+					if (oldState !== 3) {
 						battle.play();
 					} else {
 						battle.pause();


### PR DESCRIPTION
Resetting the battle also resets the playback state, so it needs to be extracted before that.
If the battle is finished, fast-forward directly to the end so it doesn't redo the last turn's animations needlessly.