### PR TITLE
Include group in join/leave messages

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -1472,7 +1472,7 @@
 				this.$chat.append('<div class="message"><small>Loading...</small></div>');
 				this.$joinLeave = this.$chat.children().last();
 			}
-			this.joinLeave[action].push(user.name);
+			this.joinLeave[action].push(user.group + user.name);
 			var message = '';
 			if (this.joinLeave['join'].length) {
 				var preList = this.joinLeave['join'];


### PR DESCRIPTION
Battle join/leave was fixed to include group in #1295, but apparently chat join/leave should show group as well.