### PR TITLE
Don't count nonexistent moves as physical

### DIFF
--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -2635,6 +2635,7 @@ export class BattleStatGuesser {
 
 		for (let i = 0, len = set.moves.length; i < len; i++) {
 			let move = this.dex.moves.get(set.moves[i]);
+			if (!move.exists) continue;
 			hasMove[move.id] = 1;
 			if (move.category === 'Status') {
 				if (['batonpass', 'healingwish', 'lunardance'].includes(move.id)) {


### PR DESCRIPTION
Mostly irrelevant, but if a move was typed incorrectly, it would count as a physical move toward the guessed role.