### PR TITLE
Preact: Fix "friend came online" console messages now leave dm box as unread

### DIFF
--- a/play.pokemonshowdown.com/src/panel-chat.tsx
+++ b/play.pokemonshowdown.com/src/panel-chat.tsx
@@ -158,6 +158,9 @@ export class ChatRoom extends PSRoom {
 						title: `${this.title}`,
 						body: textContent,
 					});
+				} else if (!isIgnored) {
+					// /nonotify messages (e.g. "friend came online") should still mark the room as unread
+					this.subtleNotify();
 				}
 			} else {
 				this.subtleNotify();


### PR DESCRIPTION
when a friend comes online the server sends a `|pm|~|USER|/nonotify Your friend ... has just connected!` PM. the `/nonotify` is intentional, it suppresses the full desktop notification popup. however, in panel-chat.tsx the `dm-` room's handler only skipped `notify()` for `nonotify()` messages but never called `subtleNotify()` either, so the room tab showed no indication of new content.