### PR TITLE
Meteor Beam animation should use the space background instead of sand

### DIFF
--- a/play.pokemonshowdown.com/src/battle-animations-moves.ts
+++ b/play.pokemonshowdown.com/src/battle-animations-moves.ts
@@ -23787,7 +23787,7 @@ export const BattleMoveAnims: AnimTable = {
 			let ystep = (defender.x - 200 - attacker.x) / 5;
 			let zstep = (defender.z - attacker.z) / 5;
 
-			scene.backgroundEffect(`url('https://${Config.routes.client}/fx/weather-sandstorm.png')`, 900, 0.5);
+			scene.backgroundEffect(`url('https://${Config.routes.client}/fx/bg-space.jpg')`, 900, 0.6);
 
 			for (let i = 0; i < 5; i++) {
 				scene.showEffect('mudwisp', {


### PR DESCRIPTION
https://www.smogon.com/forums/threads/have-meteor-beam-use-the-space-background-instead-of-the-sand-background.3690923/

[Screencast 2026-05-23 11:32:49.webm](https://github.com/user-attachments/assets/f57be9d0-8f36-4ffa-981f-5d21b78ffbae)
