### PR TITLE
Unify username and format replay search internals

### DIFF
--- a/replays/replays.lib.php
+++ b/replays/replays.lib.php
@@ -78,7 +78,7 @@ class Replays {
 	}
 
 	function search($args) {
-		$page = isset(args["page"]) ? args["page"] : 0;
+		$page = args["page"] ?? 0;
 
 		if (!$this->db) return [];
 		if ($page > 100) return [];
@@ -86,15 +86,15 @@ class Replays {
 		$limit1 = intval(50*($page-1));
 		if ($limit1 < 0) $limit1 = 0;
 
-		$isPrivate = (isset($args["isPrivate"]) && args["isPrivate"]) ? 1 : 0;
-		$byRating = isset(args["byRating"]) && args["byRating"];
+		$isPrivate = ($args["isPrivate"] ?? null) ? 1 : 0;
+		$byRating = args["byRating"] ?? null;
 
-		if (isset($args["p1"])) {
+		if ($args["p1"] ?? null) {
 			$order = $byRating ? "rating" : "uploadtime";
 			$p1id = $this->toId($args["p1"]);
-			if (isset($args["p2"])) {
+			if ($args["p2"] ?? null) {
 				$p2id = $this->toId($args["p2"]);
-				if (isset($args["format"])) {
+				if ($args["format"] ?? null) {
 					$format = $this->toId($args["format"]);
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? AND format = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? AND format = ? ORDER BY ? DESC) ORDER BY ? DESC LIMIT ?, 51;");
 					$res->execute([$isPrivate, $p1id, $p2id, $format, $order, $isPrivate, $p2id, $p1id, $format, $order, $limit1]);
@@ -103,7 +103,7 @@ class Replays {
 					$res->execute([$isPrivate, $p1id, $p2id, $order, $isPrivate, $p2id, $p1id, $order, $limit1]);
 				}
 			} else {
-				if (isset($args["format"])) {
+				if ($args["format"] ?? null) {
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND format = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) WHERE private = ? AND p2id = ? AND format = ? ORDER BY uploadtime DESC) ORDER BY ? DESC LIMIT ?, 51;");
 					$res->execute([$isPrivate, $p1id, $this->toId($args["format"]), $order, $isPrivate, $p1id, $format, $order, $limit1]);
 				} else {

--- a/replays/replays.lib.php
+++ b/replays/replays.lib.php
@@ -89,26 +89,26 @@ class Replays {
 		$isPrivate = ($args["isPrivate"] ?? null) ? 1 : 0;
 		$byRating = args["byRating"] ?? null;
 
-		if ($args["p1"] ?? null) {
+		if ($args["username"] ?? null) {
 			$order = $byRating ? "rating" : "uploadtime";
-			$p1id = $this->toId($args["p1"]);
-			if ($args["p2"] ?? null) {
-				$p2id = $this->toId($args["p2"]);
+			$userid = $this->toId($args["username"]);
+			if ($args["username2"] ?? null) {
+				$userid2 = $this->toId($args["username2"]);
 				if ($args["format"] ?? null) {
 					$format = $this->toId($args["format"]);
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? AND format = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? AND format = ? ORDER BY ? DESC) ORDER BY ? DESC LIMIT ?, 51;");
-					$res->execute([$isPrivate, $p1id, $p2id, $format, $order, $isPrivate, $p2id, $p1id, $format, $order, $limit1]);
+					$res->execute([$isPrivate, $userid, $userid2, $format, $order, $isPrivate, $userid2, $userid, $format, $order, $limit1]);
 				} else {
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? ORDER BY ? DESC) ORDER BY ? DESC LIMIT ?, 51;");
-					$res->execute([$isPrivate, $p1id, $p2id, $order, $isPrivate, $p2id, $p1id, $order, $limit1]);
+					$res->execute([$isPrivate, $userid, $userid2, $order, $isPrivate, $userid2, $userid, $order, $limit1]);
 				}
 			} else {
 				if ($args["format"] ?? null) {
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND format = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) WHERE private = ? AND p2id = ? AND format = ? ORDER BY uploadtime DESC) ORDER BY ? DESC LIMIT ?, 51;");
-					$res->execute([$isPrivate, $p1id, $this->toId($args["format"]), $order, $isPrivate, $p1id, $format, $order, $limit1]);
+					$res->execute([$isPrivate, $userid, $this->toId($args["format"]), $order, $isPrivate, $userid, $format, $order, $limit1]);
 				} else {
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) WHERE private = ? AND p2id = ? ORDER BY uploadtime DESC) ORDER BY ? DESC LIMIT ?, 51;");
-					$res->execute([$isPrivate, $p1id, $order, $isPrivate, $p1id, $order, $limit1]);
+					$res->execute([$isPrivate, $userid, $order, $isPrivate, $userid, $order, $limit1]);
 				}
 			}
 			return $res->fetchAll();

--- a/replays/replays.lib.php
+++ b/replays/replays.lib.php
@@ -77,17 +77,47 @@ class Replays {
 		return preg_replace('/[^a-z0-9]+/','',$name);
 	}
 
-	function search($term, $page = 0, $isPrivate) {
+	function search($p1 = NULL, $p2 = NULL, $format = NULL, $byRating = false, $isPrivate = false, $page = 0) {
 		if (!$this->db) return [];
 		if ($page > 100) return [];
 
 		$limit1 = intval(50*($page-1));
 		if ($limit1 < 0) $limit1 = 0;
-		$term = $this->toID($term);
+
 		$isPrivate = $isPrivate ? 1 : 0;
-		// $res = $this->db->prepare("SELECT uploadtime, id, format, p1, p2 FROM ps_replays WHERE private = 0 AND (p1id = ? OR p2id = ?) ORDER BY uploadtime DESC LIMIT ?, 51");
-		$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? ORDER BY uploadtime DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) WHERE private = ? AND p2id = ? ORDER BY uploadtime DESC) ORDER BY uploadtime DESC LIMIT ?, 51;");
-		$res->execute([$isPrivate, $term, $isPrivate, $term, $limit1]);
+
+		if ($p1) {
+			$order = $byRating ? "rating" : "uploadtime";
+			$p1id = $this->toId($p1);
+			if ($p2) {
+				$p2id = $this->toId($p2);
+				if ($format) {
+					$format = $this->toId($format);
+					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? AND format = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? AND format = ? ORDER BY ? DESC) ORDER BY ? DESC LIMIT ?, 51;");
+					$res->execute([$isPrivate, $p1id, $p2id, $format, $order, $isPrivate, $p2id, $p1id, $format, $order, $limit1]);
+				} else {
+					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? ORDER BY ? DESC) ORDER BY ? DESC LIMIT ?, 51;");
+					$res->execute([$isPrivate, $p1id, $p2id, $order, $isPrivate, $p2id, $p1id, $order, $limit1]);
+				}
+			} else {
+				if ($format) {
+					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND format = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) WHERE private = ? AND p2id = ? AND format = ? ORDER BY uploadtime DESC) ORDER BY ? DESC LIMIT ?, 51;");
+					$res->execute([$isPrivate, $p1id, $format, $order, $isPrivate, $p1id, $format, $order, $limit1]);
+				} else {
+					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) WHERE private = ? AND p2id = ? ORDER BY uploadtime DESC) ORDER BY ? DESC LIMIT ?, 51;");
+					$res->execute([$isPrivate, $p1id, $order, $isPrivate, $p1id, $order, $limit1]);
+				}
+			}
+			return $res->fetchAll();
+		}
+
+		$res = null;
+		if ($byRating) {
+			$res = $this->db->prepare("SELECT uploadtime, id, format, p1, p2, rating, password FROM ps_replays FORCE INDEX (top) WHERE private = ? AND formatid = ? ORDER BY rating DESC LIMIT ?, 51");
+		} else {
+			$res = $this->db->prepare("SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (format) WHERE private = ? AND formatid = ? ORDER BY uploadtime DESC LIMIT ?, 51");
+		}
+		$res->execute([$isPrivate, $this->toId($format), $limit1]);
 
 		return $res->fetchAll();
 	}
