### PR TITLE
Teambuilder: Show Restricted Legendaries for Series 11

### DIFF
--- a/src/battle-dex-search.ts
+++ b/src/battle-dex-search.ts
@@ -896,7 +896,7 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 		else if (isVGCOrBS) {
 			if (
 				format === 'vgc2010' || format === 'vgc2016' || format.startsWith('vgc2019') ||
-				format.endsWith('series8') || format.endsWith('series10')
+				format.endsWith('series10') || format.endsWith('series11')
 			) {
 				tierSet = tierSet.slice(slices["Restricted Legendary"]);
 			} else {


### PR DESCRIPTION
I also removed series 8 in the code since there's never been a bss/vgc format that had series 8 in the name