### PR TITLE
Stop prefixing battle names with a space

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -3208,7 +3208,6 @@ class Battle {
 				let room = app!.rooms[this.roomid];
 				let user = BattleTextParser.parseNameParts(args[1]);
 				let userid = toUserid(user.name);
-				if (/^[a-z0-9]/i.test(user.name)) user.name = ' ' + user.name;
 				if (!room.users[userid]) room.userCount.users++;
 				room.users[userid] = user;
 				room.userList.add(userid);


### PR DESCRIPTION
As far as I can tell, this comes from #1071, which was from a much, much older name format and isn't necessary anymore (rank isn't included as any part of the name string anymore)