### PR TITLE
Replace (fainted) text with 0/X hp

### DIFF
--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -873,7 +873,7 @@ export class BattleTooltips {
 		if (pokemon.fainted && pokemon.maxhp === 100) {
 			text += `<p><small>HP:</small> (fainted)</p>`;
 		} else if (pokemon.fainted) {
-			text += `<p><small>HP:</small> <s class="gray">0/${pokemon.maxhp}</s></p>`;
+			text += `<p><small>HP:</small> <span class="gray">0/${pokemon.maxhp} (fainted)</span></p>`;
 		} else if (this.battle.hardcoreMode) {
 			if (serverPokemon) {
 				const status = pokemon.status ? ` <span class="status ${pokemon.status}">${pokemon.status.toUpperCase()}</span>` : '';


### PR DESCRIPTION
Based on https://www.smogon.com/forums/threads/show-0-x-hp-instead-of-fainted-in-battle.3765617/

This only works for the Pokeicons below the trainer. Kind of a band-aid implementation, but not sure how interested we are in refactoring the HP system to avoid setting maxhp to 100.