### PR TITLE
Remove broadcast Restriction on avatar.

### DIFF
--- a/play.pokemonshowdown.com/js/client-chat.js
+++ b/play.pokemonshowdown.com/js/client-chat.js
@@ -1101,15 +1101,14 @@
 				return text;
 
 			case 'avatar':
-				if (this.checkBroadcast(cmd, text)) return false;
 				var parts = target.split(',');
 				var avatar = parts[0].toLowerCase().replace(/[^a-z0-9-]+/g, '');
 				// Replace avatar number with name before sending it to the server, only the client knows what to do with the numbers
 				if (window.BattleAvatarNumbers && Object.prototype.hasOwnProperty.call(window.BattleAvatarNumbers, avatar)) {
 					avatar = window.BattleAvatarNumbers[avatar];
 				}
-				Storage.prefs('avatar', avatar);
-				return '/avatar ' + avatar; // Send the command through to the server.
+				if (text.startsWith('/')) Storage.prefs('avatar', avatar);
+				return text.charAt(0) + 'avatar ' + avatar; // Send the command through to the server.
 
 			case 'afd':
 				if (this.checkBroadcast(cmd, text)) return false;


### PR DESCRIPTION
Depends on https://github.com/smogon/pokemon-showdown/pull/10961

Client end of implementing the suggestion: https://www.smogon.com/forums/threads/avatar-avatar-to-be-broadcastable-showing-the-avatar-sprite-and-the-credit.3759095/

Removes the restriction on sending a broadcast prefix '!' with the avatar command to allow for users to broadcast it in chat. Prevents caching the selected avatar when using the '!' prefix to send the command.