### PR TITLE
Make `getTemplate` able to override tiers for Doubles

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -1319,15 +1319,8 @@
 
 		// number
 		// buf += '<span class="col numcol">' + (pokemon.num >= 0 ? pokemon.num : 'CAP') + '</span> ';
-		var tier;
-		if (pokemon.tier) {
-			tier = Dex.getTier(Dex.forGen(this.gen).getTemplate(id), this.gen, this.isDoubles);
-		} else if (pokemon.forme && pokemon.forme.endsWith('Totem')) {
-			tier = Dex.getTier(Dex.forGen(this.gen).getTemplate(pokemon.species.slice(0, (pokemon.forme.startsWith('Alola') ? -6 : pokemon.baseSpecies.length + 1))), this.gen, this.isDoubles);
-		} else {
-			tier = Dex.getTier(Dex.forGen(this.gen).getTemplate(pokemon.baseSpecies), this.gen, this.isDoubles);
-		}
-		buf += '<span class="col numcol">' + tier + '</span> ';
+		pokemon = Dex.forGen(this.gen).getTemplate(id, this.isDoubles);
+		buf += '<span class="col numcol">' + pokemon.tier + '</span> ';
 
 		// icon
 		buf += '<span class="col iconcol">';

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -367,7 +367,7 @@ const Dex = new class implements ModdedDex {
 		return ability;
 	}
 
-	getTemplate(nameOrTemplate: string | Template | null | undefined): Template {
+	getTemplate(nameOrTemplate: string | Template | null | undefined, isDoubles: boolean = false): Template {
 		if (nameOrTemplate && typeof nameOrTemplate !== 'string') {
 			// TODO: don't accept Templates here
 			return nameOrTemplate;
@@ -397,6 +397,13 @@ const Dex = new class implements ModdedDex {
 			}
 			template = new Template(id, name, data);
 			window.BattlePokedex[id] = template;
+		}
+
+		if (isDoubles) {
+			const table = window.BattleTeambuilderTable[`gen${this.gen}doubles`];
+			if (table && id in table.overrideTier) {
+				template = {...template, tier: table.overrideTier[id]};
+			}
 		}
 
 		if (formid === id || !template.otherForms || !template.otherForms.includes(formid)) {

--- a/src/battle-dex.ts
+++ b/src/battle-dex.ts
@@ -421,31 +421,6 @@ const Dex = new class implements ModdedDex {
 		return template;
 	}
 
-	/** @deprecated */
-	getTier(pokemon: Template, gen = 7, isDoubles = false): string {
-		if (gen < 7) pokemon = this.forGen(gen).getTemplate(pokemon.id);
-		if (!isDoubles) return pokemon.tier;
-		let table = window.BattleTeambuilderTable;
-		if (table && table[`gen${this.gen}doubles`]) {
-			table = table[`gen${this.gen}doubles`];
-		}
-		if (!table) return pokemon.tier;
-
-		let id = pokemon.id;
-		if (id in table.overrideTier) {
-			return table.overrideTier[id];
-		}
-		if (id.slice(-5) === 'totem' && id.slice(0, -5) in table.overrideTier) {
-			return table.overrideTier[id.slice(0, -5)];
-		}
-		id = toID(pokemon.baseSpecies);
-		if (id in table.overrideTier) {
-			return table.overrideTier[id];
-		}
-
-		return pokemon.tier;
-	}
-
 	getType(type: any): Effect {
 		if (!type || typeof type === 'string') {
 			let id = toID(type) as string;


### PR DESCRIPTION
This lets `getTemplate` handle overriding tiers for Doubles. Doing it this way means we can remove `getTier` entirely.