### PR TITLE
Don't error out incorrectly for ladder ranks with a long input name

### DIFF
--- a/lib/dispatcher.lib.php
+++ b/lib/dispatcher.lib.php
@@ -529,9 +529,9 @@ class LadderActionHandler {
 	// There's no need to make a database query for this.
 	private function getUserData($username) {
 		if (!$username) $username = '';
-		if (mb_strlen($username) > 18) return false;
 		$userid = strtr($username, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz");
 		$userid = preg_replace('/[^A-Za-z0-9]+/', '', $userid);
+		if (mb_strlen($userid) > 18) return false;
 		return array('userid' => $userid, 'username' => $username);
 	}
 


### PR DESCRIPTION
Relevant if someone accidentally prefixes / appends a character to an already long name.