### PR TITLE
Display Elo in rated battles

### DIFF
--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -625,8 +625,8 @@ class BattleScene {
 		pokemonhtml = '<div class="teamicons">' + pokemonhtml + '</div>';
 		const $sidebar = (side.n ? this.$rightbar : this.$leftbar);
 		if (side.name) {
-			const ratinghtml = side.rating ? `title="Rating: ${BattleLog.escapeHTML(side.rating)}` : ``;
-			$sidebar.html(`<div class="trainer" ${ratinghtml}><strong>${BattleLog.escapeHTML(side.name)}</strong><div class="trainersprite" style="background-image:url(${Dex.resolveAvatar(side.avatar)})"></div>${pokemonhtml}</div>`);
+			const ratinghtml = side.rating ? ` title="Rating: ${BattleLog.escapeHTML(side.rating)}` : ``;
+			$sidebar.html(`<div class="trainer"${ratinghtml}><strong>${BattleLog.escapeHTML(side.name)}</strong><div class="trainersprite" style="background-image:url(${Dex.resolveAvatar(side.avatar)})"></div>${pokemonhtml}</div>`);
 			$sidebar.find('.trainer').css('opacity', 1);
 		} else {
 			$sidebar.find('.trainer').css('opacity', 0.4);

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -625,8 +625,8 @@ class BattleScene {
 		pokemonhtml = '<div class="teamicons">' + pokemonhtml + '</div>';
 		const $sidebar = (side.n ? this.$rightbar : this.$leftbar);
 		if (side.name) {
-						const ratinghtml = side.rating ? `title="Rating: ${BattleLog.escapeHTML(side.rating)}` : ``;
-						$sidebar.html(`<div class="trainer" ${ratinghtml}><strong>${BattleLog.escapeHTML(side.name)}</strong><div class="trainersprite" style="background-image:url(${Dex.resolveAvatar(side.avatar)})"></div>${pokemonhtml}</div>`);
+			const ratinghtml = side.rating ? `title="Rating: ${BattleLog.escapeHTML(side.rating)}` : ``;
+			$sidebar.html(`<div class="trainer" ${ratinghtml}><strong>${BattleLog.escapeHTML(side.name)}</strong><div class="trainersprite" style="background-image:url(${Dex.resolveAvatar(side.avatar)})"></div>${pokemonhtml}</div>`);
 			$sidebar.find('.trainer').css('opacity', 1);
 		} else {
 			$sidebar.find('.trainer').css('opacity', 0.4);

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -625,7 +625,8 @@ class BattleScene {
 		pokemonhtml = '<div class="teamicons">' + pokemonhtml + '</div>';
 		const $sidebar = (side.n ? this.$rightbar : this.$leftbar);
 		if (side.name) {
-			$sidebar.html('<div class="trainer" ' + (side.rating ? 'title="Rating: ' + side.rating + "\">" : '>') + '<strong>' + BattleLog.escapeHTML(side.name) + '</strong><div class="trainersprite" style="background-image:url(' + Dex.resolveAvatar(side.avatar) + ')"></div>' + pokemonhtml + '</div>');
+						const ratinghtml = side.rating ? `title="Rating: ${BattleLog.escapeHTML(side.rating)}` : ``;
+						$sidebar.html(`<div class="trainer" ${ratinghtml}><strong>${BattleLog.escapeHTML(side.name)}</strong><div class="trainersprite" style="background-image:url(${Dex.resolveAvatar(side.avatar)})"></div>${pokemonhtml}</div>`);
 			$sidebar.find('.trainer').css('opacity', 1);
 		} else {
 			$sidebar.find('.trainer').css('opacity', 0.4);

--- a/src/battle-animations.ts
+++ b/src/battle-animations.ts
@@ -625,7 +625,7 @@ class BattleScene {
 		pokemonhtml = '<div class="teamicons">' + pokemonhtml + '</div>';
 		const $sidebar = (side.n ? this.$rightbar : this.$leftbar);
 		if (side.name) {
-			$sidebar.html('<div class="trainer"><strong>' + BattleLog.escapeHTML(side.name) + '</strong><div class="trainersprite" style="background-image:url(' + Dex.resolveAvatar(side.avatar) + ')"></div>' + pokemonhtml + '</div>');
+			$sidebar.html('<div class="trainer" ' + (side.rating ? 'title="Rating: ' + side.rating + "\">" : '>') + '<strong>' + BattleLog.escapeHTML(side.name) + '</strong><div class="trainersprite" style="background-image:url(' + Dex.resolveAvatar(side.avatar) + ')"></div>' + pokemonhtml + '</div>');
 			$sidebar.find('.trainer').css('opacity', 1);
 		} else {
 			$sidebar.find('.trainer').css('opacity', 0.4);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1130,7 +1130,11 @@ class Battle {
 	log(args: Args, kwArgs?: KWArgs, preempt?: boolean) {
 		this.scene.log.add(args, kwArgs, preempt);
 	}
-
+	showElo(name: string, elo: string) {
+		this.scene.log.addDiv('chat battle-history',
+			'<strong>' + BattleLog.escapeHTML(name) + (name.endsWith('s') ? '\'' : '\'s') + ' Elo: ' + elo + '</strong>'
+		);
+	}
 	resetToCurrentTurn() {
 		if (this.ended) {
 			this.reset(true);
@@ -3190,6 +3194,11 @@ class Battle {
 			if (!this.ignoreSpects) {
 				this.log(args, undefined, preempt);
 			}
+			break;
+		}
+		case 'elo': {
+			const [, name, elo] = args;
+			this.showElo(name, elo);
 			break;
 		}
 		case 'player': {

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -637,10 +637,10 @@ class Side {
 		}
 		if (this.battle.stagnateCallback) this.battle.stagnateCallback(this.battle);
 	}
-	showElo(elo: string) {
-		if (elo !== '0') {
+	showRating(rating: string) {
+		if (rating !== '0') {
 			this.battle.scene.log.addDiv('chat battle-history',
-				'<strong>' + BattleLog.escapeHTML(this.name) + (this.name.endsWith('s') ? '\'' : '\'s') + ' rating: ' + elo + '</strong>'
+				'<strong>' + BattleLog.escapeHTML(this.name) + (this.name.endsWith('s') ? '\'' : '\'s') + ' rating: ' + rating + '</strong>'
 			);
 		}
 	}
@@ -3203,7 +3203,7 @@ class Battle {
 			let side = this.getSide(args[1]);
 			side.setName(args[2]);
 			if (args[3]) side.setAvatar(args[3]);
-			if (args[4]) side.showElo(args[4]);
+			if (args[4]) side.showRating(args[4]);
 			this.scene.updateSidebar(side);
 			if (this.joinButtons) this.scene.hideJoinButtons();
 			this.log(args);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -627,9 +627,6 @@ class Side {
 	setAvatar(avatar: string) {
 		this.avatar = avatar;
 	}
-	setRating(rating: string) {
-		this.rating = rating;
-	}
 	setName(name: string, avatar?: string) {
 		if (name) this.name = name;
 		this.id = toID(this.name);
@@ -3200,7 +3197,7 @@ class Battle {
 			let side = this.getSide(args[1]);
 			side.setName(args[2]);
 			if (args[3]) side.setAvatar(args[3]);
-			if (args[4]) side.setRating(args[4]);
+			if (args[4]) side.rating = args[4];
 			this.scene.updateSidebar(side);
 			if (this.joinButtons) this.scene.hideJoinButtons();
 			this.log(args);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -569,6 +569,7 @@ class Side {
 	n: number;
 	foe: Side = null!;
 	avatar: string = 'unknown';
+	rating: string = '';
 	totalPokemon = 6;
 	x = 0;
 	y = 0;
@@ -626,6 +627,9 @@ class Side {
 	setAvatar(avatar: string) {
 		this.avatar = avatar;
 	}
+	setRating(rating: string) {
+		this.rating = rating;
+	}
 	setName(name: string, avatar?: string) {
 		if (name) this.name = name;
 		this.id = toID(this.name);
@@ -636,11 +640,6 @@ class Side {
 			if (this.foe && this.avatar === this.foe.avatar) this.rollTrainerSprites();
 		}
 		if (this.battle.stagnateCallback) this.battle.stagnateCallback(this.battle);
-	}
-	showRating(rating: string) {
-		this.battle.scene.log.addDiv('chat battle-history',
-			'<strong>' + BattleLog.escapeHTML(this.name) + (this.name.endsWith('s') ? '\'' : '\'s') + ' rating: ' + rating + '</strong>'
-		);
 	}
 	addSideCondition(effect: Effect) {
 		let condition = effect.id;
@@ -3201,7 +3200,7 @@ class Battle {
 			let side = this.getSide(args[1]);
 			side.setName(args[2]);
 			if (args[3]) side.setAvatar(args[3]);
-			if (args[4]) side.showRating(args[4]);
+			if (args[4]) side.setRating(args[4]);
 			this.scene.updateSidebar(side);
 			if (this.joinButtons) this.scene.hideJoinButtons();
 			this.log(args);

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -638,11 +638,9 @@ class Side {
 		if (this.battle.stagnateCallback) this.battle.stagnateCallback(this.battle);
 	}
 	showRating(rating: string) {
-		if (rating !== '0') {
-			this.battle.scene.log.addDiv('chat battle-history',
-				'<strong>' + BattleLog.escapeHTML(this.name) + (this.name.endsWith('s') ? '\'' : '\'s') + ' rating: ' + rating + '</strong>'
-			);
-		}
+		this.battle.scene.log.addDiv('chat battle-history',
+			'<strong>' + BattleLog.escapeHTML(this.name) + (this.name.endsWith('s') ? '\'' : '\'s') + ' rating: ' + rating + '</strong>'
+		);
 	}
 	addSideCondition(effect: Effect) {
 		let condition = effect.id;

--- a/src/battle.ts
+++ b/src/battle.ts
@@ -637,6 +637,13 @@ class Side {
 		}
 		if (this.battle.stagnateCallback) this.battle.stagnateCallback(this.battle);
 	}
+	showElo(elo: string) {
+		if (elo !== '0') {
+			this.battle.scene.log.addDiv('chat battle-history',
+				'<strong>' + BattleLog.escapeHTML(this.name) + (this.name.endsWith('s') ? '\'' : '\'s') + ' rating: ' + elo + '</strong>'
+			);
+		}
+	}
 	addSideCondition(effect: Effect) {
 		let condition = effect.id;
 		if (this.sideConditions[condition]) {
@@ -1130,11 +1137,7 @@ class Battle {
 	log(args: Args, kwArgs?: KWArgs, preempt?: boolean) {
 		this.scene.log.add(args, kwArgs, preempt);
 	}
-	showElo(name: string, elo: string) {
-		this.scene.log.addDiv('chat battle-history',
-			'<strong>' + BattleLog.escapeHTML(name) + (name.endsWith('s') ? '\'' : '\'s') + ' Elo: ' + elo + '</strong>'
-		);
-	}
+
 	resetToCurrentTurn() {
 		if (this.ended) {
 			this.reset(true);
@@ -3196,15 +3199,11 @@ class Battle {
 			}
 			break;
 		}
-		case 'elo': {
-			const [, name, elo] = args;
-			this.showElo(name, elo);
-			break;
-		}
 		case 'player': {
 			let side = this.getSide(args[1]);
 			side.setName(args[2]);
 			if (args[3]) side.setAvatar(args[3]);
+			if (args[4]) side.showElo(args[4]);
 			this.scene.updateSidebar(side);
 			if (this.joinButtons) this.scene.hideJoinButtons();
 			this.log(args);


### PR DESCRIPTION
Server Pull Request: Zarel/Pokemon-Showdown#5595

Suggested and approved here: https://www.smogon.com/forums/threads/3651687/

I did not implement the "make `/rank` only display the tier of the battle you're playing in" suggestion because you can use `/rank [player], [format]` or with this change it's even easier because you can just scroll up.