### PR TITLE
Preact: Optimize TimerButton performance

### DIFF
--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -253,7 +253,7 @@ class TimerButton extends preact.Component<{ room: BattleRoom }, { timeDisplay: 
 		if (!isActive) return '';
 
 		const secondsLeft = room.battle.kickingInactive;
-		if (secondsLeft !== true && secondsLeft <= 10) {
+		if (typeof secondsLeft === 'number' && secondsLeft <= 10) {
 			return ' timerbutton-critical';
 		}
 


### PR DESCRIPTION
Replace forceUpdate() with setState() to prevent unnecessary re-renders during battle timer updates.