### PR TITLE
Teambuilder: Support sorting in reverse

### DIFF
--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -998,7 +998,7 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 			return results.sort(([rowType1, id1], [rowType2, id2]) => {
 				const stat1 = this.dex.species.get(id1).baseStats[sortCol as StatName];
 				const stat2 = this.dex.species.get(id2).baseStats[sortCol as StatName];
-				return (stat2 - stat1)* sortOrder;
+				return (stat2 - stat1) * sortOrder;
 			});
 		} else if (sortCol === 'bst') {
 			return results.sort(([rowType1, id1], [rowType2, id2]) => {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/set-sort-direction-in-teambuilder.3668345/

First click will sort regularly, second click will sort in reverse, and a third click will stop sorting.