### PR TITLE
Support room highlights

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -232,10 +232,7 @@
 			return ((highlights.length > 0) && highlighRegExp.test(message));
 		},
 		convertHighlights: function (highlights) {
-			var newHLs = {global: []};
-			for (var i = 0; i < highlights.length; i++) {
-				newHLs.global.push(highlights[i]);
-			}
+			var newHLs = {global: highlights};
 			Dex.prefs('highlights', newHLs);
 		},
 		getHighlightRegExp: function (highlights) {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -208,14 +208,15 @@
 		// highlight
 
 		getHighlight: function (message) {
-			if (Array.isArray(Dex.prefs('highlights'))) {
+			var highlights = Dex.prefs('highlights') || {};
+			if (Array.isArray(highlights)) {
+				highlights = {global: highlights};
 				// Migrate from the old highlight system
-				Dex.prefs('highlights', {global: Dex.prefs('highlights')});
+				Dex.prefs('highlights', highlights);
 			}
 			if (!Dex.prefs('noselfhighlight') && app.user.nameRegExp) {
 				if (app.user.nameRegExp.test(message)) return true;
 			}
-			var highlights = Dex.prefs('highlights') || {};
 			if (!app.highlightRegExp) {
 				try {
 					this.updateHighlightRegExp(highlights);

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -211,9 +211,8 @@
 			if (Array.isArray(Dex.prefs('highlights'))) {
 				this.convertHighlights(Dex.prefs('highlights'));
 			}
-			var roomid = this.id;
 			var allHighlights = Dex.prefs('highlights') || {};
-			var roomHighlights = allHighlights[roomid] || [];
+			var roomHighlights = allHighlights[this.id] || [];
 			var globalHighlights = allHighlights['global'] || [];
 			var highlights = roomHighlights.concat(globalHighlights);
 			if (!Dex.prefs('noselfhighlight') && app.user.nameRegExp) {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -209,7 +209,8 @@
 
 		getHighlight: function (message) {
 			if (Array.isArray(Dex.prefs('highlights'))) {
-				this.convertHighlights(Dex.prefs('highlights'));
+				var newHLs = {global: Dex.prefs('highlights')};
+				Dex.prefs('highlights', newHLs);
 			}
 			var id = Config.server.id + '#' + this.id;
 			var allHighlights = Dex.prefs('highlights') || {};
@@ -230,10 +231,6 @@
 				return false;
 			}
 			return ((highlights.length > 0) && highlighRegExp.test(message));
-		},
-		convertHighlights: function (highlights) {
-			var newHLs = {global: highlights};
-			Dex.prefs('highlights', newHLs);
 		},
 		getHighlightRegExp: function (highlights) {
 			// Enforce boundary for match sides, if a letter on match side is

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -760,7 +760,6 @@
 						this.parseCommand('/help highlight'); // show help
 						return false;
 					}
-					console.log(highlights);
 					Dex.prefs('highlights', highlights);
 				} else {
 					if (target === 'delete') {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -726,7 +726,7 @@
 					}
 					switch (targets[0]) {
 					case 'add': case 'roomadd':
-						var key = targets[0] === 'roomadd' ? Config.server.id + '#' + this.id : 'global';
+						var key = targets[0] === 'roomadd' ? (Config.server.id + '#' + this.id) : 'global';
 						var highlightList = highlights[key] || [];
 						for (var i = 1, len = targets.length; i < len; i++) {
 							if (!targets[i]) continue;
@@ -748,7 +748,7 @@
 						this.updateHighlightRegExp(highlights);
 						break;
 					case 'delete': case 'roomdelete':
-						var key = targets[0] === 'roomdelete' ? Config.server.id + '#' + this.id : 'global';
+						var key = targets[0] === 'roomdelete' ? (Config.server.id + '#' + this.id) : 'global';
 						var highlightList = highlights[key] || [];
 						var newHls = [];
 						for (var i = 0, len = highlightList.length; i < len; i++) {
@@ -774,7 +774,7 @@
 						this.add("All highlights cleared");
 					} else if (['show', 'list', 'roomshow', 'roomlist'].includes(target)) {
 						// Shows a list of the current highlighting words
-						var key = target.startsWith('room') ? Config.server.id + '#' + this.id : 'global';
+						var key = target.startsWith('room') ? (Config.server.id + '#' + this.id) : 'global';
 						if (highlights[key].length > 0) {
 							this.add("Current highlight list " + (key === 'global' ? "(everywhere): " : "(in " + key + "): ") + highlights[key].join(", "));
 						} else {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -211,7 +211,7 @@
 			if (Array.isArray(Dex.prefs('highlights'))) {
 				this.convertHighlights(Dex.prefs('highlights'));
 			}
-			var roomid = toID(this.title);
+			var roomid = this.id;
 			var allHighlights = Dex.prefs('highlights') || {};
 			var roomHighlights = allHighlights[roomid] || [];
 			var globalHighlights = allHighlights['global'] || [];
@@ -727,7 +727,7 @@
 					}
 					switch (targets[0]) {
 					case 'add': case 'roomadd':
-						var key = targets[0] === 'roomadd' ? toID(this.title) : 'global';
+						var key = targets[0] === 'roomadd' ? this.id : 'global';
 						var highlightList = highlights[key] || [];
 						for (var i = 1, len = targets.length; i < len; i++) {
 							if (!targets[i]) continue;
@@ -747,7 +747,7 @@
 						this.add("Now highlighting on " + (key === 'global' ? "(everywhere): " : "(in " + key + "): ") + highlights[key].join(', '));
 						break;
 					case 'delete': case 'roomdelete':
-						var key = targets[0] === 'roomdelete' ? toID(this.title) : 'global';
+						var key = targets[0] === 'roomdelete' ? this.id : 'global';
 						var highlightList = highlights[key] || [];
 						var newHls = [];
 						for (var i = 0, len = highlightList.length; i < len; i++) {
@@ -772,7 +772,7 @@
 						this.add("All highlights cleared");
 					} else if (['show', 'list', 'roomshow', 'roomlist'].includes(target)) {
 						// Shows a list of the current highlighting words
-						var key = target.startsWith('room') ? toID(this.title) : 'global';
+						var key = target.startsWith('room') ? this.id : 'global';
 						if (highlights[key].length > 0) {
 							this.add("Current highlight list " + (key === 'global' ? "(everywhere): " : "(in " + key + "): ") + highlights[key].join(", "));
 						} else {

--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -211,8 +211,9 @@
 			if (Array.isArray(Dex.prefs('highlights'))) {
 				this.convertHighlights(Dex.prefs('highlights'));
 			}
+			var id = Config.server.id + '#' + this.id;
 			var allHighlights = Dex.prefs('highlights') || {};
-			var roomHighlights = allHighlights[this.id] || [];
+			var roomHighlights = allHighlights[id] || [];
 			var globalHighlights = allHighlights['global'] || [];
 			var highlights = roomHighlights.concat(globalHighlights);
 			if (!Dex.prefs('noselfhighlight') && app.user.nameRegExp) {
@@ -723,7 +724,7 @@
 					}
 					switch (targets[0]) {
 					case 'add': case 'roomadd':
-						var key = targets[0] === 'roomadd' ? this.id : 'global';
+						var key = targets[0] === 'roomadd' ? Config.server.id + '#' + this.id : 'global';
 						var highlightList = highlights[key] || [];
 						for (var i = 1, len = targets.length; i < len; i++) {
 							if (!targets[i]) continue;
@@ -743,7 +744,7 @@
 						this.add("Now highlighting on " + (key === 'global' ? "(everywhere): " : "(in " + key + "): ") + highlights[key].join(', '));
 						break;
 					case 'delete': case 'roomdelete':
-						var key = targets[0] === 'roomdelete' ? this.id : 'global';
+						var key = targets[0] === 'roomdelete' ? Config.server.id + '#' + this.id : 'global';
 						var highlightList = highlights[key] || [];
 						var newHls = [];
 						for (var i = 0, len = highlightList.length; i < len; i++) {
@@ -767,7 +768,7 @@
 						this.add("All highlights cleared");
 					} else if (['show', 'list', 'roomshow', 'roomlist'].includes(target)) {
 						// Shows a list of the current highlighting words
-						var key = target.startsWith('room') ? this.id : 'global';
+						var key = target.startsWith('room') ? Config.server.id + '#' + this.id : 'global';
 						if (highlights[key].length > 0) {
 							this.add("Current highlight list " + (key === 'global' ? "(everywhere): " : "(in " + key + "): ") + highlights[key].join(", "));
 						} else {


### PR DESCRIPTION
I took inspiration from @submindraikou's Pull Request (Zarel/Pokemon-Showdown-Client#747), which unfortunately became inactive after some time.

Here's an example of the new format: `{global: ['jet'], localhost#development: ['.*']}`.

Old highlights are converted by moving all the highlights to the `global` array.

(I'm not very good at writing simple, concise English sentences, so I'd appreciate if someone looked over the help entries and messages sent.)