### PR TITLE
Teambuilder: Roll default Pokémon gender according to gender ratio

### DIFF
--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -209,6 +209,13 @@ export class TeamEditorState extends PSModel {
 		set.species = species.name;
 		set.ability = this.getDefaultAbility(set);
 		set.item = this.getDefaultItem(species.name) ?? set.item;
+		if (!set.gender && species.genderRatio) {
+			const ratio = species.genderRatio;
+			const total = ratio.M + ratio.F;
+			if (total > 0) {
+				set.gender = Math.random() < ratio.M / total ? 'M' : 'F';
+			}
+		} 
 
 		if (toID(speciesName) === 'Cathy') {
 			set.name = "Cathy";


### PR DESCRIPTION
Related Smogon threads:
- [Have randomized genders reflect in-game gender ratio of Pokemon](https://www.smogon.com/forums/threads/have-randomized-genders-reflect-in-game-gender-ratio-of-pokemon.3700500/#post-9184371) (pending approval)
- [Lock gender in best-of-X series](https://www.smogon.com/forums/threads/lock-gender-in-best-of-x-series.3781777/) (pending approval)

Related PRs:
- smogon/pokemon-showdown#12005

I originally noticed this because genders were inconsistent in a bo3 series but it seems like there was some more spirited debate a couple years back on this subject without a definite consensus. Let me know if this is a better approach than the first PR, thanks!