### PR TITLE
Add analytics to track battle sound preferences

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -47,6 +47,8 @@
 			this.battle.startCallback = function () { self.updateControls(); };
 			this.battle.stagnateCallback = function () { self.updateControls(); };
 
+			if (window.ga) ga('send', 'event', 'Battle', 'join');
+
 			this.battle.play();
 		},
 		events: {

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -62,6 +62,7 @@
 			var muted = !Dex.prefs('mute');
 			Dex.prefs('mute', muted);
 			BattleSound.setMute(muted);
+			if (window.ga) ga('set', /* mute */ 'dimension1', muted);
 			app.topbar.$('button[name=openSounds]').html('<i class="' + (muted ? 'fa fa-volume-off' : 'fa fa-volume-up') + '"></i>');
 		},
 
@@ -404,6 +405,7 @@
 			var muted = !!e.currentTarget.checked;
 			Dex.prefs('mute', muted);
 			BattleSound.setMute(muted);
+			if (window.ga) ga('set', /* mute */ 'dimension1', muted);
 
 			if (!muted) {
 				this.$('.effect-volume').html('<label class="optlabel">Effect volume:</label><input type="range" min="0" max="100" step="1" name="effectvolume" value="' + (Dex.prefs('effectvolume') || 50) + '" />');

--- a/js/client.js
+++ b/js/client.js
@@ -451,6 +451,7 @@ function toId() {
 
 				var muted = Dex.prefs('mute');
 				BattleSound.setMute(muted);
+				if (window.ga) ga('set', /* mute */ 'dimension1', muted);
 
 				$('html').toggleClass('dark', !!Dex.prefs('dark'));
 


### PR DESCRIPTION
It seems like the mute preference (or any preference really) should be a [User-level scoped Custom Dimension](https://support.google.com/analytics/answer/2709828?hl=en) that gets updated when the pref gets updated (ie. set in `Storage.whenPrefsLoaded()` and when it's toggled), only this doesn't accomplish much because we need an event for the custom dimension to be sent with. We can't send this dimension with the `ga('send', 'pageview')` metric because that happens on page load, before we have prefs available (and also doesnt cover changes in the pref's value over the session). 

Instead, I've created a 'join battle' event (event category `'Battle'`, event action `'join'`, [per the documentation](https://developers.google.com/analytics/devguides/collection/analyticsjs/events#event_fields)), so that we could track what the sound preference was when the battle was joined. This doesn't cover the case where a user immediately mutes after joining a battle (something I often do), but I'm not sure what a good solution to that is.

**NOTE:** The custom dimension requires [additional setup in the Admin UI](https://support.google.com/analytics/answer/2709829).