### PR TITLE
Make Maushold-Four default

### DIFF
--- a/play.pokemonshowdown.com/src/battle-dex-data.ts
+++ b/play.pokemonshowdown.com/src/battle-dex-data.ts
@@ -379,7 +379,7 @@ export const BattlePokemonIconIndexes: { [id: string]: number } = {
 	wooperpaldea: 1032 + 227,
 	oinkolognef: 1032 + 228,
 	palafinhero: 1032 + 229,
-	mausholdfour: 1032 + 230,
+	mausholdthree: 1032 + 230,
 	tatsugiridroopy: 1032 + 231,
 	tatsugiristretchy: 1032 + 232,
 	squawkabillyblue: 1032 + 233,


### PR DESCRIPTION
This requires renaming all of the 'Maushold' sprites to 'Maushold-Three' and the 'Maushold-Four' sprites to 'Maushold', as well as changing either the order of Maushold sprites on pokemonicons-sheet.png or changing where the Maushold formes appear in play.pokemonshowdown.com\src\battle-dex-data.ts.

Requires [server PR](https://github.com/smogon/pokemon-showdown/pull/11821).