### PR TITLE
Get rid of FRLG custom tier logic

### DIFF
--- a/build-tools/build-indexes
+++ b/build-tools/build-indexes
@@ -622,7 +622,7 @@ process.stdout.write("Building `data/teambuilder-tables.js`... ");
 			if (isVGC || isGen9BH) {
 				return ["Mythical", "Restricted", "Regular", "NFE", "LC"];
 			}
-			if (isRS || isFRLG) {
+			if (isRS) {
 				return ["Regular", "NFE", "LC", "Uber"];
 			}
 			if (isDoubles && genNum > 4) {


### PR DESCRIPTION
FRLG OU now has an OU/UU split as of https://github.com/smogon/pokemon-showdown/commit/55725c3ade51b83ba0af7a10c844262595b5a20e, so the custom tier logic is no longer necessary.