### PR TITLE
Add nickname toggle button to replay controls

### DIFF
--- a/replay.pokemonshowdown.com/src/replays-battle.tsx
+++ b/replay.pokemonshowdown.com/src/replays-battle.tsx
@@ -334,6 +334,12 @@ export class BattlePanel extends preact.Component<{ id: string }> {
 		this.battle?.setMute(!BattleSound.muted);
 		this.forceUpdate();
 	}
+	toggleIgnoreNicks = () => {
+		if (!this.battle) return;
+		this.battle.ignoreNicks = !this.battle.ignoreNicks;
+		this.battle.resetToCurrentTurn();
+		this.forceUpdate();
+	};
 	changeSound = (e: Event) => {
 		const muted = (e.target as HTMLSelectElement).value;
 		this.battle?.setMute(muted === 'off');
@@ -497,6 +503,12 @@ export class BattlePanel extends preact.Component<{ id: string }> {
 					<button onClick={this.switchViewpoint} name="viewpoint" class={this.battle ? 'button' : 'button disabled'}>
 						{(this.battle?.viewpointSwitched ? this.result?.players[1] : this.result?.players[0] || "Player")} {}
 						<i class="fa fa-random" aria-hidden aria-label="Switch viewpoint"></i>
+					</button>
+				</label> {}
+				<label class="optgroup">
+					Nicknames:<br />
+					<button onClick={this.toggleIgnoreNicks} name="ignorenicks" class={this.battle ? 'button' : 'button disabled'}>
+						{this.battle?.ignoreNicks ? 'Hidden' : 'Shown'}
 					</button>
 				</label> {}
 				<label class="optgroup">


### PR DESCRIPTION
Link to issue is [here](https://www.smogon.com/forums/threads/add-option-to-ignore-pokemon-nicknames-in-replays.3773899/)

Description

- Added a toggle when watching replays to show/hide nicknames
- Nickname show/hide was already a feature in battling but not replays, used same logic

Testing

- Deployed localy
- npm run test
<img width="1123" height="508" alt="Screenshot 2025-12-03 at 5 59 18 PM" src="https://github.com/user-attachments/assets/0c2ae493-b0d5-4195-8af4-96c2129ba39f" />
<img width="1117" height="498" alt="Screenshot 2025-12-03 at 5 59 28 PM" src="https://github.com/user-attachments/assets/c6a8830d-233a-4f2c-9bdd-665f1de2d7b1" />
