### PR TITLE
Update sugar's name to Luna

### DIFF
--- a/pokemonshowdown.com/credits.php
+++ b/pokemonshowdown.com/credits.php
@@ -80,7 +80,7 @@ includeHeader();
 			<ul>
 				<li><p><strong>Austin Couturier</strong> [Austin] <small>&ndash; Development (damage calculator)</small></p></li>
 				<li><p><strong>Kevin Lau</strong> [Ascriptmaster] <small>&ndash; Development, Art (battle animations)</small></p></li>
-				<li><p><strong>Kamila Borowska</strong> [xfix] <small>&ndash; Development</small></p></li>
+				<li><p><strong>Luna Borowska</strong> [sugar700] <small>&ndash; Development</small></p></li>
 				<li><p><strong>Neil Rashbrook</strong> [urkerab] <small>&ndash; Development (battle simulation)</small></p></li>
 				<li><p>[<strong>peach</strong>] <small>&ndash; Development</small></p></li>
 				<li><p>[<strong>pyuk</strong>] <small>&ndash; Development (game mechanics)</small></p></li>


### PR DESCRIPTION
sugar (previously xfix) has ultimately decided on the name Luna, rather than previously listed name.

This is connected to https://github.com/smogon/pokemon-showdown-client/pull/2176, except, well, decided on a different name (Kamila was essentially me experimenting).