### PR TITLE
Preact: Fix bug with command tabcomplete

### DIFF
--- a/play.pokemonshowdown.com/src/panel-chat.tsx
+++ b/play.pokemonshowdown.com/src/panel-chat.tsx
@@ -1174,9 +1174,11 @@ export class ChatTextEntry extends preact.Component<{
 			});
 
 			const currentLine = prefix.substring(prefix.lastIndexOf('\n') + 1);
-			const isCommandSearch = (currentLine.startsWith('/') && !currentLine.startsWith('//')) || currentLine.startsWith('!');
+			const isCommandWord = (word: string) => (word.startsWith('/') && !word.startsWith('//')) || word.startsWith('!');
+			const currentWord = currentLine.substring(currentLine.lastIndexOf(' ') + 1);
+			const isCommandSearch = isCommandWord(currentWord);
 			if (isCommandSearch) {
-				PS.mainmenu.makeQuery('cmdsearch', currentLine, true).then((data: string[]) => {
+				PS.mainmenu.makeQuery('cmdsearch', currentWord, true).then((data: string[]) => {
 					const cmds = data.sort((a, b) => a.length < b.length ? 1 : -1);
 					const nextCmd = cmds[cmds.length - 1];
 					const newValue = nextCmd + value.substring(end);


### PR DESCRIPTION
the current implementation treats the entire line as one argument for tabcomplete which allowed it to perform tabcomplete on the whole line itself instead of individual words, so it would tabcomplete "/re ply" to "/reply" and also not allowing username tabcomplete on command arguments. for ex. "/forcerename 67skib" wouldnt tabcomplete the username argument.

this fixes it.

