### PR TITLE
Display spread move target even during fast forward

### DIFF
--- a/src/battle.ts
+++ b/src/battle.ts
@@ -1367,6 +1367,7 @@ class Battle {
 		}
 	}
 	animateMove(pokemon: Pokemon, move: Move, target: Pokemon | null, kwArgs: KWArgs) {
+		this.activeMoveIsSpread = kwArgs.spread;
 		if (this.fastForward || kwArgs.still) return;
 
 		if (!target) target = pokemon.side.foe.active[0];
@@ -1389,7 +1390,6 @@ class Battle {
 			return;
 		}
 
-		this.activeMoveIsSpread = kwArgs.spread;
 		let targets = [pokemon];
 		if (kwArgs.spread === '.') {
 			//  no target was hit by the attack


### PR DESCRIPTION
Currently if you fast-forward past a spread move then the log just says "A critical hit!" or "It's super-effective!" or "It's not very effective..." instead of naming the target like it does when playing at normal speed.