### PR TITLE
Fix stale Leech Seed visual after Shed Tail switch

### DIFF
--- a/play.pokemonshowdown.com/src/battle.ts
+++ b/play.pokemonshowdown.com/src/battle.ts
@@ -441,8 +441,8 @@ export class Pokemon implements PokemonDetails, PokemonHealth {
 	 * copyAll = 'shedtail' means Shed Tail
 	 */
 	copyVolatileFrom(pokemon: Pokemon, copySource?: | 'shedtail' | boolean) {
-		this.boosts = pokemon.boosts;
-		this.volatiles = pokemon.volatiles;
+		this.boosts = { ...pokemon.boosts };
+		this.volatiles = { ...pokemon.volatiles };
 		// this.lastMove = pokemon.lastMove; // I think
 		if (!copySource) {
 			const volatilesToRemove = [
@@ -467,8 +467,7 @@ export class Pokemon implements PokemonDetails, PokemonHealth {
 		delete this.volatiles['formechange'];
 
 		pokemon.boosts = {};
-		pokemon.volatiles = {};
-		pokemon.side.battle.scene.removeTransform(pokemon);
+		pokemon.clearVolatiles();
 		pokemon.statusStage = 0;
 	}
 	copyTypesFrom(pokemon: Pokemon, preterastallized = false) {


### PR DESCRIPTION
Fixes a client-side visual desync where Leech Seed particles could remain on the incoming Pokémon after a seeded user switched out with Shed Tail.
Root cause: volatile state in copyVolatileForm reused shared object references, then removed entries without fully clearing source-side sprite effects.
Fix: clone boosts/volatiles instead of aliasing, and clear source volatile visuals after transfer so old effects (including Leech Seed) are removed reliably.
Changed file: play.pokemonshowdown.com/src/battle.ts
Validation: local build succeeds (npm run build), TS compile passes.

Closes [https://github.com/smogon/pokemon-showdown-client/issues/2447](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)