### PR TITLE
Fix stat bars proportions for Champions, VGC and LC

### DIFF
--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1291,14 +1291,16 @@
 			if ($(window).width() < 640) this.show();
 		},
 		renderSet: function (set, i) {
+			var baseFormat = this.curTeam.format;
+			if (baseFormat.substr(-5) === 'draft') baseFormat = baseFormat.substr(0, baseFormat.length - 5);
 			var species = this.curTeam.dex.species.get(set.species);
-			var isChampions = this.curTeam.format.includes('champions');
-			var isLetsGo = this.curTeam.format.includes('letsgo');
-			var isBDSP = this.curTeam.format.includes('bdsp');
-			var isNatDex = this.curTeam.format.includes('nationaldex') || this.curTeam.format.includes('natdex');
-			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
-				this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
-			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
+			var isChampions = baseFormat.includes('champions');
+			var isLetsGo = baseFormat.includes('letsgo');
+			var isBDSP = baseFormat.includes('bdsp');
+			var isNatDex = baseFormat.includes('nationaldex') || baseFormat.includes('natdex');
+			var isVGC = baseFormat.includes('battlespot') || baseFormat.includes('bss') ||
+				baseFormat.includes('vgc') || baseFormat.includes('battlefestival');
+			var isLC = baseFormat.startsWith('lc') || baseFormat.endsWith('lc');
 			var buf = '<li value="' + i + '">';
 			if (!set.species) {
 				if (this.deletedSet) {
@@ -2077,11 +2079,13 @@
 
 			var stats = { hp: '', atk: '', def: '', spa: '', spd: '', spe: '' };
 
-			var usesStatPoints = this.curTeam.format.includes('champions');
-			var supportsEVs = !this.curTeam.format.includes('letsgo');
-			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
-				this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
-			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
+			var baseFormat = this.curTeam.format;
+			if (baseFormat.substr(-5) === 'draft') baseFormat = baseFormat.substr(0, baseFormat.length - 5);
+			var usesStatPoints = baseFormat.includes('champions');
+			var supportsEVs = !baseFormat.includes('letsgo');
+			var isVGC = baseFormat.includes('battlespot') || baseFormat.includes('bss') ||
+				baseFormat.includes('vgc') || baseFormat.includes('battlefestival');
+			var isLC = baseFormat.startsWith('lc') || baseFormat.endsWith('lc');
 
 			// stat cell
 			var buf = '<span class="statrow statrow-head"><label></label> <span class="statgraph"></span> <em>' + (usesStatPoints ? 'Points' : supportsEVs ? 'EV' : 'AV') + '</em></span>';
@@ -2361,15 +2365,17 @@
 			var nature = BattleNatures[set.nature || 'Serious'];
 			if (!nature) nature = {};
 
-			var usesStatPoints = this.curTeam.format.includes('champions');
-			var supportsEVs = !this.curTeam.format.includes('letsgo') && !usesStatPoints;
-			// var supportsAVs = !supportsEVs && this.curTeam.format.endsWith('norestrictions');
+			var baseFormat = this.curTeam.format;
+			if (baseFormat.substr(-5) === 'draft') baseFormat = baseFormat.substr(0, baseFormat.length - 5);
+			var usesStatPoints = baseFormat.includes('champions');
+			var supportsEVs = !baseFormat.includes('letsgo') && !usesStatPoints;
+			// var supportsAVs = !supportsEVs && baseFormat.endsWith('norestrictions');
 			var defaultEV = this.curTeam.gen <= 2 ? 252 : 0;
 			var maxEV = usesStatPoints ? 32 : supportsEVs ? 252 : 200;
 			var stepEV = supportsEVs ? 4 : 1;
-			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
-				this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
-			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
+			var isVGC = baseFormat.includes('battlespot') || baseFormat.includes('bss') ||
+				baseFormat.includes('vgc') || baseFormat.includes('battlefestival');
+			var isLC = baseFormat.startsWith('lc') || baseFormat.endsWith('lc');
 
 			// label column
 			buf += '<div class="col labelcol"><div></div>';

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1296,6 +1296,9 @@
 			var isLetsGo = this.curTeam.format.includes('letsgo');
 			var isBDSP = this.curTeam.format.includes('bdsp');
 			var isNatDex = this.curTeam.format.includes('nationaldex') || this.curTeam.format.includes('natdex');
+			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
+						this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
+			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
 			var buf = '<li value="' + i + '">';
 			if (!set.species) {
 				if (this.deletedSet) {
@@ -1409,15 +1412,16 @@
 				} else if (BattleNatures[set.nature] && BattleNatures[set.nature].minus === j) {
 					evBuf += '<small>&minus;</small>';
 				}
-				var highestStat = 499;
-				if (j === 'hp') highestStat = 714;
-				if (isChampions) {
-					if (j === 'hp') highestStat = 362;
-					else highestStat = 252;
+				var highestStat = j === 'hp' ? 714 : 499;
+				if (isChampions || isVGC) {
+					highestStat = j === 'hp' ? 362 : 252;
+				}
+				if (isLC) {
+					highestStat = j === 'hp' ? 45 : 29;
 				}
 				var width = stats[j] * 75 / highestStat;
 				if (width > 75) width = 75;
-				var color = Math.floor(stats[j] * 180 / (isChampions ? 362 : 714));
+				var color = Math.floor(stats[j] * 180 / highestStat);
 				if (color > 360) color = 360;
 				var statName = this.curTeam.gen === 1 && j === 'spa' ? 'Spc' : BattleStatNames[j];
 				buf += '<span class="statrow"><label>' + statName + '</label> <span class="statgraph"><span style="width:' + width + 'px;background:hsl(' + color + ',40%,75%);"></span></span> ' + evBuf + '</span>';
@@ -2075,6 +2079,9 @@
 
 			var usesStatPoints = this.curTeam.format.includes('champions');
 			var supportsEVs = !this.curTeam.format.includes('letsgo');
+			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
+						this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
+			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
 
 			// stat cell
 			var buf = '<span class="statrow statrow-head"><label></label> <span class="statgraph"></span> <em>' + (usesStatPoints ? 'Points' : supportsEVs ? 'EV' : 'AV') + '</em></span>';
@@ -2089,15 +2096,16 @@
 				} else if (BattleNatures[set.nature] && BattleNatures[set.nature].minus === stat) {
 					evBuf += '<small>&minus;</small>';
 				}
-				var highestStat = 499;
-				if (stat === 'hp') highestStat = 714;
-				if (usesStatPoints) {
-					if (stat === 'hp') highestStat = 362;
-					else highestStat = 252;
+				var highestStat = stat === 'hp' ? 714 : 499;
+				if (usesStatPoints || isVGC) {
+					highestStat = stat === 'hp' ? 362 : 252;
+				}
+				if (isLC) {
+					highestStat = stat === 'hp' ? 45 : 29;
 				}
 				var width = stats[stat] * 75 / highestStat;
 				if (width > 75) width = 75;
-				var color = Math.floor(stats[stat] * 180 / (usesStatPoints ? 362 : 714));
+				var color = Math.floor(stats[stat] * 180 / highestStat);
 				if (color > 360) color = 360;
 				var statName = this.curTeam.gen === 1 && stat === 'spa' ? 'Spc' : BattleStatNames[stat];
 				buf += '<span class="statrow"><label>' + statName + '</label> <span class="statgraph"><span style="width:' + width + 'px;background:hsl(' + color + ',40%,75%);"></span></span> ' + evBuf + '</span>';
@@ -2117,15 +2125,16 @@
 			var totalev = 0;
 			for (var stat in stats) {
 				if (stat === 'spd' && this.curTeam.gen === 1) continue;
-				var highestStat = 499;
-				if (stat === 'hp') highestStat = 714;
-				if (usesStatPoints) {
-					if (stat === 'hp') highestStat = 362;
-					else highestStat = 252;
+				var highestStat = stat === 'hp' ? 714 : 499;
+				if (usesStatPoints || isVGC) {
+					highestStat = stat === 'hp' ? 362 : 252;
+				}
+				if (isLC) {
+					highestStat = stat === 'hp' ? 45 : 29;
 				}
 				var width = stats[stat] * 180 / highestStat;
 				if (width > 179) width = 179;
-				var color = Math.floor(stats[stat] * 180 / (usesStatPoints ? 362 : 714));
+				var color = Math.floor(stats[stat] * 180 / highestStat);
 				if (color > 360) color = 360;
 				buf += '<div><em><span style="width:' + Math.floor(width) + 'px;background:hsl(' + color + ',85%,45%);border-color:hsl(' + color + ',85%,35%)"></span></em></div>';
 				totalev += (set.evs[stat] || 0);
@@ -2358,6 +2367,9 @@
 			var defaultEV = this.curTeam.gen <= 2 ? 252 : 0;
 			var maxEV = usesStatPoints ? 32 : supportsEVs ? 252 : 200;
 			var stepEV = supportsEVs ? 4 : 1;
+			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
+						this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
+			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
 
 			// label column
 			buf += '<div class="col labelcol"><div></div>';
@@ -2379,15 +2391,16 @@
 			buf += '<div class="col graphcol"><div></div>';
 			for (var i in stats) {
 				stats[i] = this.getStat(i);
-				var highestStat = 499;
-				if (i === 'hp') highestStat = 714;
-				if (usesStatPoints) {
-					if (i === 'hp') highestStat = 362;
-					else highestStat = 252;
+				var highestStat = i === 'hp' ? 714 : 499;
+				if (usesStatPoints || isVGC) {
+					highestStat = i === 'hp' ? 362 : 252;
+				}
+				if (isLC) {
+					highestStat = i === 'hp' ? 45 : 29;
 				}
 				var width = stats[i] * 180 / highestStat;
 				if (width > 179) width = 179;
-				var color = Math.floor(stats[i] * 180 / (usesStatPoints ? 362 : 714));
+				var color = Math.floor(stats[i] * 180 / highestStat);
 				if (color > 360) color = 360;
 				buf += '<div><em><span style="width:' + Math.floor(width) + 'px;background:hsl(' + color + ',85%,45%);border-color:hsl(' + color + ',85%,35%)"></span></em></div>';
 			}

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1297,7 +1297,7 @@
 			var isBDSP = this.curTeam.format.includes('bdsp');
 			var isNatDex = this.curTeam.format.includes('nationaldex') || this.curTeam.format.includes('natdex');
 			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
-						this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
+				this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
 			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
 			var buf = '<li value="' + i + '">';
 			if (!set.species) {
@@ -2080,7 +2080,7 @@
 			var usesStatPoints = this.curTeam.format.includes('champions');
 			var supportsEVs = !this.curTeam.format.includes('letsgo');
 			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
-						this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
+				this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
 			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
 
 			// stat cell
@@ -2368,7 +2368,7 @@
 			var maxEV = usesStatPoints ? 32 : supportsEVs ? 252 : 200;
 			var stepEV = supportsEVs ? 4 : 1;
 			var isVGC = this.curTeam.format.includes('battlespot') || this.curTeam.format.includes('bss') ||
-						this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
+				this.curTeam.format.includes('vgc') || this.curTeam.format.includes('battlefestival');
 			var isLC = this.curTeam.format.startsWith('lc') || this.curTeam.format.endsWith('lc');
 
 			// label column

--- a/play.pokemonshowdown.com/js/client-teambuilder.js
+++ b/play.pokemonshowdown.com/js/client-teambuilder.js
@@ -1409,16 +1409,15 @@
 				} else if (BattleNatures[set.nature] && BattleNatures[set.nature].minus === j) {
 					evBuf += '<small>&minus;</small>';
 				}
-				var highestStat = 504;
-				if (j === 'hp') highestStat = 704;
+				var highestStat = 499;
+				if (j === 'hp') highestStat = 714;
 				if (isChampions) {
-					if (j === 'hp') highestStat = 267;
-					else highestStat = 310;
+					if (j === 'hp') highestStat = 362;
+					else highestStat = 252;
 				}
 				var width = stats[j] * 75 / highestStat;
-				if (j === 'hp') width = stats[j] * 75 / highestStat;
 				if (width > 75) width = 75;
-				var color = Math.floor(stats[j] * 180 / (isChampions ? 310 : 714));
+				var color = Math.floor(stats[j] * 180 / (isChampions ? 362 : 714));
 				if (color > 360) color = 360;
 				var statName = this.curTeam.gen === 1 && j === 'spa' ? 'Spc' : BattleStatNames[j];
 				buf += '<span class="statrow"><label>' + statName + '</label> <span class="statgraph"><span style="width:' + width + 'px;background:hsl(' + color + ',40%,75%);"></span></span> ' + evBuf + '</span>';
@@ -2090,16 +2089,15 @@
 				} else if (BattleNatures[set.nature] && BattleNatures[set.nature].minus === stat) {
 					evBuf += '<small>&minus;</small>';
 				}
-				var highestStat = 504;
-				if (stat === 'hp') highestStat = 704;
+				var highestStat = 499;
+				if (stat === 'hp') highestStat = 714;
 				if (usesStatPoints) {
-					if (stat === 'hp') highestStat = 267;
-					else highestStat = 310;
+					if (stat === 'hp') highestStat = 362;
+					else highestStat = 252;
 				}
 				var width = stats[stat] * 75 / highestStat;
-				if (stat === 'hp') width = stats[stat] * 75 / highestStat;
 				if (width > 75) width = 75;
-				var color = Math.floor(stats[stat] * 180 / (usesStatPoints ? 310 : 714));
+				var color = Math.floor(stats[stat] * 180 / (usesStatPoints ? 362 : 714));
 				if (color > 360) color = 360;
 				var statName = this.curTeam.gen === 1 && stat === 'spa' ? 'Spc' : BattleStatNames[stat];
 				buf += '<span class="statrow"><label>' + statName + '</label> <span class="statgraph"><span style="width:' + width + 'px;background:hsl(' + color + ',40%,75%);"></span></span> ' + evBuf + '</span>';
@@ -2119,16 +2117,15 @@
 			var totalev = 0;
 			for (var stat in stats) {
 				if (stat === 'spd' && this.curTeam.gen === 1) continue;
-				var highestStat = 504;
-				if (stat === 'hp') highestStat = 704;
+				var highestStat = 499;
+				if (stat === 'hp') highestStat = 714;
 				if (usesStatPoints) {
-					if (stat === 'hp') highestStat = 267;
-					else highestStat = 310;
+					if (stat === 'hp') highestStat = 362;
+					else highestStat = 252;
 				}
 				var width = stats[stat] * 180 / highestStat;
-				if (stat === 'hp') width = stats[stat] * 180 / highestStat;
 				if (width > 179) width = 179;
-				var color = Math.floor(stats[stat] * 180 / (usesStatPoints ? 310 : 714));
+				var color = Math.floor(stats[stat] * 180 / (usesStatPoints ? 362 : 714));
 				if (color > 360) color = 360;
 				buf += '<div><em><span style="width:' + Math.floor(width) + 'px;background:hsl(' + color + ',85%,45%);border-color:hsl(' + color + ',85%,35%)"></span></em></div>';
 				totalev += (set.evs[stat] || 0);
@@ -2382,16 +2379,15 @@
 			buf += '<div class="col graphcol"><div></div>';
 			for (var i in stats) {
 				stats[i] = this.getStat(i);
-				var highestStat = 504;
-				if (i === 'hp') highestStat = 704;
+				var highestStat = 499;
+				if (i === 'hp') highestStat = 714;
 				if (usesStatPoints) {
-					if (i === 'hp') highestStat = 267;
-					else highestStat = 310;
+					if (i === 'hp') highestStat = 362;
+					else highestStat = 252;
 				}
 				var width = stats[i] * 180 / highestStat;
-				if (i === 'hp') width = Math.floor(stats[i] * 180 / highestStat);
 				if (width > 179) width = 179;
-				var color = Math.floor(stats[i] * 180 / (usesStatPoints ? 310 : 714));
+				var color = Math.floor(stats[i] * 180 / (usesStatPoints ? 362 : 714));
 				if (color > 360) color = 360;
 				buf += '<div><em><span style="width:' + Math.floor(width) + 'px;background:hsl(' + color + ',85%,45%);border-color:hsl(' + color + ',85%,35%)"></span></em></div>';
 			}

--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -2453,8 +2453,8 @@ class StatForm extends preact.Component<{
 			const maxStat = statID === 'hp' ?
 				Math.floor(176 * editor.defaultLevel / 25) + 10 :
 				Math.floor(247 * editor.defaultLevel / 50) + 5;
-			let width = Math.min(stat * 75 / maxStat, 75);
-			let hue = Math.min(Math.floor(stat * 180 / maxStat), 360);
+			const width = Math.min(stat * 75 / maxStat, 75);
+			const hue = Math.min(Math.floor(stat * 180 / maxStat), 360);
 			const statName = editor.gen === 1 && statID === 'spa' ? 'Spc' : BattleStatNames[statID];
 			if (evs && !ev && !set.evs && statID === 'hp') ev = 'EVs';
 			return <span class="statrow">
@@ -2718,8 +2718,8 @@ class StatForm extends preact.Component<{
 		const maxStat = statID === 'hp' ?
 			Math.floor(176 * editor.defaultLevel / 25) + 10 :
 			Math.floor(247 * editor.defaultLevel / 50) + 5;
-		let width = Math.min(stat * 180 / maxStat, 180);
-		let hue = Math.min(Math.floor(stat * 180 / maxStat), 360);
+		const width = Math.min(stat * 180 / maxStat, 180);
+		const hue = Math.min(Math.floor(stat * 180 / maxStat), 360);
 		return <span
 			style={`width:${Math.floor(width)}px;background:hsl(${hue},85%,45%);border-color:hsl(${hue},85%,35%)`}
 		></span>;

--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -116,7 +116,8 @@ export class TeamEditorState extends PSModel {
 		this.defaultLevel = 100;
 		if (
 			formatid.includes('vgc') || formatid.includes('bss') || formatid.includes('ultrasinnohclassic') ||
-			formatid.includes('battlespot') || formatid.includes('battlestadium') || formatid.includes('battlefestival')
+			formatid.includes('battlespot') || formatid.includes('battlestadium') || formatid.includes('battlefestival') ||
+			formatid.includes('letsgo') || formatid.includes('champions')
 		) {
 			this.defaultLevel = 50;
 		}

--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -2453,10 +2453,8 @@ class StatForm extends preact.Component<{
 			const maxStat = statID === 'hp' ?
 				Math.floor(176 * editor.defaultLevel / 25) + 10 :
 				Math.floor(247 * editor.defaultLevel / 50) + 5;
-			let width = stat * 75 / maxStat;
-			if (width > 75) width = 75;
-			let hue = Math.floor(stat * 180 / maxStat);
-			if (hue > 360) hue = 360;
+			let width = Math.min(stat * 75 / maxStat, 75);
+			let hue = Math.min(Math.floor(stat * 180 / maxStat), 360);
 			const statName = editor.gen === 1 && statID === 'spa' ? 'Spc' : BattleStatNames[statID];
 			if (evs && !ev && !set.evs && statID === 'hp') ev = 'EVs';
 			return <span class="statrow">
@@ -2720,10 +2718,8 @@ class StatForm extends preact.Component<{
 		const maxStat = statID === 'hp' ?
 			Math.floor(176 * editor.defaultLevel / 25) + 10 :
 			Math.floor(247 * editor.defaultLevel / 50) + 5;
-		let width = stat * 180 / maxStat;
-		if (width > 179) width = 179;
-		let hue = Math.floor(stat * 180 / maxStat);
-		if (hue > 360) hue = 360;
+		let width = Math.min(stat * 180 / maxStat, 180);
+		let hue = Math.min(Math.floor(stat * 180 / maxStat), 360);
 		return <span
 			style={`width:${Math.floor(width)}px;background:hsl(${hue},85%,45%);border-color:hsl(${hue},85%,35%)`}
 		></span>;

--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -2449,10 +2449,12 @@ class StatForm extends preact.Component<{
 
 			const stat = editor.getStat(statID, set, ivs[statID]);
 			let ev: number | string = set.evs ? (set.evs[statID] || 0) : defaultEV;
-			let width = stat * 75 / 504;
-			if (statID === 'hp') width = stat * 75 / 704;
+			const maxStat = statID === 'hp' ?
+				Math.floor(176 * editor.defaultLevel / 25) + 10 :
+				Math.floor(247 * editor.defaultLevel / 50) + 5;
+			let width = stat * 75 / maxStat;
 			if (width > 75) width = 75;
-			let hue = Math.floor(stat * 180 / 714);
+			let hue = Math.floor(stat * 180 / maxStat);
 			if (hue > 360) hue = 360;
 			const statName = editor.gen === 1 && statID === 'spa' ? 'Spc' : BattleStatNames[statID];
 			if (evs && !ev && !set.evs && statID === 'hp') ev = 'EVs';
@@ -2713,10 +2715,13 @@ class StatForm extends preact.Component<{
 	plus: Dex.StatNameExceptHP | null = null;
 	minus: Dex.StatNameExceptHP | null = null;
 	renderStatbar(stat: number, statID: StatName) {
-		let width = stat * 180 / 504;
-		if (statID === 'hp') width = Math.floor(stat * 180 / 704);
+		const { editor } = this.props;
+		const maxStat = statID === 'hp' ?
+			Math.floor(176 * editor.defaultLevel / 25) + 10 :
+			Math.floor(247 * editor.defaultLevel / 50) + 5;
+		let width = stat * 180 / maxStat;
 		if (width > 179) width = 179;
-		let hue = Math.floor(stat * 180 / 714);
+		let hue = Math.floor(stat * 180 / maxStat);
 		if (hue > 360) hue = 360;
 		return <span
 			style={`width:${Math.floor(width)}px;background:hsl(${hue},85%,45%);border-color:hsl(${hue},85%,35%)`}


### PR DESCRIPTION
It makes the stat bars have the same proportions for different levels. We could probably use Champions values for VGC and BSS formats, and use 45 (HP) and 29 (other stats) for Little Cup.

Edit: I'm fixing it for VGC and LC.