### PR TITLE
Don't steal focus from a textbox when updating user

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -43,7 +43,7 @@
 					animate: false,
 					extraSpace: 0
 				});
-				if (this === app.curSideRoom || this === app.curRoom) {
+				if (document.activeElement.tagName.toLowerCase() !== 'textarea' && (this === app.curSideRoom || this === app.curRoom)) {
 					this.$chatbox.focus();
 				}
 			}


### PR DESCRIPTION
Most notable when you type a message that leaves idle state in a PM or left window, it'll steal your cursor to the right chat room.