### PR TITLE
Preact: Improve room leave handling

### DIFF
--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -1652,7 +1652,7 @@ export class PSRoom extends PSStreamModel<Args | null> implements RoomOptions {
 	}
 	destroy() {
 		if (this.connected === true) {
-			this.sendDirect('/noreply /leave ' + this.id);
+			this.sendDirect(`/noreply /leave ${this.id}`);
 			this.connected = false;
 		}
 	}


### PR DESCRIPTION
I added the room ID because, for example, if we take ticket and then leave; client send `/noreply /leave`, so we don't actually leave it properly. By specifying the room ID, it will be handled correctly and we'll properly leave the ticket.

Before
![image](https://github.com/user-attachments/assets/7955f369-0520-4083-b146-6d4e5d04292b)

After
![image](https://github.com/user-attachments/assets/5af72c4d-ce81-497e-bf0a-e526c4976898)
