### PR TITLE
Fix Castform-Rainy

### DIFF
--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -500,7 +500,6 @@ const BattlePokemonIconIndexesLeft: {[id: string]: number} = {
 	roselia: 1044 + 37,
 	zangoose: 1044 + 38,
 	seviper: 1044 + 39,
-	castformrainy: 1044 + 40,
 	absolmega: 1044 + 41,
 	absol: 1044 + 42,
 	regirock: 1044 + 43,

--- a/src/battle-dex-data.ts
+++ b/src/battle-dex-data.ts
@@ -500,6 +500,7 @@ const BattlePokemonIconIndexesLeft: {[id: string]: number} = {
 	roselia: 1044 + 37,
 	zangoose: 1044 + 38,
 	seviper: 1044 + 39,
+	castformsnowy: 1044 + 40,
 	absolmega: 1044 + 41,
 	absol: 1044 + 42,
 	regirock: 1044 + 43,


### PR DESCRIPTION
Castform-Rainy's sprite is defined twice. Further, the second definition actually points to Castform-Snowy. This causes Castform-Rainy to appear as Castform-Snowy.

https://i.imgur.com/K9wS7K4.png