### PR TITLE
Fix modified stat display for Spc

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -736,18 +736,22 @@ class BattleTooltips {
 	calculateModifiedStats(clientPokemon: Pokemon | null, serverPokemon: ServerPokemon) {
 		let stats = {...serverPokemon.stats};
 		let pokemon = clientPokemon || serverPokemon;
-		for (const statName of Dex.statNamesExceptHP) {
-			stats[statName] = serverPokemon.stats[statName];
-
-			if (clientPokemon && clientPokemon.boosts[statName]) {
-				let boostTable = [1, 1.5, 2, 2.5, 3, 3.5, 4];
-				if (clientPokemon.boosts[statName] > 0) {
-					stats[statName] *= boostTable[clientPokemon.boosts[statName]];
-				} else {
-					if (this.battle.gen <= 2) boostTable = [1, 100 / 66, 2, 2.5, 100 / 33, 100 / 28, 4];
-					stats[statName] /= boostTable[-clientPokemon.boosts[statName]];
+		
+		if (clientPokemon && clientPokemon.boosts) {
+      	for (const statName in clientPokemon.boosts) {
+      		const boost = clientPokemon.boosts[statName];
+      		const targetStat = statName == 'spc' ? 'spa' : statName;
+      		
+				if (stats[targetStat]) {
+      			let boostTable = [1, 1.5, 2, 2.5, 3, 3.5, 4];
+					if (boost > 0) {
+						stats[targetStat] *= boostTable[boost];
+					} else {
+						if (this.battle.gen <= 2) boostTable = [1, 100 / 66, 2, 2.5, 100 / 33, 100 / 28, 4];
+						stats[targetStat] /= boostTable[-boost];
+					}
+      			stats[targetStat] = Math.floor(stats[targetStat]);
 				}
-				stats[statName] = Math.floor(stats[statName]);
 			}
 		}
 


### PR DESCRIPTION
This fixes a big where tooltips don't show stat changes to Special in gen 1 games.

`serverPokemon.stats` uses `spa` to store the special stat, but `clientPokemon.boosts` uses `spc`.
`Dex.statNamesExceptHP` also does not include `spc`, so the original iteration would have skipped it anyway.