@@ -118,24 +148,6 @@ class Replays {
 		default;
 			return [];
 		}
-
-		return $res->fetchAll();
-	}
-
-	function searchFormat($term, $page = 0, $byRating = false) {
-		if (!$this->db) return [];
-		if ($page > 100) return [];
-
-		$limit1 = intval(50*($page-1));
-		if ($limit1 < 0) $limit1 = 0;
-		$term = $this->toID($term);
-		$res = null;
-		if ($byRating) {
-			$res = $this->db->prepare("SELECT uploadtime, id, format, p1, p2, rating, password FROM ps_replays FORCE INDEX (top) WHERE private = 0 AND formatid = ? ORDER BY rating DESC LIMIT ?, 51");
-		} else {
-			$res = $this->db->prepare("SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (format) WHERE private = 0 AND formatid = ? ORDER BY uploadtime DESC LIMIT ?, 51");
-		}
-		$res->execute([$term, $limit1]);
 
 		return $res->fetchAll();
 	}

--- a/replays/replays.lib.php
+++ b/replays/replays.lib.php
@@ -77,22 +77,25 @@ class Replays {
 		return preg_replace('/[^a-z0-9]+/','',$name);
 	}
 
-	function search($p1 = NULL, $p2 = NULL, $format = NULL, $byRating = false, $isPrivate = false, $page = 0) {
+	function search($args) {
+		$page = isset(args["page"]) ? args["page"] : 0;
+
 		if (!$this->db) return [];
 		if ($page > 100) return [];
 
 		$limit1 = intval(50*($page-1));
 		if ($limit1 < 0) $limit1 = 0;
 
-		$isPrivate = $isPrivate ? 1 : 0;
+		$isPrivate = (isset($args["isPrivate"]) && args["isPrivate"]) ? 1 : 0;
+		$byRating = isset(args["byRating"]) && args["byRating"];
 
-		if ($p1) {
+		if (isset($args["p1"])) {
 			$order = $byRating ? "rating" : "uploadtime";
-			$p1id = $this->toId($p1);
-			if ($p2) {
-				$p2id = $this->toId($p2);
-				if ($format) {
-					$format = $this->toId($format);
+			$p1id = $this->toId($args["p1"]);
+			if (isset($args["p2"])) {
+				$p2id = $this->toId($args["p2"]);
+				if (isset($args["format"])) {
+					$format = $this->toId($args["format"]);
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? AND format = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND p2id = ? AND format = ? ORDER BY ? DESC) ORDER BY ? DESC LIMIT ?, 51;");
 					$res->execute([$isPrivate, $p1id, $p2id, $format, $order, $isPrivate, $p2id, $p1id, $format, $order, $limit1]);
 				} else {
@@ -100,9 +103,9 @@ class Replays {
 					$res->execute([$isPrivate, $p1id, $p2id, $order, $isPrivate, $p2id, $p1id, $order, $limit1]);
 				}
 			} else {
-				if ($format) {
+				if (isset($args["format"])) {
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? AND format = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) WHERE private = ? AND p2id = ? AND format = ? ORDER BY uploadtime DESC) ORDER BY ? DESC LIMIT ?, 51;");
-					$res->execute([$isPrivate, $p1id, $format, $order, $isPrivate, $p1id, $format, $order, $limit1]);
+					$res->execute([$isPrivate, $p1id, $this->toId($args["format"]), $order, $isPrivate, $p1id, $format, $order, $limit1]);
 				} else {
 					$res = $this->db->prepare("(SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p1) WHERE private = ? AND p1id = ? ORDER BY ? DESC) UNION (SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (p2) WHERE private = ? AND p2id = ? ORDER BY uploadtime DESC) ORDER BY ? DESC LIMIT ?, 51;");
 					$res->execute([$isPrivate, $p1id, $order, $isPrivate, $p1id, $order, $limit1]);
@@ -117,7 +120,7 @@ class Replays {
 		} else {
 			$res = $this->db->prepare("SELECT uploadtime, id, format, p1, p2, password FROM ps_replays FORCE INDEX (format) WHERE private = ? AND formatid = ? ORDER BY uploadtime DESC LIMIT ?, 51");
 		}
-		$res->execute([$isPrivate, $this->toId($format), $limit1]);
+		$res->execute([$isPrivate, $this->toId($args["format"]), $limit1]);
 
 		return $res->fetchAll();
 	}

--- a/replays/search.php
+++ b/replays/search.php
@@ -92,7 +92,7 @@ if ($username || $format || $contains) {
 		// no
 	} else if ($username) {
 		if (!$isPrivate || $isPrivateAllowed) {
-			$replays = $Replays->search(["p1" => $username, "isPrivate" => $isPrivate, "page" => $page]);
+			$replays = $Replays->search(["username" => $username, "isPrivate" => $isPrivate, "page" => $page]);
 		}
 	} else if ($contains) {
 		$replays = $Replays->fullSearch($contains, $page);

--- a/replays/search.php
+++ b/replays/search.php
@@ -92,12 +92,12 @@ if ($username || $format || $contains) {
 		// no
 	} else if ($username) {
 		if (!$isPrivate || $isPrivateAllowed) {
-			$replays = $Replays->search($username, NULL, NULL, false, $isPrivate, $page);
+			$replays = $Replays->search(array("p1" => $username, "isPrivate" => $isPrivate, "page" => $page));
 		}
 	} else if ($contains) {
 		$replays = $Replays->fullSearch($contains, $page);
 	} else {
-		$replays = $Replays->search(NULL, NULL, $format, $byRating, false, $page);
+		$replays = $Replays->search(array("format" => $format, "byRating" => $byRating, "page" => $page));
 	}
 
 	$time = time();

--- a/replays/search.php
+++ b/replays/search.php
@@ -92,12 +92,12 @@ if ($username || $format || $contains) {
 		// no
 	} else if ($username) {
 		if (!$isPrivate || $isPrivateAllowed) {
-			$replays = $Replays->search($username, $page, $isPrivate);
+			$replays = $Replays->search($username, NULL, NULL, false, $isPrivate, $page);
 		}
 	} else if ($contains) {
 		$replays = $Replays->fullSearch($contains, $page);
 	} else {
-		$replays = $Replays->searchFormat($format, $page, $byRating);
+		$replays = $Replays->search(NULL, NULL, $format, $byRating, false, $page);
 	}
 
 	$time = time();

--- a/replays/search.php
+++ b/replays/search.php
@@ -92,12 +92,12 @@ if ($username || $format || $contains) {
 		// no
 	} else if ($username) {
 		if (!$isPrivate || $isPrivateAllowed) {
-			$replays = $Replays->search(array("p1" => $username, "isPrivate" => $isPrivate, "page" => $page));
+			$replays = $Replays->search(["p1" => $username, "isPrivate" => $isPrivate, "page" => $page]);
 		}
 	} else if ($contains) {
 		$replays = $Replays->fullSearch($contains, $page);
 	} else {
-		$replays = $Replays->search(array("format" => $format, "byRating" => $byRating, "page" => $page));
+		$replays = $Replays->search(["format" => $format, "byRating" => $byRating, "page" => $page]);
 	}
 
 	$time = time();


### PR DESCRIPTION
This is a step towards #1307, where eventually we will support calling `search` with any combination of player username, opponent username and format.