### PR TITLE
Import @pokemon-showdown/sets during build

### DIFF
--- a/build
+++ b/build
@@ -37,7 +37,6 @@ case 'full':
 	execSync(`node ./build-tools/build-indexes`, options);
 	execSync(`node ./build-tools/build-learnsets`, options);
 	execSync(`node ./build-tools/build-minidex`, options);
-	execSync(`node ./build-tools/build-sets`, options);
 	execSync(`node ./replays/build`, options);
 	full = ' full';
 	break;

--- a/build
+++ b/build
@@ -37,6 +37,7 @@ case 'full':
 	execSync(`node ./build-tools/build-indexes`, options);
 	execSync(`node ./build-tools/build-learnsets`, options);
 	execSync(`node ./build-tools/build-minidex`, options);
+	execSync(`node ./build-tools/build-sets`, options);
 	execSync(`node ./replays/build`, options);
 	full = ' full';
 	break;
@@ -49,6 +50,9 @@ case 'learnsets':
 case 'minidex':
 case 'sprites':
 	execSync(`node ./build-tools/build-minidex`, options);
+	break;
+case 'sets':
+	execSync(`node ./build-tools/build-sets`, options);
 	break;
 case 'replays':
 	execSync(`node ./replays/build`, options);

--- a/build-tools/build-sets
+++ b/build-tools/build-sets
@@ -8,7 +8,7 @@ const path = require("path");
 process.stdout.write("Importing sets from @pokemon-showdown/sets... ");
 
 const shell = cmd => child_process.execSync(cmd, {stdio: 'inherit', cwd: path.resolve(__dirname, '../..')});
-shell(`npm install --force --no-save @pokemon-showdown/sets`);
+shell(`npm install --force --no-audit --no-save @pokemon-showdown/sets`);
 
 const src = path.resolve(__dirname, '../node_modules/@pokemon-showdown/sets');
 const dest = path.resolve(__dirname, '../data/sets');

--- a/build-tools/build-sets
+++ b/build-tools/build-sets
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require("fs");
+const child_process = require('child_process');
+const path = require("path");
+
+process.stdout.write("Importing sets from @pokemon-showdown/sets... ");
+
+const shell = cmd => child_process.execSync(cmd, {stdio: 'inherit', cwd: path.resolve(__dirname, '../..')});
+shell(`npm install --no-save @pokemon-showdown/sets`);
+
+const src = path.resolve(__dirname, '../node_modules/@pokemon-showdown/sets');
+const dest = path.resolve(__dirname, '../data/sets');
+
+try {
+	fs.mkdirSync(dest);
+} catch (err) {
+	if (err.code !== 'EEXIST') throw err;
+}
+
+for (const file of fs.readdirSync(src)) {
+	if (!file.endsWith('.json')) continue;
+	fs.copyFileSync(`${src}/${file}`, `${dest}/${file}`);
+}

--- a/build-tools/build-sets
+++ b/build-tools/build-sets
@@ -7,8 +7,8 @@ const path = require("path");
 
 process.stdout.write("Importing sets from @pokemon-showdown/sets... ");
 
-const shell = cmd => child_process.execSync(cmd, {stdio: 'inherit', cwd: path.resolve(__dirname, '../..')});
-shell(`npm install --force --no-audit --no-save @pokemon-showdown/sets`);
+const shell = cmd => child_process.execSync(cmd, {stdio: 'inherit', cwd: path.resolve(__dirname, '..')});
+shell(`npm install --no-audit --no-save @pokemon-showdown/sets`);
 
 const src = path.resolve(__dirname, '../node_modules/@pokemon-showdown/sets');
 const dest = path.resolve(__dirname, '../data/sets');

--- a/build-tools/build-sets
+++ b/build-tools/build-sets
@@ -8,7 +8,7 @@ const path = require("path");
 process.stdout.write("Importing sets from @pokemon-showdown/sets... ");
 
 const shell = cmd => child_process.execSync(cmd, {stdio: 'inherit', cwd: path.resolve(__dirname, '../..')});
-shell(`npm install --no-save @pokemon-showdown/sets`);
+shell(`npm install --force --no-save @pokemon-showdown/sets`);
 
 const src = path.resolve(__dirname, '../node_modules/@pokemon-showdown/sets');
 const dest = path.resolve(__dirname, '../data/sets');


### PR DESCRIPTION
Required for #1357. We're installing with `--no-save` because we pretty much always want the latest version and don't want to deal with the hassle of updating deps in `package.json`.