### PR TITLE
Assume neutral Natures in Random Battles

### DIFF
--- a/play.pokemonshowdown.com/src/battle-tooltips.ts
+++ b/play.pokemonshowdown.com/src/battle-tooltips.ts
@@ -1596,6 +1596,10 @@ export class BattleTooltips {
 
 		let minNatureMult = 0.9;
 		let maxNatureMult = 1.1;
+		if (tier.includes('Random Battle')) {
+			minNatureMult = 1;
+			maxNatureMult = 1;
+		}
 		if (pokemon.nature) {
 			let natureVals = BattleNatures[pokemon.nature];
 			if (natureVals.minus === 'spe') maxNatureMult = 0.9;


### PR DESCRIPTION
Fixes https://www.smogon.com/forums/threads/bug-report-client.3784995/

Natures are always neutral in Random Battle, so using `min`, which uses a -Spe nature, was returning a value lower than possible in rands.
I put the mult setter above the Nature set, so that in the case where a Pokemon DOES have a nature, through whatever means, it won't break the tooltip with incorrect values (assuming neutral when it has pos/neg).