### PR TITLE
Store format drop down form reference and find format button dynamically

### DIFF
--- a/play.pokemonshowdown.com/js/client-mainmenu.js
+++ b/play.pokemonshowdown.com/js/client-mainmenu.js
@@ -1404,7 +1404,7 @@
 		},
 		selectFormat: function (format) {
 			var $form = this.$form.length ? this.$form : this.sourceEl.closest('form');
-			
+
 			if (this.onselect) {
 				this.onselect(format);
 			} else if (app.rooms[''].curFormat !== format) {


### PR DESCRIPTION
The bug: shortly after opening ps, roughly coinciding with your login (maybe related to user data being loaded from server? don't know why these are connected) the main ps server sends the client a protocol message containing all valid formats. when the client receives this, it re-renders the format button with the new formats. the issue is that when it does that, it does it by REPLACING the format button with a new one, but the code which selects formats relies on stored references to the format select pop up menu's original format button. the result of this is that the format button doesn't exist if formats have been updated since opening the drop down menu, so nothing happens when you select the format. It will stay on random battles, and if you pick another format again, it will keep the randomized format team preview.

Recreate bug: go into ps and open the ladder format menu immediately after the site opens. wait for your username to populate in the top right. then select a non-randomized format from the opened format menu. you should see that nothing happens

The fix: store a reference to the drop down form (this is stable even if updateFormats is called) and dynamically find the format button when necessary so we can set the html of the current button, not the dead reference. 

Notes: it's probably generally best to update buttons rather than replace them to avoid these sorts of DOM reference issues, but I'm not good with frontend, and this was the only fix I could manage without refactoring lots of other peoples' code. I also haven't noticed any other instances of DOM reference bugs other than this one.