### PR TITLE
Preact: subscribe ChatUserList to room to prevent blank user list on join/refresh

### DIFF
--- a/play.pokemonshowdown.com/src/panel-chat.tsx
+++ b/play.pokemonshowdown.com/src/panel-chat.tsx
@@ -1428,12 +1428,18 @@ export class ChatUserList extends preact.Component<{
 	room: ChatRoom, left?: number, top?: number, minimized?: boolean, static?: boolean,
 }> {
 	subscription: PSSubscription | null = null;
+	subscribeTimeout: number | null = null;
 	override componentDidMount() {
-		this.subscription = this.props.room.subscribe(args => {
-			if (!args) this.forceUpdate();
-		});
+		this.subscribeTimeout = window.setTimeout(() => {
+			this.subscribeTimeout = null;
+			this.subscription = this.props.room.subscribe(args => {
+				if (!args) this.forceUpdate();
+			});
+			this.forceUpdate();
+		}, 0);
 	}
 	override componentWillUnmount() {
+		if (this.subscribeTimeout !== null) window.clearTimeout(this.subscribeTimeout);
 		this.subscription?.unsubscribe();
 	}
 	render() {

--- a/play.pokemonshowdown.com/src/panel-chat.tsx
+++ b/play.pokemonshowdown.com/src/panel-chat.tsx
@@ -1427,6 +1427,15 @@ class ChatPanel extends PSRoomPanel<ChatRoom> {
 export class ChatUserList extends preact.Component<{
 	room: ChatRoom, left?: number, top?: number, minimized?: boolean, static?: boolean,
 }> {
+	subscription: PSSubscription | null = null;
+	override componentDidMount() {
+		this.subscription = this.props.room.subscribe(args => {
+			if (!args) this.forceUpdate();
+		});
+	}
+	override componentWillUnmount() {
+		this.subscription?.unsubscribe();
+	}
 	render() {
 		const room = this.props.room;
 		const pmTargetid = room.pmTarget ? toID(room.pmTarget) : null;


### PR DESCRIPTION
bug fix: `User list is blank when you join a room or refresh, happens rarely` https://github.com/orgs/smogon/projects/2?pane=issue&itemId=111176277