### PR TITLE
Teambuilder: Fix changed hidden abilities in older gens

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -718,6 +718,8 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 		BattleTeambuilderTable[gen].overrideType = overrideType;
 		const overrideAbility = {};
 		BattleTeambuilderTable[gen].overrideAbility = overrideAbility;
+		const overrideHiddenAbility = {};
+		BattleTeambuilderTable[gen].overrideHiddenAbility = overrideHiddenAbility;
 		const removeSecondAbility = {};
 		BattleTeambuilderTable[gen].removeSecondAbility = removeSecondAbility;
 		for (const id in genData.Pokedex) {
@@ -736,6 +738,9 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			}
 			if (pastEntry.abilities['0'] !== nowEntry.abilities['0']) {
 				overrideAbility[id] = pastEntry.abilities['0'];
+			}
+			if (pastEntry.abilities['H'] !== nowEntry.abilities['H']) {
+				overrideHiddenAbility[id] = pastEntry.abilities['H'];
 			}
 			// in the gen 3 dex, Pokemon already have the abilities that were added in gen 4
 			const hasAbilityFromNewerGen = Dex.getTemplate(id).gen <= genNum && Dex.getAbility(pastEntry.abilities['1']).gen > genNum;

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -771,6 +771,9 @@ class ModdedDex {
 			if (id in table.removeSecondAbility) {
 				delete abilities['1'];
 			}
+			if (id in table.overrideHiddenAbility) {
+				abilities['H'] = table.overrideHiddenAbility[id];
+			}
 			if (this.gen < 5) delete abilities['H'];
 			if (this.gen < 7) delete abilities['S'];
 


### PR DESCRIPTION
This is relevant for the Scolipede line (used to have Quick Feet instead of Speed Boost) and Aurumoth (used to have Illusion instead of Light Metal).

I don't know if just slapping new properties into the teambuilder tables like this is the best solution, but it works at least.