### PR TITLE
Adds OM custom banlist filtering for teambuilding to non permanent OMs

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -433,6 +433,11 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			if (genNum === 9) {
 				for (const meta of [
 					'ubersuu', 'almostanyability', 'balancedhackmons', 'godlygift', 'mixandmega', 'sharedpower', 'stabmons',
+					'350cup', 'alphabetcup', 'badnboosted', 'battlefields', 'biomechmons', 'camomons', 'category swap',
+					'convergence', 'crossevolution', 'ferventimpersonation', 'foresighters', 'formemons', 'fortemons',
+					'franticfusions', 'fullpotential', 'inheritance', 'inverse', 'natureswap', 'passiveaggressive',
+					'pokebilities', 'pokemoves', 'relayrace', 'revelationmons', 'sharingiscaring', 'teradonation',
+					'teraoverride', 'thecardgame', 'thelosersgame', 'tiershift', 'trademarked', 'typesplit',
 				]) {
 					const format = Dex.formats.get(gen + meta);
 					if (format.exists && Dex.formats.getRuleTable(format).isBannedSpecies(species)) {
@@ -447,7 +452,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 				}
 			}
 			if (genNum >= 8) {
-				for (const meta of ['nationaldexdoubles', 'nationaldexmonotype']) {
+				for (const meta of ['nationaldexdoubles', 'nationaldexmonotype',]) {
 					const format = Dex.formats.get(gen + meta);
 					if (format.exists && Dex.formats.getRuleTable(format).isBannedSpecies(species)) {
 						if (!metagameBans[meta]) metagameBans[meta] = {};

--- a/play.pokemonshowdown.com/src/battle-dex-search.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-search.ts
@@ -1156,13 +1156,26 @@ class BattlePokemonSearch extends BattleTypedSearch<'pokemon'> {
 			];
 		}
 		const customBanlists = [
-			'ubersuu', 'almostanyability', 'balancedhackmons', 'godlygift', 'mixandmega', 'sharedpower', 'stabmons',
+			'ubersuu', 'almostanyability', 'balancedhackmons', 'godlygift', 'mixandmega', 'sharedpower', 'stabmons', 
+			'350cup', 'alphabetcup', 'badnboosted', 'battlefields', 'biomechmons', 'camomons', 'category swap', 'convergence', 
+			'crossevolution', 'ferventimpersonation', 'foresighters', 'formemons', 'fortemons', 'franticfusions', 'fullpotential',
+			'inheritance', 'inverse', 'natureswap', 'passiveaggressive', 'pokebilities', 'pokemoves', 'relayrace', 'revelationmons',
+			'sharingiscaring', 'teradonation', 'teraoverride', 'thecardgame', 'thelosersgame', 'tiershift', 'trademarked', 'typesplit',
 		];
 		if (customBanlists.includes(format) && table.metagameBans?.[format]) {
 			tierSet = tierSet.filter(([type, id]) => {
 				if (id in table.metagameBans[format]) return false;
 				if ('miraidon' in table.metagameBans[format] && 'calyrexshadow' in table.metagameBans[format] &&
 					type === 'header' && id === 'AG') return false;
+				const ubers = [
+					'annihilape', 'arceus', 'archaludon', 'baxcalibur', 'calyrexice', 'chiyu', 'chienpao', 'deoxys', 'dialga',
+					'dialgaorigin', 'espathra', 'eternatus', 'fluttermane', 'giratina', 'giratinaorigin', 'gougingfire', 'groudon',
+					'hooh', 'ironbundle', 'koraidon', 'kyogre', 'kyuremblack', 'kyuremwhite', 'landorus', 'lugia', 'lunala', 'magearna',
+					'mewtwo', 'necrozmadawnwings', 'necrozmaduskmane', 'ogerponhearthflame', 'palafin', 'palkia', 'palkiaorigin', 
+					'rayquaza', 'regieleki', 'reshiram', 'roaringmoon', 'shayminsky', 'sneasler', 'solgaleo', 'spectrier', 'terapagos',
+					'ursalunabloodmoon', 'urshifu', 'urshifurapidstrike', 'volcarona', 'zacian', 'zamazentacrowned', 'zekrom'
+				];
+				if (ubers.every(uber => uber in table.metagameBans[format] && type === 'header' && id === 'Uber')) return false;	
 				return true;
 			});
 		}


### PR DESCRIPTION
Just adds non permanent OMs to dhelmise's builder utility (useful for tours/roomtours/OMM building) as well as a check to get rid of the Uber header if every Uber mon is banned