### PR TITLE
fix long live battle skipping errors

### DIFF
--- a/replay.pokemonshowdown.com/src/replay.js
+++ b/replay.pokemonshowdown.com/src/replay.js
@@ -208,7 +208,7 @@ var ReplayPanel = Panels.StaticPanel.extend({
 		this.battle.skipTurn();
 	},
 	rewind: function() {
-		this.battle.seekTurn(this.battle.turn - 1);
+		this.battle.seekBy(-1);
 	},
 	ffto: function() {
 		var turn = prompt('Turn?');


### PR DESCRIPTION
Fixes a bug introduced by[ this commit](https://github.com/smogon/pokemon-showdown-client/commit/fc00e6823140fac0cde2c101091d646845e60284). Because it adds the ability to interrupt "seeking" with new button presses, the original PR adds 

```ts
   seekBy(deltaTurn: number) {
		if (this.seeking === Infinity && deltaTurn < 0) {
			return this.seekTurn(this.turn + 1);
		}
		this.seekTurn((this.seeking ?? this.turn) + deltaTurn);
	}
```

which accounts for interruptions while seeking by updating the `seeking` turn rather than seeking the turn before. However, the original author missed adding this change in the live battle viewer, resulting in multiple quick rewinds in long battles sending you back to a random turn if your pc is cpu limited and can't perform the full seek sequence in <300ms. 


