### PR TITLE
Preact: Fix bug with accept challenge

### DIFF
--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -782,7 +782,7 @@ export class TeamForm extends preact.Component<{
 	};
 	submit = (ev: Event, validate?: 'validate') => {
 		ev.preventDefault();
-		const format = this.format;
+		const format = this.props.format || this.format;
 		const teamElement = this.base!.querySelector<HTMLButtonElement>('button[name=team]');
 		const teamKey = teamElement!.value;
 		const team = teamKey ? PS.teams.byKey[teamKey] : undefined;


### PR DESCRIPTION
i missed this last time
so basically when you have starred a format that requires a team and when someone challenges you to a format that requires no team, the `TeamForm` considers the starred format instead of the incoming challenge format and hence shows the error 'This format requires team'

hence suggesting use `props.format` in case of incoming challenge, i probably used it at wrong place last time