### PR TITLE
Fix database connection pool exhaustion

### DIFF
--- a/lib/ntbb-database.lib.php
+++ b/lib/ntbb-database.lib.php
@@ -31,6 +31,7 @@ class PSDatabase {
 					[PDO::ATTR_PERSISTENT => true]
 				);
 				$this->db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+				$this->db->exec("SET SESSION wait_timeout = 7200");
 			} catch (PDOException $e) {
 				if (strpos($e->getMessage(), '1040') !== false || strpos($e->getMessage(), 'Too many connections') !== false) {
 					http_response_code(503);


### PR DESCRIPTION
- **Symptom:** Crashes with MySQL 1040 (“Too many connections”).
- **Cause:** PHP opens a new DB connection per request; no reuse under load.
- **Fixes:** Enable `PDO::ATTR_PERSISTENT => true`; on 1040 return **HTTP 503** with a user-friendly message (keep existing handling for other DB errors).
