### PR TITLE
Tooltips: Fix type/base power of Z-Hidden Power

### DIFF
--- a/js/client-battle.js
+++ b/js/client-battle.js
@@ -622,11 +622,13 @@
 					if (canZMove) {
 						movebuttons = '<div class="movebuttons-noz">' + movebuttons + '</div><div class="movebuttons-z" style="display:none">';
 						for (var i = 0; i < curActive.moves.length; i++) {
-							var moveData = curActive.moves[i];
-							var move = this.battle.dex.getMove(moveData.move);
-							var moveType = this.tooltips.getMoveType(move, typeValueTracker)[0];
 							if (canZMove[i]) {
-								var tooltipArgs = 'zmove|' + move.id + '|' + pos;
+								// when possible, use Z move to decide type, for cases like Z-Hidden Power
+								var baseMove = this.battle.dex.getMove(curActive.moves[i].move);
+								// might not exist, such as for Z status moves - fall back on base move to determine type then
+								var zMove = this.battle.dex.getMove(canZMove[i].move);
+								var moveType = this.tooltips.getMoveType(zMove.exists ? zMove : baseMove, typeValueTracker)[0];
+								var tooltipArgs = 'zmove|' + baseMove.id + '|' + pos;
 								movebuttons += '<button class="type-' + moveType + ' has-tooltip" name="chooseMove" value="' + (i + 1) + '" data-move="' + BattleLog.escapeHTML(canZMove[i].move) + '" data-target="' + BattleLog.escapeHTML(canZMove[i].target) + '" data-tooltip="' + BattleLog.escapeHTML(tooltipArgs) + '">';
 								movebuttons += canZMove[i].move + '<br /><small class="type">' + (moveType ? Dex.getType(moveType).name : "Unknown") + '</small> <small class="pp">1/1</small>&nbsp;</button> ';
 							} else {

--- a/src/battle-tooltips.ts
+++ b/src/battle-tooltips.ts
@@ -441,10 +441,13 @@ class BattleTooltips {
 				zEffect = this.getStatusZMoveEffect(move);
 			} else {
 				const zMove = this.battle.dex.getMove(BattleTooltips.zMoveTable[item.zMoveType as TypeName]);
+				let zMovePower = move.zMovePower;
+				// the different Hidden Power types don't have a Z power set, fall back on base move
+				if (move.id.startsWith('hiddenpower')) zMovePower = this.battle.dex.getMove('hiddenpower').zMovePower;
 				move = new Move(zMove.id, zMove.name, {
 					...zMove,
 					category: move.category,
-					basePower: move.zMovePower,
+					basePower: zMovePower,
 				});
 				// TODO: Weather Ball type-changing shenanigans
 			}


### PR DESCRIPTION
The first issue was that Z-Hidden Power wrongly displayed its type as that of the base Hidden Power instead of normal (in the move selection, not the tooltips). So I made it base the type of the actual Z move, if a separate object is available, and only fall back on the base move if there is none (like for Z status moves).
The second issue was that Z-Hidden Power did not have a base power displayed in the tooltips, because only the base HP has a zMovePower, the typed ones don't. Instead of adding that property to all hidden powers I opted to make it fall back on the base move here. I can do the former instead if you'd prefer.