### PR TITLE
Desktop: Small package.json changes

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,8 +3,7 @@
   "version": "0.3.0",
 
   "main": "index.html",
-  "node-remote": "*://play.pokemonshowdown.com/*",
-  "no-edit-menu": false,
+  "node-remote": "https://play.pokemonshowdown.com/*",
   "window": {
 	  "icon": "icons/icon_32x32.png",
     "title": "Loading...",


### PR DESCRIPTION
Restrict node-remote to https as per suggestion in https://github.com/Zarel/Pokemon-Showdown-Client/pull/1246#discussion_r290869251

no-edit-menu defaults to false since v0.7.3 (https://github.com/nwjs/nw.js/wiki/Manifest-format#no-edit-menu) to current (http://docs.nwjs.io/en/latest/References/Manifest%20Format/#no-edit-menu-mac)