### PR TITLE
Preact: Fix DM challenge edge cases

### DIFF
--- a/play.pokemonshowdown.com/src/panel-chat.tsx
+++ b/play.pokemonshowdown.com/src/panel-chat.tsx
@@ -351,7 +351,12 @@ export class ChatRoom extends PSRoom {
 			this.challenged = null;
 			this.teamSent = null;
 			this.update(null);
-			this.sendDirect(`/reject ${target}`);
+			const userid = toID(target || this.pmTarget || '');
+			PS.send(userid ? `/reject ${userid}` : `/reject`);
+		},
+		'accept'(target) {
+			const userid = toID(target || this.pmTarget || '');
+			PS.send(userid ? `/accept ${userid}` : `/accept`);
 		},
 		'clear'() {
 			this.log?.reset();
@@ -598,6 +603,7 @@ export class ChatRoom extends PSRoom {
 			this.add(`|error|Can only be used in a PM.`);
 			return;
 		}
+		if (this.challenged) return;
 		this.challengeMenuOpen = true;
 		this.update(null);
 	}
@@ -679,7 +685,11 @@ export class ChatRoom extends PSRoom {
 	}
 	override sendDirect(line: string) {
 		if (this.pmTarget) {
-			line = line.split('\n').filter(Boolean).map(row => `/pm ${this.pmTarget!}, ${row}`).join('\n');
+			const rows = line.split('\n').filter(Boolean);
+			if (rows.some(row => row.startsWith('/') && !row.startsWith('//'))) {
+				PS.mainmenu.trackPMCommandTarget(this.pmTarget);
+			}
+			line = rows.map(row => `/pm ${this.pmTarget!}, ${row}`).join('\n');
 			PS.send(line);
 			return;
 		}
@@ -1344,7 +1354,7 @@ class ChatPanel extends PSRoomPanel<ChatRoom> {
 		const packedTeam = team ? team.packedTeam : '';
 		if (!room.pmTarget) throw new Error("Not a PM room");
 		PS.send(`/utm ${packedTeam}`);
-		this.props.room.send(`/accept`);
+		PS.send(`/accept ${toID(room.pmTarget)}`);
 		room.teamSent = format || '-';
 		room.update(null);
 	};

--- a/play.pokemonshowdown.com/src/panel-chat.tsx
+++ b/play.pokemonshowdown.com/src/panel-chat.tsx
@@ -354,10 +354,6 @@ export class ChatRoom extends PSRoom {
 			const userid = toID(target || this.pmTarget || '');
 			PS.send(userid ? `/reject ${userid}` : `/reject`);
 		},
-		'accept'(target) {
-			const userid = toID(target || this.pmTarget || '');
-			PS.send(userid ? `/accept ${userid}` : `/accept`);
-		},
 		'clear'() {
 			this.log?.reset();
 			this.update(null);
@@ -685,11 +681,7 @@ export class ChatRoom extends PSRoom {
 	}
 	override sendDirect(line: string) {
 		if (this.pmTarget) {
-			const rows = line.split('\n').filter(Boolean);
-			if (rows.some(row => row.startsWith('/') && !row.startsWith('//'))) {
-				PS.mainmenu.trackPMCommandTarget(this.pmTarget);
-			}
-			line = rows.map(row => `/pm ${this.pmTarget!}, ${row}`).join('\n');
+			line = line.split('\n').filter(Boolean).map(row => `/pm ${this.pmTarget!}, ${row}`).join('\n');
 			PS.send(line);
 			return;
 		}

--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -49,7 +49,6 @@ export class MainMenuRoom extends PSRoom {
 	search: { searching: string[], games: Record<RoomID, string> | null } = { searching: [], games: null };
 	disallowSpectators: boolean | null = PS.prefs.disallowspectators;
 	lastChallenged: number | null = null;
-	pendingPMCommandTargets: { name: string, time: number }[] = [];
 	constructor(options: RoomOptions) {
 		super(options);
 		if (this.backlog) {
@@ -61,21 +60,6 @@ export class MainMenuRoom extends PSRoom {
 			}
 			this.backlog = null;
 		}
-	}
-	trackPMCommandTarget(name: string) {
-		if (!toID(name)) return;
-		const now = Date.now();
-		this.pendingPMCommandTargets = this.pendingPMCommandTargets.filter(pending => now - pending.time <= 30_000);
-		this.pendingPMCommandTargets.push({ name, time: now });
-		if (this.pendingPMCommandTargets.length > 10) this.pendingPMCommandTargets.shift();
-	}
-	consumePMCommandTarget() {
-		const now = Date.now();
-		while (this.pendingPMCommandTargets.length) {
-			const pending = this.pendingPMCommandTargets.shift()!;
-			if (now - pending.time <= 30_000) return pending.name;
-		}
-		return null;
 	}
 	adjustPrivacy() {
 		PS.prefs.set('disallowspectators', this.disallowSpectators);
@@ -373,15 +357,8 @@ export class MainMenuRoom extends PSRoom {
 	handlePM(user1: string, user2: string, message?: string) {
 		const userid1 = toID(user1);
 		const userid2 = toID(user2);
-		let pmTarget = PS.user.userid === userid1 ? user2 : user1;
-		let pmTargetid = PS.user.userid === userid1 ? userid2 : userid1;
-		if (PS.user.userid === userid1 && !userid2 && message?.startsWith('/error ')) {
-			const pendingPMTarget = this.consumePMCommandTarget();
-			if (pendingPMTarget) {
-				pmTarget = pendingPMTarget;
-				pmTargetid = toID(pendingPMTarget);
-			}
-		}
+		const pmTarget = PS.user.userid === userid1 ? user2 : user1;
+		const pmTargetid = PS.user.userid === userid1 ? userid2 : userid1;
 		let roomid = `dm-${pmTargetid}` as RoomID;
 		if (pmTargetid === PS.user.userid) roomid = 'dm-' as RoomID;
 		let room = PS.rooms[roomid] as ChatRoom | undefined;

--- a/play.pokemonshowdown.com/src/panel-mainmenu.tsx
+++ b/play.pokemonshowdown.com/src/panel-mainmenu.tsx
@@ -49,6 +49,7 @@ export class MainMenuRoom extends PSRoom {
 	search: { searching: string[], games: Record<RoomID, string> | null } = { searching: [], games: null };
 	disallowSpectators: boolean | null = PS.prefs.disallowspectators;
 	lastChallenged: number | null = null;
+	pendingPMCommandTargets: { name: string, time: number }[] = [];
 	constructor(options: RoomOptions) {
 		super(options);
 		if (this.backlog) {
@@ -60,6 +61,21 @@ export class MainMenuRoom extends PSRoom {
 			}
 			this.backlog = null;
 		}
+	}
+	trackPMCommandTarget(name: string) {
+		if (!toID(name)) return;
+		const now = Date.now();
+		this.pendingPMCommandTargets = this.pendingPMCommandTargets.filter(pending => now - pending.time <= 30_000);
+		this.pendingPMCommandTargets.push({ name, time: now });
+		if (this.pendingPMCommandTargets.length > 10) this.pendingPMCommandTargets.shift();
+	}
+	consumePMCommandTarget() {
+		const now = Date.now();
+		while (this.pendingPMCommandTargets.length) {
+			const pending = this.pendingPMCommandTargets.shift()!;
+			if (now - pending.time <= 30_000) return pending.name;
+		}
+		return null;
 	}
 	adjustPrivacy() {
 		PS.prefs.set('disallowspectators', this.disallowSpectators);
@@ -357,8 +373,15 @@ export class MainMenuRoom extends PSRoom {
 	handlePM(user1: string, user2: string, message?: string) {
 		const userid1 = toID(user1);
 		const userid2 = toID(user2);
-		const pmTarget = PS.user.userid === userid1 ? user2 : user1;
-		const pmTargetid = PS.user.userid === userid1 ? userid2 : userid1;
+		let pmTarget = PS.user.userid === userid1 ? user2 : user1;
+		let pmTargetid = PS.user.userid === userid1 ? userid2 : userid1;
+		if (PS.user.userid === userid1 && !userid2 && message?.startsWith('/error ')) {
+			const pendingPMTarget = this.consumePMCommandTarget();
+			if (pendingPMTarget) {
+				pmTarget = pendingPMTarget;
+				pmTargetid = toID(pendingPMTarget);
+			}
+		}
 		let roomid = `dm-${pmTargetid}` as RoomID;
 		if (pmTargetid === PS.user.userid) roomid = 'dm-' as RoomID;
 		let room = PS.rooms[roomid] as ChatRoom | undefined;


### PR DESCRIPTION
## Summary
- Prevent opening the outgoing challenge form in a PM while an incoming challenge from that user is active.
- Send PM challenge reject actions as global challenge commands targeting the PM user, matching old-client behavior for offline users.
- Send the incoming-challenge Accept button as a global targeted `/accept` command instead of routing it through the PM room.

## Validation
- `npm test`
- Targeted protocol smoke against rebuilt `panel-chat.js`:
  - Incoming challenge blocks the outgoing challenge menu.
  - PM `/reject` emits global `/reject alice`.
  - Typed PM `/accept` remains routed through the PM room and is intentionally not special-cased.

Note: the build step still logs `php: command not found` while trying to retrieve news, but `npm test` completed successfully.