### PR TITLE
Don't give private smogtours replays passwords

### DIFF
--- a/replays/replays.lib.php
+++ b/replays/replays.lib.php
@@ -231,7 +231,7 @@ class Replays {
 			return 'not found';
 		}
 
-		$smogtours = preg_match('/^[a-z0-9]+-smogtours-[0-9]+$/', $id);
+		$smogtours = preg_match('/^smogtours-[a-z0-9]+-[0-9]+$/', $id);
 		$password = null;
 		if ($pReplay['private'] && $pReplay['private'] !== 2) {
 			if ($replay && $replay['password']) {

--- a/replays/replays.lib.php
+++ b/replays/replays.lib.php
@@ -231,11 +231,12 @@ class Replays {
 			return 'not found';
 		}
 
+		$smogtours = preg_match('/^[a-z0-9]+-smogtours-[0-9]+$/', $id);
 		$password = null;
 		if ($pReplay['private'] && $pReplay['private'] !== 2) {
 			if ($replay && $replay['password']) {
 				$password = $replay['password'];
-			} else if (!($replay && $replay['private'])) {
+			} else if (!$smogtours && !($replay && $replay['private'])) {
 				$password = $this->genPassword();
 			}
 		}


### PR DESCRIPTION
Smogon TDs would like to go back to the old replay approach, as they're "having trouble gathering usage statistics an experiencing issues being unable to open games and replays".