### PR TITLE
Fix tooltips for Crystal Free Z-Moves

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -1521,7 +1521,7 @@ export class Battle {
 			let moveName = move.name;
 			if (!callerMoveForPressure) {
 				const previousLine = this.stepQueue[this.currentStep - 1];
-				const zPower = previousLine.startsWith('|-zpower')
+				const zPower = previousLine.startsWith('|-zpower');
 				if (move.isZ && zPower) {
 					pokemon.item = move.isZ;
 					let item = Dex.items.get(move.isZ);


### PR DESCRIPTION
Made it so tooltips don't incorrectly show the wrong move or item when Crystal Free Z-Moves are used, by checking if the previous line was the Z-Move activation message when a Z-Move is used.
https://www.smogon.com/forums/threads/hackmons-cfz-item-tooltips.3747306/
https://www.smogon.com/forums/threads/5-moves-in-hackmons.3770643/