### PR TITLE
Make speed tooltip values a configurable option

### DIFF
--- a/play.pokemonshowdown.com/js/client-topbar.js
+++ b/play.pokemonshowdown.com/js/client-topbar.js
@@ -518,7 +518,7 @@
 			}
 			buf += '<p><label class="optlabel">Background: <button class="button" name="background">Change background</button></label></p>';
 			var speedTipType = Dex.prefs('speedtiptype') || 'full';
-			buf += '<p><label class="optlabel">Speed tooltips: <select name="speedtiptype" class="button"><option value="full"' + (speedTipType === 'full' ? ' selected="selected"' : '') + '>Full (min, 0 EVs, 252 EVs, max</option><option value="partial"' + (speedTipType === 'partial' ? ' selected="selected"' : '') + '>Simple (min, max)</option></select></label></p>';
+			buf += '<p><label class="optlabel">Speed tooltips: <select name="speedtiptype" class="button"><option value="full"' + (speedTipType === 'full' ? ' selected="selected"' : '') + '>Full (min, 0 EVs, 252 EVs, max)</option><option value="partial"' + (speedTipType === 'partial' ? ' selected="selected"' : '') + '>Simple (min, max)</option></select></label></p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="noanim"' + (Dex.prefs('noanim') ? ' checked' : '') + ' /> Disable animations</label></p>';
 			if (navigator.userAgent.includes(' Chrome/64.')) {
 				buf += '<p><label class="checkbox"><input type="checkbox" name="nogif"' + (Dex.prefs('nogif') ? ' checked' : '') + ' /> Disable GIFs for Chrome 64 bug</label></p>';

--- a/play.pokemonshowdown.com/js/client-topbar.js
+++ b/play.pokemonshowdown.com/js/client-topbar.js
@@ -473,6 +473,7 @@
 			'change select[name=timestamps-lobby]': 'setTimestampsLobby',
 			'change select[name=timestamps-pms]': 'setTimestampsPMs',
 			'change select[name=onepanel]': 'setOnePanel',
+			'change select[name=speedtiptype]': 'setSpeedTipType',
 			'change select[name=theme]': 'setTheme',
 			'change input[name=logchat]': 'setLogChat',
 			'change input[name=selfhighlight]': 'setSelfHighlight',
@@ -516,6 +517,8 @@
 				buf += '<p><label class="optlabel">Layout: <select name="onepanel" class="button"><option value=""' + (!onePanel ? ' selected="selected"' : '') + '>&#x25EB; Left and right panels</option><option value="1"' + (onePanel ? ' selected="selected"' : '') + '>&#x25FB; Single panel</option></select></label></p>';
 			}
 			buf += '<p><label class="optlabel">Background: <button class="button" name="background">Change background</button></label></p>';
+			var speedTipType = Dex.prefs('speedtiptype') || 'full';
+			buf += '<p><label class="optlabel">Speed tooltips: <select name="speedtiptype" class="button"><option value="full"' + (speedTipType === 'full' ? ' selected="selected"' : '') + '>Full (min, 0 EVs, 252 EVs, max</option><option value="partial"' + (speedTipType === 'partial' ? ' selected="selected"' : '') + '>Simple (min, max)</option></select></label></p>';
 			buf += '<p><label class="checkbox"><input type="checkbox" name="noanim"' + (Dex.prefs('noanim') ? ' checked' : '') + ' /> Disable animations</label></p>';
 			if (navigator.userAgent.includes(' Chrome/64.')) {
 				buf += '<p><label class="checkbox"><input type="checkbox" name="nogif"' + (Dex.prefs('nogif') ? ' checked' : '') + ' /> Disable GIFs for Chrome 64 bug</label></p>';
@@ -614,6 +617,10 @@
 				}
 			}
 			$('html').toggleClass('dark', theme === 'dark');
+		},
+		setSpeedTipType: function (e) {
+			var speedtiptype = e.currentTarget.value;
+			Storage.prefs('speedtiptype', speedtiptype);
 		},
 		setBwgfx: function (e) {
 			var bwgfx = !!e.currentTarget.checked;

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1459,7 +1459,13 @@ export class BattleTooltips {
 			} else if (this.battle.tier.includes("Let's Go")) {
 				return `<p><small>Spe</small> ${min} to ${ev0} to ${max} <small>(before external modifiers)</small></p>`;
 			} else {
-				return `<p><small>Spe</small> ${min} to ${ev0} to ${ev252} to ${max}<br><small>(before external modifiers)</small></p>`;
+				if (Dex.prefs('speedtiptype') === 'full') {
+					return `<p><small>Spe</small> ${min} to ${ev0} to ${ev252} to ${max}<br><small>(before external modifiers)</small></p>`;
+				} else if (Dex.prefs('speedtiptype') === 'partial') {
+					return `<p><small>Spe</small> ${min} to ${max} <small>(before external modifiers)</small></p>`;
+				} else {
+					return `<p><small>Spe</small> ${min} to ${ev0} to ${ev252} to ${max}<br><small>(before external modifiers)</small></p>`;
+				};
 			};
 		}
 		const stats = serverPokemon.stats;

--- a/play.pokemonshowdown.com/src/client-main.ts
+++ b/play.pokemonshowdown.com/src/client-main.ts
@@ -95,6 +95,7 @@ class PSPrefs extends PSStreamModel<string | null> {
 	noanim: boolean | null = null;
 	bwgfx: boolean | null = null;
 	nopastgens: boolean | null = null;
+	speedtiptype: 'partial' | 'full' = 'full';
 
 	/* Chat Preferences */
 	blockPMs: boolean | null = null;

--- a/play.pokemonshowdown.com/src/panel-popups.tsx
+++ b/play.pokemonshowdown.com/src/panel-popups.tsx
@@ -584,6 +584,10 @@ class OptionsPanel extends PSRoomPanel {
 		}
 		PS.update();
 	};
+	setSpeedTipType = (e: Event) => {
+		PS.prefs.set('speedtiptype', (e.currentTarget as HTMLSelectElement).value as 'full' | 'partial');
+		this.forceUpdate();
+	};
 	setChatroomTimestamp = (ev: Event) => {
 		const timestamp = (ev.currentTarget as HTMLSelectElement).value as TimestampOptions;
 		PS.prefs.set('timestamps', { ...PS.prefs.timestamps, chatrooms: timestamp || undefined });
@@ -699,6 +703,16 @@ class OptionsPanel extends PSRoomPanel {
 						Change Background
 					</button>
 				</label>
+			</p>
+			<p>
+				<label class="optlabel">Speed tooltips: <select
+					name="speedtiptype" class="button" value={PS.prefs.speedtiptype}
+					onChange={this.setSpeedTipType}
+				>
+					<option value="full">Full (min, 0 EVs, 252 EVs, max)</option>
+					<option value="partial">Simple (min, max)</option>
+
+				</select></label>
 			</p>
 			<p>
 				<label class="checkbox"> <input


### PR DESCRIPTION
https://www.smogon.com/forums/threads/new-speed-tier-change.3782753/

Some people are not a fan of #2654 . This changes the forced full 4-value option to allow users to select between partial (Simple, 2 value) and full (Full, 4 value) in most battle formats. No changes affect Let's Go or Random Battle tiers.

The default is still full, but this allows users who are not a fan of full to use partial instead.

<img width="335" height="86" alt="image" src="https://github.com/user-attachments/assets/fd82cc37-339c-475f-988c-b06fcc997379" />
