### PR TITLE
Fix speed tooltip values in Gen 1/2

### DIFF
--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1454,6 +1454,12 @@ export class BattleTooltips {
 		if (!serverPokemon || isTransformed) {
 			if (!clientPokemon) throw new Error('Must pass either clientPokemon or serverPokemon');
 			let { min, ev0, ev84, ev252, max } = this.getSpeedRange(clientPokemon);
+			if (this.battle.gen < 3) {
+				if (this.battle.tier.includes('Random')) {
+					return `<p><small>Spe</small> ${max} <small>(before external modifiers)</small></p>`;
+				}
+				return `<p><small>Spe</small> ${min} to ${max} <small>(before external modifiers)</small></p>`;
+			}
 			if (this.battle.tier.includes('Random')) {
 				return `<p><small>Spe</small> ${min} or ${ev84} <small>(before external modifiers)</small></p>`;
 			} else if (this.battle.tier.includes("Let's Go")) {
@@ -1604,8 +1610,15 @@ export class BattleTooltips {
 			ev84 = tr(baseSpe + 13 + 20);
 			ev252 = tr(baseSpe + 32 + 20);
 			max = tr(maxNature * (baseSpe + 32 + 20));
+		} else if (gen < 3) {
+			max = tr((2 * baseSpe + maxIv + 63) * level / 100 + 5);
+			min = isCGT ? max : tr(2 * baseSpe * level / 100 + 5);
+			if (isRandomBattle) min = max;
+			ev0 = min;
+			ev84 = max;
+			ev252 = max;
 		} else {
-			let maxIvEvOffset = maxIv + ((isRandomBattle && gen >= 3) ? 21 : 63);
+			let maxIvEvOffset = maxIv + (isRandomBattle ? 21 : 63);
 			max = tr(tr((2 * baseSpe + maxIvEvOffset) * level / 100 + 5) * maxNature);
 			ev252 = tr(tr((2 * baseSpe + maxIvEvOffset) * level / 100 + 5));
 			ev84 = tr(tr((2 * baseSpe + 31 + 21) * level / 100 + 5));

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1613,8 +1613,8 @@ export class BattleTooltips {
 		} else if (gen < 3) {
 			max = tr((2 * baseSpe + maxIv + 63) * level / 100 + 5);
 			ev252 = max;
-			ev0 = tr((2 * baseSpe + maxIv) * level / 100 + 5);
 			ev84 = 0;
+			ev0 = tr((2 * baseSpe + maxIv) * level / 100 + 5);
 			min = isCGT ? max : tr(2 * baseSpe * level / 100 + 5);
 		} else {
 			let maxIvEvOffset = maxIv + (isRandomBattle ? 21 : 63);

--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1456,9 +1456,9 @@ export class BattleTooltips {
 			let { min, ev0, ev84, ev252, max } = this.getSpeedRange(clientPokemon);
 			if (this.battle.gen < 3) {
 				if (this.battle.tier.includes('Random')) {
-					return `<p><small>Spe</small> ${max} <small>(before external modifiers)</small></p>`;
+					return `<p><small>Spe</small> ${max} <small>(before stat stage changes)</small></p>`;
 				}
-				return `<p><small>Spe</small> ${min} to ${max} <small>(before external modifiers)</small></p>`;
+				return `<p><small>Spe</small> ${min} to ${max} <small>(before stat stage changes)</small></p>`;
 			}
 			if (this.battle.tier.includes('Random')) {
 				return `<p><small>Spe</small> ${min} or ${ev84} <small>(before external modifiers)</small></p>`;
@@ -1612,11 +1612,10 @@ export class BattleTooltips {
 			max = tr(maxNature * (baseSpe + 32 + 20));
 		} else if (gen < 3) {
 			max = tr((2 * baseSpe + maxIv + 63) * level / 100 + 5);
-			min = isCGT ? max : tr(2 * baseSpe * level / 100 + 5);
-			if (isRandomBattle) min = max;
-			ev0 = min;
-			ev84 = max;
 			ev252 = max;
+			ev0 = tr((2 * baseSpe + maxIv) * level / 100 + 5);
+			ev84 = 0;
+			min = isCGT ? max : tr(2 * baseSpe * level / 100 + 5);
 		} else {
 			let maxIvEvOffset = maxIv + (isRandomBattle ? 21 : 63);
 			max = tr(tr((2 * baseSpe + maxIvEvOffset) * level / 100 + 5) * maxNature);


### PR DESCRIPTION
flagged in the Showdown dev chat room earlier today by @iforgetwhyimhere (author of #2654) and confirmed by viola, Volsur, and others — i volunteered to take it in that conversation.

## what's wrong

#2654 enhanced the opponent speed tooltip to show per-EV-spread breakpoints (`min`, `ev0`, `ev84`, `ev252`, `max`). the math added in the catch-all branch of `getSpeedRange` uses the Gen 3+ stat formula `(2·base + IV + EV/4) · level/100 + 5` for every generation outside Let's Go and Champions. that's fine for Gen 3+, but Gens 1 and 2 use a completely different formula: DVs (0–15, not 0–31) and stat experience (0–65535, mapped to a stat-exp bonus of `floor(min(255, ceil(sqrt(statexp))) / 4)`).

so in a Gen 1 random battle, the tooltip's `ev84` value is computed as if the Pokemon had IV=31 + EV=21 instead of DV=15 + max stat exp, and the two numbers don't line up.

## concrete repro from dev chat

viola tested a level 88 Kabuto in a Gen 1 random battle:
- actual speed (in-game / teambuilder / damage calc): **183**
- tooltip showed: **101 or 147** ← off by 36 on the `ev84` side

walking the Gen 1 formula:
```
stat = floor( ((base + DV) * 2 + statExpBonus) * level / 100 ) + 5
     = floor( ((55 + 15) * 2 + 63) * 88 / 100 ) + 5
     = floor( 203 * 0.88 ) + 5
     = 178 + 5
     = 183  ✓
```

the Gen 3+ formula being misapplied:
```
ev84 = floor((2*55 + 31 + 21) * 88/100) + 5 = 147  ✗
```

the 36 difference is exactly the gap between the two formulas at this base stat and level.

## fix

two small changes in `play.pokemonshowdown.com/src/battle-tooltips.ts`:

1. **`getSpeedRange`** — add a `gen < 3` branch that uses the Gen 1/2 formula directly. PS Gen 1/2 random battles always give every Pokemon max DV + max stat exp, so `min`, `ev0`, `ev84`, `ev252`, and `max` all collapse to the same value in that case. for non-random Gen 1/2 (where DVs and stat exp can vary on uploaded teams) it returns the actual `min` (DV=0, statexp=0) and `max` (DV=15, max statexp), with the intermediate breakpoints pinned to the endpoints since the Gen 3+ EV-quartile breakpoints don't have a meaningful Gen 1/2 analog.

2. **`renderStats` display switch** — add a `gen < 3` case that shows a single value for random battles (since there's only one possible value) and `min to max` for non-random Gen 1/2 (matching what the original `[min, max]` tooltip showed before #2654).

i side-stepped the `gen >= 3` redundancy in the `maxIvEvOffset` line of the catch-all branch since the new `gen < 3` branch handles those cases already.

## sanity checks

verified the formula against several known Gen 1 random-battle speeds at level 100 (Pikachu base 90 → 278, Mewtwo base 130 → 358) and viola's level-88 Kabuto repro (183).

## test plan

- [x] `npm run lint` — clean
- [x] `npx tsc` — clean
- [x] `node build` — clean
- [x] `mocha test/*.js` — passes (1 pass, 3 pre-existing pending — no battle-tooltips tests existed to break)
- [x] math verified against viola's level 88 Kabuto, plus a few other Gen 1 mons