### PR TITLE
Fix broken avatar change messsage when using avatar numbers

### DIFF
--- a/js/client-chat.js
+++ b/js/client-chat.js
@@ -923,8 +923,12 @@
 			case 'avatar':
 				var parts = target.split(',');
 				var avatar = parts[0].toLowerCase().replace(/[^a-z0-9-]+/g, '');
+				// Replace avatar number with name before sending it to the server, only the client knows what to do with the numbers
+				if (window.BattleAvatarNumbers && Object.prototype.hasOwnProperty.call(window.BattleAvatarNumbers, avatar)) {
+					avatar = window.BattleAvatarNumbers[avatar];
+				}
 				Dex.prefs('avatar', avatar);
-				return text; // Send the /avatar command through to the server.
+				return '/avatar ' + avatar; // Send the command through to the server.
 
 			case 'afd':
 				var cleanedTarget = toID(target);

--- a/js/client-topbar.js
+++ b/js/client-topbar.js
@@ -670,10 +670,14 @@
 			buf += '<p><button name="close">Cancel</button></p>';
 			this.$el.html(buf).css('max-width', 780);
 		},
-		setAvatar: function (i) {
-			app.send('/avatar ' + i);
+		setAvatar: function (avatar) {
+			// Replace avatar number with name before sending it to the server, only the client knows what to do with the numbers
+			if (window.BattleAvatarNumbers && Object.prototype.hasOwnProperty.call(window.BattleAvatarNumbers, avatar)) {
+				avatar = window.BattleAvatarNumbers[avatar];
+			}
+			app.send('/avatar ' + avatar);
 			app.send('/cmd userdetails ' + app.user.get('userid'));
-			Dex.prefs('avatar', i);
+			Dex.prefs('avatar', avatar);
 			this.close();
 		}
 	});


### PR DESCRIPTION
When changing your avatar with /avatar [number], or when using the popup menu to select one, the success message has a broken image:
![image](https://user-images.githubusercontent.com/5814184/65861000-bc335f80-e36b-11e9-81e9-2773976539a6.png)
because it sends the avatar number directly to the server, and avatars are organized by name instead of number now, so the server has no way to display the new avatar. This way we'd just always send the name.