### PR TITLE
Fix crash with tournament preferences

### DIFF
--- a/js/client.js
+++ b/js/client.js
@@ -410,7 +410,7 @@
 					// Support legacy tournament setting and migrate to new pref
 					if (Dex.prefs('notournaments')) {
 						Dex.prefs('tournaments', Dex.prefs('notournaments') ? 'hide' : 'notify');
-						Storage.removeItem('notournaments');
+						Dex.prefs('notournaments', null);
 					}
 					var autojoin = (Dex.prefs('autojoin') || '');
 					var autojoinIds = [];


### PR DESCRIPTION
Self explanitory. User's clients are crashing when they load up so this is high priority.