### PR TITLE
Doom Desire & Future Sight Timers UI

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -2745,8 +2745,8 @@ export class Battle {
 				this.scene.updateWeather();
 				break;
 			}
-			if (!(effect.id === 'typechange' && poke.terastallized) && 
-			    effect.id !== 'futuresight' && effect.id !== 'doomdesire') {
+			if (!(effect.id === 'typechange' && poke.terastallized) &&
+				effect.id !== 'futuresight' && effect.id !== 'doomdesire') {
 				poke.addVolatile(effect.id);
 			}
 			this.scene.updateStatbar(poke);


### PR DESCRIPTION
# Future Sight and Doom Desire Timer UI
Added Future Sight and Doom Desire UI timers so that both users can easily see when damage will actually be dealt. Currently spawns in with 3 turns remaining when used, then ticks down to 2, then 1, then attacks.

[Link to issue](https://www.smogon.com/forums/threads/future-sight-indicator.3684086/)

## Changes
### `battle.ts`
Added Future Sight and Doom Desire as sideConditions on client side. Not affected by Court Change because courtchange in moves file on server side manually selects the sideConditions it affects. Also added them as -sidestart cases.
### `battle.css`
Added an optional animation implementation for Future Sight and Doom Desire. The animation is currently unused, as it did not feel fully faithful to in-game behavior, but the underlying implementation is preserved for potential future use.

## Example:
<img width="1366" height="786" alt="image" src="https://github.com/user-attachments/assets/014bc040-4c8f-4b2b-82e4-c65bef68c9cc" />
