### PR TITLE
Preact: Fix EV slider behavior for Champions

### DIFF
--- a/play.pokemonshowdown.com/src/battle-team-editor.tsx
+++ b/play.pokemonshowdown.com/src/battle-team-editor.tsx
@@ -2750,7 +2750,11 @@ class StatForm extends preact.Component<{
 				let totalEv = 0;
 				for (const curEv of Object.values(set.evs || {})) totalEv += curEv;
 				if (totalEv > maxEv && totalEv - value <= maxEv) {
-					set.evs![statID] = maxEv - (totalEv - value) - (maxEv % 4);
+					if (this.props.editor.isChampions) {
+						set.evs![statID] = maxEv - (totalEv - value);
+					} else {
+						set.evs![statID] = maxEv - (totalEv - value) - (maxEv % 4);
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
The EV slider doesn't give you the 2 remaining SPs if you drag it beyond the limit in Champions formats.

New behavior:

[Screencast 2026-05-23 10:52:36.webm](https://github.com/user-attachments/assets/2eca2b85-8acd-48fe-9214-10a22509af56)
