### PR TITLE
Fix groundedness check

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -498,7 +498,8 @@ class Pokemon implements PokemonDetails, PokemonHealth {
 		}
 		if (this.volatiles['magnetrise'] || this.volatiles['telekinesis']) {
 			return false;
-		} else if (item !== 'airballoon') {
+		}
+		if (item === 'airballoon') {
 			return false;
 		}
 		return !this.getTypeList(serverPokemon).includes('Flying');


### PR DESCRIPTION
`Pokemon#isGrounded` was erroneously returning `false` in a lot of cases because of a flipped operator, which mostly showed itself in moves lacking their terrain boosts.

I suppose the choice between using `else if` and just chaining `if`s with early returns here is a matter of taste, I switched to the latter because that makes it consistent with the conditions immediately above, and the previous inconsistency was more confusing to read at a glance.