### PR TITLE
Replays: Fix controls when skipping to first turn

### DIFF
--- a/replay.pokemonshowdown.com/src/replays-battle.tsx
+++ b/replay.pokemonshowdown.com/src/replays-battle.tsx
@@ -241,6 +241,7 @@ export class BattlePanel extends preact.Component<{ id: string }> {
 	};
 	firstTurn = () => {
 		this.battle?.seekTurn(0);
+		this.forceUpdate();
 	};
 	lastTurn = () => {
 		this.battle?.seekTurn(Infinity);


### PR DESCRIPTION
We need to re-render the battle when skipping back to the first turn as the skip turn / last turn button won't render back to their enabled state until the first turn starts. This means if you skip to the end then decide to go back, you can't skip turns forward again until the first turn begins. That doesn't sound like it matters, but try watching [this replay](https://replay.pokemonshowdown.com/gen9doublesou-2491309465-p0hdpwk1mkaioitx24k54tr4h45iwhmpw) by skipping to the end and then back to the first turn. it can take a long time to get to the first turn from preview. 