### PR TITLE
Champions: Prefer max IVs

### DIFF
--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -579,7 +579,7 @@ export class TeamEditorState extends PSModel {
 		// only available through an event with 31 Spe IVs
 		if (set.species.startsWith('Terapagos')) minSpe = false;
 
-		const preferMaxAtkFormats = ['1v1', 'categoryswap', 'partnersincrime', 'typesplit'];
+		const preferMaxAtkFormats = ['1v1', 'categoryswap', 'partnersincrime', 'typesplit', 'champions'];
 		if (preferMaxAtkFormats.some(f => this.format.includes(f))) {
 			minAtk = false;
 			return { minAtk, minSpe };

--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -576,10 +576,16 @@ export class TeamEditorState extends PSModel {
 		let minSpe = !set.evs?.spe && set.moves.includes('Gyro Ball');
 		let minAtk = !set.evs?.atk;
 
+		if (this.format.includes('champions')) {
+			minSpe = false;
+			minAtk = false;
+			return { minAtk, minSpe };
+		}
+
 		// only available through an event with 31 Spe IVs
 		if (set.species.startsWith('Terapagos')) minSpe = false;
 
-		const preferMaxAtkFormats = ['1v1', 'categoryswap', 'partnersincrime', 'typesplit', 'champions'];
+		const preferMaxAtkFormats = ['1v1', 'categoryswap', 'partnersincrime', 'typesplit'];
 		if (preferMaxAtkFormats.some(f => this.format.includes(f))) {
 			minAtk = false;
 			return { minAtk, minSpe };


### PR DESCRIPTION
You cannot adjust IVs in Champions, so all IVs should be set to the maximum IV possible. ~~It seems like it already doesn't allow Speed to be set to 0, so all that needs to be adjusted is Attack.~~
<img width="651" height="515" alt="Screenshot from 2026-05-13 20-04-41" src="https://github.com/user-attachments/assets/7a618722-fc76-48d1-90a1-64cc3872849a" />
<img width="651" height="508" alt="Screenshot from 2026-05-13 20-04-29" src="https://github.com/user-attachments/assets/4e2f4860-87a1-47bf-bc8b-e9980a4431e9" />

