### PR TITLE
Tooltips: Fix weather checks for Primordial Sea/Desolate Land

### DIFF
--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -28,7 +28,8 @@ class ModifiableValue {
 		this.itemName = Dex.getItem(serverPokemon.item).name;
 		const ability = serverPokemon.ability || (pokemon && pokemon.ability) || serverPokemon.baseAbility;
 		this.abilityName = Dex.getAbility(ability).name;
-		this.weatherName = Dex.getMove(battle.weather).name;
+		this.weatherName = Dex.getMove(battle.weather).exists ?
+			Dex.getMove(battle.weather).name : Dex.getAbility(battle.weather).name;
 	}
 	reset(value = 0, isAccuracy?: boolean) {
 		this.value = value;


### PR DESCRIPTION
It always compares the weather by name, not id. Unlike Rain Dance etc, these are not moves, so getting the name requires `getAbility`ing them.