### PR TITLE
Fix join/leave messages appearing at wrong turn in battle log

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -1150,6 +1150,7 @@ export class Battle {
 		autoresize?: boolean,
 	} = {}) {
 		this.id = options.id || '';
+		this.roomid = options.id || '';
 
 		if (options.$frame && options.$logFrame) {
 			this.scene = new BattleScene(this, options.$frame, options.$logFrame);
@@ -3539,55 +3540,19 @@ export class Battle {
 			this.log(args, undefined, preempt);
 			break;
 		}
-		case 'join': case 'j': case 'J': {
-			if (this.roomid) {
-				let room = app!.rooms[this.roomid];
-				let user = BattleTextParser.parseNameParts(args[1]);
-				let userid = toUserid(user.name);
-				if (!room.users[userid]) room.userCount.users++;
-				room.users[userid] = user;
-				room.userList.add(userid);
-				room.userList.updateUserCount();
-				room.userList.updateNoUsersOnline();
-			}
+		case 'join': case 'j': case 'J':
+		case 'leave': case 'l': case 'L':
+			// User list management is handled by ChatRoom.receiveLine
+			// Here we just log the message to the battle log
 			this.log(args, undefined, preempt);
 			break;
-		}
-		case 'leave': case 'l': case 'L': {
-			if (this.roomid) {
-				let room = app!.rooms[this.roomid];
-				let user = args[1];
-				let userid = toUserid(user);
-				if (room.users[userid]) room.userCount.users--;
-				delete room.users[userid];
-				room.userList.remove(userid);
-				room.userList.updateUserCount();
-				room.userList.updateNoUsersOnline();
-			}
-			this.log(args, undefined, preempt);
-			break;
-		}
-		case 'name': case 'n': case 'N': {
-			if (this.roomid) {
-				let room = app!.rooms[this.roomid];
-				let user = BattleTextParser.parseNameParts(args[1]);
-				let oldid = args[2];
-				if (toUserid(oldid) === app!.user.get('userid')) {
-					app!.user.set({
-						away: user.away,
-						status: user.status,
-					});
-				}
-				let userid = toUserid(user.name);
-				room.users[userid] = user;
-				room.userList.remove(oldid);
-				room.userList.add(userid);
-			}
+		case 'name': case 'n': case 'N':
+			// User list management is handled by ChatRoom.receiveLine
+			// Here we just log the message to the battle log
 			if (!this.ignoreSpects) {
 				this.log(args, undefined, preempt);
 			}
 			break;
-		}
 		case 'player': {
 			let side = this.getSide(args[1]);
 			side.setName(args[2]);

--- a/play.pokemonshowdown.com/src/panel-battle.tsx
+++ b/play.pokemonshowdown.com/src/panel-battle.tsx
@@ -148,6 +148,34 @@ export class BattleRoom extends ChatRoom {
 	choices: BattleChoiceBuilder | null = null;
 	autoTimerActivated: boolean | null = null;
 
+	override receiveLine(args: Args) {
+		switch (args[0]) {
+		case 'users':
+			const usernames = args[1].split(',');
+			const count = parseInt(usernames.shift()!, 10);
+			this.setUsers(count, usernames);
+			return;
+		case 'join': case 'j': case 'J':
+			this.addUser(args[1]);
+			break;
+		case 'leave': case 'l': case 'L':
+			this.removeUser(args[1]);
+			break;
+		case 'name': case 'n': case 'N':
+			this.renameUser(args[1], args[2]);
+			break;
+		case 'noinit':
+			this.loadReplay();
+			return;
+		}
+		// Route to battle or backlog
+		if (this.battle) {
+			this.update(args);
+		} else {
+			(this.backlog ||= []).push(args);
+		}
+	}
+
 	loadReplay() {
 		const replayid = this.id.slice(7);
 		Net(`https://replay.pokemonshowdown.com/${replayid}.json`).get().catch().then(data => {


### PR DESCRIPTION
In the Preact client, spectators and players joining a battle would appear grouped together at the current turn instead of at their correct historical positions in the battle log.

Changes:

1.  `BattleRoom.receiveLine` (new override in `panel-battle.tsx`):
  - Handles user list updates for join/leave/name
  - Routes messages to battle (if exists) or backlog (for later processing by BattlePanel)
  - Keeps ChatRoom clean with no battle-specific conditionals

2. `Battle.runMajor` (simplified in `battle.ts`):
  - Join/leave/name handlers now just log the message
  - User list management delegated to BattleRoom

Testing:
  - Spectate a live battle or watch a replay
  - Join messages should appear at their correct historical positions