### PR TITLE
Fix possible error in spread move animation

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1356,7 +1356,7 @@ class Battle {
 			targets.push(target.side.missedPokemon);
 		} else {
 			for (const hitTarget of kwArgs.spread.split(',')) {
-				targets.push(this.getPokemon(hitTarget + ': ?')!);
+				targets.push(this.getPokemon(hitTarget)!);
 			}
 		}
 


### PR DESCRIPTION
I don't know what that `': ?'` was supposed to be for, it's been there since this feature was implemented 3 years ago, but I found no use for it in the current code.
Adding it to the end of the target breaks things when there is an identity where the slot is not specific enough to identify the target on its own, so it will have to resort to comparing idents. The added suffix will make it not find a match.
Currently, this causes a big ugly client error message when using Mind Blown in Doubles.