### PR TITLE
Don't include the ! in away status display

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -939,7 +939,7 @@
 					this.receive(data.substr(nlIndex + 1));
 					parts = data.slice(1, nlIndex).split('|');
 				}
-				var parsed = BattleTextParser.parseNameParts(parts[1]);
+				var parsed = BattleTextParser.parseNameParts(parts[1].slice(1));
 				var named = !!+parts[2];
 
 				var userid = toUserid(parsed.name);

--- a/js/client.js
+++ b/js/client.js
@@ -939,7 +939,7 @@
 					this.receive(data.substr(nlIndex + 1));
 					parts = data.slice(1, nlIndex).split('|');
 				}
-				var parsed = BattleTextParser.parseNameParts(parts[1].slice(1));
+				var parsed = BattleTextParser.parseNameParts(parts[1]);
 				var named = !!+parts[2];
 
 				var userid = toUserid(parsed.name);

--- a/src/battle-log.ts
+++ b/src/battle-log.ts
@@ -383,9 +383,6 @@ class BattleLog {
 		if (this.colorCache[name]) return this.colorCache[name];
 		let hash;
 		if (window.Config && Config.customcolors && Config.customcolors[name]) {
-			if (Config.customcolors[name].color) {
-				return (this.colorCache[name] = Config.customcolors[name].color);
-			}
 			hash = MD5(Config.customcolors[name]);
 		} else {
 			hash = MD5(name);

--- a/src/battle-text-parser.ts
+++ b/src/battle-text-parser.ts
@@ -58,6 +58,12 @@ class BattleTextParser {
 	}
 
 	static parseNameParts(text: string) {
+		let rank: string | undefined;
+		// Names cannot start with symbols, so if we do see a symbol then we know it is the user's rank.
+		if (text.match(/^A-Za-z0-9/)) {
+			rank = text.charAt(0);
+			text = text.slice(1);
+		}
 		const atIndex = text.indexOf('@');
 		let name = text;
 		let status = '';
@@ -70,7 +76,7 @@ class BattleTextParser {
 				status = status.substr(1);
 			}
 		}
-		return {name, status, away};
+		return {rank, name, status, away};
 	}
 
 	static upgradeArgs({args, kwArgs}: {args: Args, kwArgs: KWArgs}): {args: Args, kwArgs: KWArgs} {


### PR DESCRIPTION
https://github.com/Zarel/Pokemon-Showdown/pull/5002/commits/e373c1d026ef4f70a3ee25c133dacfbf0333ef93 will cause the rank to sometimes be erroneously displayed in the UI: 

<img width="166" alt="Screen Shot 2019-05-27 at 15 40 42" src="https://user-images.githubusercontent.com/117249/58441320-f1fec980-8095-11e9-8ad7-59cc0affe6da.png">
<img width="243" alt="Screen Shot 2019-05-27 at 15 41 15" src="https://user-images.githubusercontent.com/117249/58441321-f3c88d00-8095-11e9-9c8c-c913de56c82e.png">

Zarel/Pokemon-Showdown#5002 will not _break_ the client when it lands, but to preserve the current display semantics **this PR should be committed and pushed in coordination with the server restart that  deploys the protocol change**. I've marked this change as 'DO NOT MERGE' because if deployed without the server change it will result in lopping off the first character of usernames, which is clearly undesirable.