### PR TITLE
Preact: Fix scrolling news tab UI freeze

### DIFF
--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -495,7 +495,8 @@ class NewsPanel extends PSRoomPanel {
 	};
 	override render() {
 		const cookieSet = document.cookie.includes('preactalpha=1');
-		return <PSPanelWrapper room={this.props.room} fullSize scrollable>
+		const tinyLayout = PS.mainmenu.width < 620;
+		return <PSPanelWrapper room={this.props.room} fullSize={tinyLayout} scrollable={!tinyLayout}>
 			<div class="construction">
 				This is the client rewrite beta test.
 				<form>

--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -495,7 +495,7 @@ class NewsPanel extends PSRoomPanel {
 	};
 	override render() {
 		const cookieSet = document.cookie.includes('preactalpha=1');
-		return <PSPanelWrapper room={this.props.room} fullSize scrollable>
+		return <PSPanelWrapper room={this.props.room} scrollable>
 			<div class="construction">
 				This is the client rewrite beta test.
 				<form>

--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -495,7 +495,7 @@ class NewsPanel extends PSRoomPanel {
 	};
 	override render() {
 		const cookieSet = document.cookie.includes('preactalpha=1');
-		return <PSPanelWrapper room={this.props.room} scrollable>
+		return <PSPanelWrapper room={this.props.room} fullSize scrollable>
 			<div class="construction">
 				This is the client rewrite beta test.
 				<form>

--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -495,8 +495,7 @@ class NewsPanel extends PSRoomPanel {
 	};
 	override render() {
 		const cookieSet = document.cookie.includes('preactalpha=1');
-		const tinyLayout = PS.mainmenu.width < 620;
-		return <PSPanelWrapper room={this.props.room} fullSize={tinyLayout} scrollable={!tinyLayout}>
+		return <PSPanelWrapper room={this.props.room}>
 			<div class="construction">
 				This is the client rewrite beta test.
 				<form>

--- a/play.pokemonshowdown.com/src/panel-topbar.tsx
+++ b/play.pokemonshowdown.com/src/panel-topbar.tsx
@@ -297,14 +297,20 @@ export class PSHeader extends preact.Component {
 }
 
 export class PSMiniHeader extends preact.Component {
+	scrollRaf: number | null = null;
 	override componentDidMount() {
 		window.addEventListener('scroll', this.handleScroll);
 	}
 	override componentWillUnmount() {
 		window.removeEventListener('scroll', this.handleScroll);
+		if (this.scrollRaf !== null) cancelAnimationFrame(this.scrollRaf);
 	}
 	handleScroll = () => {
-		this.forceUpdate();
+		if (this.scrollRaf !== null) return;
+		this.scrollRaf = requestAnimationFrame(() => {
+			this.scrollRaf = null;
+			this.forceUpdate();
+		});
 	};
 	override render() {
 		if (PS.leftPanelWidth !== null) return null;

--- a/play.pokemonshowdown.com/src/panels.tsx
+++ b/play.pokemonshowdown.com/src/panels.tsx
@@ -282,10 +282,11 @@ export function PSPanelWrapper(props: {
 }) {
 	const room = props.room;
 	if (room.location === 'mini-window') {
-		const size = props.fullSize ? ' mini-window-flex' : '';
+		const tinyLayout = PS.mainmenu.width < 620;
+		const size = (props.fullSize ?? tinyLayout) ? ' mini-window-flex' : '';
 		return <div
 			id={`room-${room.id}`}
-			class={`mini-window-contents tiny-layout ps-room-light${props.scrollable === true ? ' scrollable' : ''}${size}`}
+			class={`mini-window-contents tiny-layout ps-room-light${(props.scrollable ?? !tinyLayout) === true ? ' scrollable' : ''}${size}`}
 			onClick={props.focusClick ? PSView.focusIfNoSelection : undefined} onDragEnter={props.onDragEnter}
 		>
 			{props.children}

--- a/play.pokemonshowdown.com/src/panels.tsx
+++ b/play.pokemonshowdown.com/src/panels.tsx
@@ -284,9 +284,10 @@ export function PSPanelWrapper(props: {
 	if (room.location === 'mini-window') {
 		const tinyLayout = PS.mainmenu.width < 620;
 		const size = (props.fullSize ?? tinyLayout) ? ' mini-window-flex' : '';
+		const scrollable = (props.scrollable ?? !tinyLayout) === true;
 		return <div
 			id={`room-${room.id}`}
-			class={`mini-window-contents tiny-layout ps-room-light${(props.scrollable ?? !tinyLayout) === true ? ' scrollable' : ''}${size}`}
+			class={`mini-window-contents tiny-layout ps-room-light${scrollable ? ' scrollable' : ''}${size}`}
 			onClick={props.focusClick ? PSView.focusIfNoSelection : undefined} onDragEnter={props.onDragEnter}
 		>
 			{props.children}


### PR DESCRIPTION
`NewsPanel` passed `fullSize` to `PSPanelWrapper`, which adds the `mini-window-flex` CSS class `height: auto`. in wide mode the `.mainmenu-mini-windows` container is `position: absolute`, so its content is excluded from the parent scroll container's `scrollHeight` scrolling the page couldn't reach the news content, making the UI appear frozen. bug fix: `Scrolling News tab freezes UI` https://github.com/orgs/smogon/projects/2?pane=issue&itemId=111176277